### PR TITLE
Run linting based on buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,8 +5,9 @@ phases:
       - pip install --upgrade pip wheel -r requirements.txt .
   build:
     commands:
-      - black --check "setup.py" "uluru/" "tests/"
-      - flake8 "setup.py" "uluru/" "tests/"
-      - pylint "setup.py" "uluru/" "tests/"
-      - bandit -r "uluru/"
+      - isort --check-only --verbose --recursive "setup.py" "run_lint" "uluru/" "tests/"
+      - black --check "setup.py" "run_lint" "uluru/" "tests/"
+      - flake8 "setup.py" "run_lint" "uluru/" "tests/"
+      - pylint "setup.py" "run_lint" "uluru/" "tests/"
+      - bandit -r "uluru/" --exclude "tests"
       - pytest --cov="uluru/" --doctest-modules "uluru/" "tests/"

--- a/run_lint
+++ b/run_lint
@@ -1,27 +1,23 @@
-#!/bin/bash
-set -euo pipefail
-IFS=$'\n\t'
+#!/usr/bin/env python
+from subprocess import CalledProcessError, check_call
 
-PACKAGE="uluru/"
-TESTS="tests/"
-FILES=("setup.py" "$PACKAGE" "$TESTS")
+import yaml
 
-echo "--- Automatically fixing up imports using isort ---"
-isort -rc -y "${FILES[@]}"
 
-echo "--- Formatting code with black ---"
-black "${FILES[@]}"
+def main():
+    with open("buildspec.yml", "r", encoding="utf-8") as f:
+        buildspec = yaml.safe_load(f)
 
-echo "--- Linting code with flake8 ---"
-flake8 "${FILES[@]}"
+    for cmd in buildspec["phases"]["build"]["commands"]:
+        print(">>>", cmd, "<<<")
+        try:
+            # this may not work if the commands rely on things in the shell's
+            # environment between calls
+            check_call(cmd, shell=True)
+        except CalledProcessError:
+            print("FAIL:", cmd)
+            return
 
-echo "--- Linting code with pylint ---"
-pylint "${FILES[@]}"
 
-echo "--- Running safety tests ---"
-bandit -r "$PACKAGE"
-
-echo "--- Running unit tests ---"
-pytest --cov="$PACKAGE" --doctest-modules "$PACKAGE" "$TESTS"
-
-echo "PASS"
+if __name__ == "__main__":
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,4 @@ skip = env
 include_trailing_comma = true
 combine_as_imports = True
 force_grid_wrap = 0
+known_first_party = uluru


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* `./run_lint` executes linting commands as defined in `buildspec.yml`, less to keep in sync.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
