### PR TITLE
Schema

### DIFF
--- a/uluru/data/resource_provider_schema.json
+++ b/uluru/data/resource_provider_schema.json
@@ -1,7 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://json-schema.org/draft-07/schema#",
-    "title": "Core schema meta-schema",
+    "$id": "http://cloudformation.amazonaws.com/schema/draft-07/provider.definition.v1.json",
+    "title": "CloudFormation Resource Provider Definition MetaSchema",
+    "description": "This schema validates a CloudFormation resource provider definition.",
     "definitions": {
         "schemaArray": {
             "type": "array",
@@ -61,6 +62,18 @@
         },
         "default": true,
         "readOnly": {
+            "description": "A list of properties that are able to be found in a Read request but unable to be specified by the customer",
+            "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+        },
+        "writeOnly": {
+            "description": "A list of properties (typically sensitive) that are able to be specified by the customer but unable to be returned in a Read request",
+            "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+        },
+        "$version": {
+            "type": "string"
+        },
+        "insertionOrder": {
+            "description": "When set to true, this flag indicates that the order of insertion of the array will be honored, and that changing the order of the array would indicate a diff",
             "type": "boolean",
             "default": false
         },


### PR DESCRIPTION
*Issue #, if available:*
6
*Description of changes:*
This commit adds the CloudFormation Resource Provider Definition to the repo.  

In json-schema world, the resource provider definition is a "metaschema", since it defines the schema for another json-schema (providers will write their definitions in json-schema, and that definition needs to validate against our schema).  Json-schema provides a metaschema for each draft of json-schema (see www.json-schema.org/draft-07/schema -- it will actually ask you to download the file) 

Essentially, we just want to extend this document, adding our own definitions and in the future potentially some restrictions. 

Unfortunately, the only way to extend the metaschema definition is to copy paste the entire json-schema definition and then edit that file. See https://github.com/json-schema-org/json-schema-spec/issues/86 for details on why that is.

The first commit in this PR simply updates the resource_provider_schema to be a copy of json schema draft 7.  
The second commit adds our additional properties on top of this.

I will add a 3rd commit with sample schemas.

Future work should be done to add validations to ensure the schema makes sense (for example, ensuring there is a "properties" section defined with at least 1 property)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
