### PR TITLE
Update jsonschema for draft #7 validation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,9 @@ setup(
     include_package_data=True,
     zip_safe=True,
     install_requires=[
-        "jinja2",  # fmt: off
-        "jsonschema",  # fmt: off
-        "pyyaml",  # fmt: off
+        "Jinja2>=2.9",  # fmt: off
+        "jsonschema>=3.0.0a3",  # fmt: off
+        "PyYAML>=3.13",  # fmt: off
     ],
     entry_points={
         "console_scripts": ["uluru-cli = uluru.cli:main"],

--- a/uluru/data_loaders.py
+++ b/uluru/data_loaders.py
@@ -3,7 +3,7 @@ import logging
 
 import pkg_resources
 import yaml
-from jsonschema import Draft6Validator
+from jsonschema import Draft7Validator
 from jsonschema.exceptions import ValidationError
 
 LOG = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ def load_resource_spec(resource_spec_file):
     ) as f:
         resource_spec_schema = json.load(f)
 
-    validator = Draft6Validator(resource_spec_schema)
+    validator = Draft7Validator(resource_spec_schema)
     try:
         validator.validate(resource_spec)
     except ValidationError as e:
@@ -58,7 +58,7 @@ def load_project_settings(plugin, project_settings_file):
             "to further customize code generation."
         )
 
-    validator = Draft6Validator(plugin.project_settings_schema())
+    validator = Draft7Validator(plugin.project_settings_schema())
     try:
         validator.validate(project_settings)
     except ValidationError as e:


### PR DESCRIPTION
*Issue #, if available:* N/A
*Description of changes:* Use `Draft7Validator` for validation.

This is only available in the newest `jsonschema` version, so I've mandated that in `setup.py`, as well as a recent version of Jinja2 ([2.10 is from November 2017](https://pypi.org/project/Jinja2/#history)) and PyYAML ([3.13 is from July 2018](https://pypi.org/project/PyYAML/#history), 3.12 is from August 2016)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
