### PR TITLE
Utilities to lint JSON and add trailing newlines

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,9 +6,9 @@ phases:
       - pip install --upgrade --pre jsonschema
   build:
     commands:
-      - isort --check-only --verbose --recursive "setup.py" "run_lint" "uluru/" "tests/"
-      - black --check "setup.py" "run_lint" "uluru/" "tests/"
-      - flake8 "setup.py" "run_lint" "uluru/" "tests/"
-      - pylint "setup.py" "run_lint" "uluru/" "tests/"
+      - isort --check-only --verbose --recursive "setup.py" "run_lint" "json_lint" "newline_lint" "uluru/" "tests/"
+      - black --check "setup.py" "run_lint" "json_lint" "newline_lint" "uluru/" "tests/"
+      - flake8 "setup.py" "run_lint" "json_lint" "newline_lint" "uluru/" "tests/"
+      - pylint "setup.py" "run_lint" "json_lint" "newline_lint" "uluru/" "tests/"
       - bandit -r "uluru/" --exclude "tests"
       - pytest --cov="uluru/" --doctest-modules "uluru/" "tests/"

--- a/json_lint
+++ b/json_lint
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+from os.path import dirname, join
+from subprocess import STDOUT, check_output
+
+BASE_PATH = dirname(__file__).encode("utf-8")
+
+
+def rewrite_json(path):
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=4)
+        f.write("\n")  # trailing newline as per POSIX
+
+
+def check_json(path):
+    with open(path, "r", encoding="utf-8") as f:
+        raw = f.read()
+    formatted = json.dumps(json.loads(raw), indent=4) + "\n"
+    return formatted == raw
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Don't write the files back, just return the status.",
+    )
+    args = parser.parse_args()
+
+    tree = check_output(
+        ["git", "ls-tree", "--full-tree", "--name-only", "-r", "-z", "HEAD"],
+        stderr=STDOUT,
+    )
+    # note: filenames are kept as bytes where possible to avoid having to deal
+    # with the OS'/filesystem's encoding
+    return_code = 0
+    for filename in tree.split(b"\0"):
+        if filename.endswith(b".json"):
+            path = join(BASE_PATH, filename)
+            if args.check:
+                if not check_json(path):
+                    # can't use print if we want to keep the filename in bytes
+                    sys.stdout.buffer.write(b"would reformat: ")
+                    sys.stdout.buffer.write(filename)
+                    sys.stdout.buffer.write(b"\n")
+                    return_code = 1
+            else:
+                rewrite_json(path)
+
+    return return_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/newline_lint
+++ b/newline_lint
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+from os import SEEK_END
+from os.path import dirname, join
+from subprocess import STDOUT, check_output
+
+BASE_PATH = dirname(__file__).encode("utf-8")
+NEWLINE = b"\n"
+
+
+def last_char_is_newline(path):
+    with open(path, "rb") as f:
+        # skip to the end of the file
+        try:
+            f.seek(-1, SEEK_END)
+        except OSError:
+            # is this a file any content?
+            if f.read():
+                raise
+            return True
+        else:
+            return f.read(1) == NEWLINE
+
+
+def check(path):
+    return last_char_is_newline(path)
+
+
+def rewrite(path):
+    if not last_char_is_newline(path):
+        with open(path, "ab") as f:
+            f.write(NEWLINE)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Don't write the files back, just return the status.",
+    )
+    args = parser.parse_args()
+
+    tree = check_output(
+        ["git", "ls-tree", "--full-tree", "--name-only", "-r", "-z", "HEAD"],
+        stderr=STDOUT,
+    )
+    # note: filenames and content are kept as bytes where possible
+    # to avoid having to deal with the filesystem's and files' encoding
+    return_code = 0
+    for filename in tree.split(b"\0"):
+        if not filename:  # list is terminated with the delimiter causing an empty item
+            continue
+
+        path = join(BASE_PATH, filename)
+        if args.check:
+            if not check(path):
+                # can't use print if we want to keep the filename in bytes
+                sys.stdout.buffer.write(b"no newline at eof: ")
+                sys.stdout.buffer.write(filename)
+                sys.stdout.buffer.write(b"\n")
+                return_code = 1
+        else:
+            rewrite(path)
+
+    return return_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/run_lint
+++ b/run_lint
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+import sys
 from subprocess import CalledProcessError, check_call
 
 import yaml
@@ -16,8 +17,9 @@ def main():
             check_call(cmd, shell=True)
         except CalledProcessError:
             print("FAIL:", cmd)
-            return
+            return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* two scripts to lint JSON files and ensure files have newlines. i will run these on the repository and integrate them into `buildspec.yaml` in a later PR to make review easier.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
