### PR TITLE
Introduce `createOnly` semantic property to resource meta-schema

### DIFF
--- a/uluru/data/schema/README.md
+++ b/uluru/data/schema/README.md
@@ -29,6 +29,7 @@ Certain properties of a resource are _semantic_ and have special meaning when us
 
 * **`readOnly`**: A `readOnly` property cannot be specified in a **CREATE** or **UPDATE** request, and attempting to do so will produce a runtime error from the handler.
 * **`writeOnly`**: A `writeOnly` property cannot be returned in a **READ** or **LIST** request, and can be used to express things like passwords, secrets or other sensitive data. 
+* **`createOnly`**: A `createOnly` property cannot be specified in an **UPDATE** request, and can only be specified in a **CREATE** request. Another way to think about this - these are properties which are 'write-once', such as the [`Engine`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-engine) property for an [`AWS::RDS::DBInstance`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html) and if you wish to change such a property on a live resource, you should replace that resource by creating a new instance of the resource and terminating the old one. This is the behaviour CloudFormation follows for all properties documented as _'Update Requires: Replacement'_. An attempt to supply these properties to an **UPDATE** request will produce a runtime error from the handler. 
 
 ## Divergence From JSON Schema
 

--- a/uluru/data/schema/provider.definition.schema.v1.json
+++ b/uluru/data/schema/provider.definition.schema.v1.json
@@ -166,9 +166,6 @@
                         },
                         "oneOf": {
                             "$ref": "#/definitions/schemaArray"
-                        },
-                        "not": {
-                            "$ref": "#/definitions/properties"
                         }
                     },
                     "additionalProperties": false
@@ -238,6 +235,10 @@
         },
         "writeOnly": {
             "description": "A list of properties (typically sensitive) that are able to be specified by the customer but unable to be returned in a Read request",
+            "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+        },
+        "createOnly": {
+            "description": "A list of properties that are only able to be specified by the customer when creating a resource. Conversely, any property *not* in this list can be applied to an Update request.",
             "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
         },
         "required": {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-cloudformation-rpdk/issues/39

*Description of changes:* This PR introduces the `createOnly` semantic behaviour to the resource meta-schema. Documentation for this property has been added to the meta-schema README.md file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
