### PR TITLE
Refactored transport and added basic operation tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ branch = True
 omit = uluru/tests/*
 
 [report]
-fail_under = 71
+fail_under = 76

--- a/uluru/tests/transport.py
+++ b/uluru/tests/transport.py
@@ -1,9 +1,0 @@
-from abc import ABC, abstractmethod
-
-
-class Transport(ABC):
-    @abstractmethod
-    def send(self, payload, callback_endpoint):
-        """Send payload to specified endpoint
-        """
-        pass


### PR DESCRIPTION
This commit refactors the transport fixture into a base class that can be extended for different types of transports and endpoints. LocalLambdaTransport is an example of this extension.

Basic tests for each CRUDL operation are in this commit as well. For asynchronous operations, an acknowledgement test is also included.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
