### PR TITLE
Introduce `identifiers` semantic property to resource meta-schema

### DIFF
--- a/examples/schema/resource/aws.s3.bucket.v1.json
+++ b/examples/schema/resource/aws.s3.bucket.v1.json
@@ -854,6 +854,13 @@
                 "$ref": "#/definitions/AnalyticsConfiguration"
             }
         },
+        "Arn": {
+            "description": "The Amazon Resource Name (ARN) of the specified bucket.",
+            "$ref": "../aws.common.types.v1.json#/definitions/Arn",
+            "examples": [
+                "arn:aws:s3:::mybucket"
+            ]
+        },
         "BucketEncryption": {
             "description": "Specifies default encryption for a bucket using server-side encryption with either Amazon S3-managed keys (SSE-S3) or AWS KMS-managed keys (SSE-KMS).",
             "$ref": "#/definitions/BucketEncryption"
@@ -865,6 +872,22 @@
         "CorsConfiguration": {
             "description": "Rules that define cross-origin resource sharing of objects in this bucket.",
             "$ref": "#/definitions/CorsConfiguration"
+        },
+        "DomainName": {
+            "description": "The IPv4 DNS name of the specified bucket.",
+            "type": "string",
+            "format": "uri",
+            "examples": [
+                "mystack-mybucket-kdwwxmddtr2g.s3.amazonaws.com"
+            ]
+        },
+        "DualStackDomainName": {
+            "description": "The IPv6 DNS name of the specified bucket. For more information about dual-stack endpoints, see [Using Amazon S3 Dual-Stack Endpoints](https://docs.aws.amazon.com/AmazonS3/latest/dev/dual-stack-endpoints.html).",
+            "type": "string",
+            "format": "uri",
+            "examples": [
+                "mystack-mybucket-kdwwxmddtr2g.s3.dualstack.us-east-2.amazonaws.com"
+            ]
         },
         "InventoryConfigurations": {
             "type": "array",
@@ -907,7 +930,30 @@
         "WebsiteConfiguration": {
             "description": "Information used to configure the bucket as a static website.",
             "$ref": "#/definitions/WebsiteConfiguration"
+        },
+        "WebsiteURL": {
+            "description": "The Amazon S3 website endpoint for the specified bucket.",
+            "type": "string",
+            "format": "uri",
+            "examples": [
+                "Example (IPv4): http://mystack-mybucket-kdwwxmddtr2g.s3-website-us-east-2.amazonaws.com/",
+                "Example (IPv6): http://mystack-mybucket-kdwwxmddtr2g.s3.dualstack.us-east-2.amazonaws.com/"
+            ]
         }
     },
+    "createOnly": [
+        "#/properties/BucketName"
+    ],
+    "readOnly": [
+        "#/properties/Arn",
+        "#/properties/DomainName",
+        "#/properties/DualStackDomainName",
+        "#/properties/WebsiteURL"
+    ],
+    "identifiers": [
+        "#/properties/Arn",
+        "#/properties/BucketName",
+        "#/properties/URL"
+    ],
     "additionalProperties": false
 }

--- a/examples/schema/resource/aws.sqs.queue.v1.json
+++ b/examples/schema/resource/aws.sqs.queue.v1.json
@@ -2,6 +2,13 @@
     "$id": "aws.sqs.queue.v1.json",
     "typeName": "AWS::SQS::Queue",
     "properties": {
+        "Arn": {
+            "description": "The Amazon Resource Name (ARN) of the queue.",
+            "$ref": "../aws.common.types.v1.json#/definitions/Arn",
+            "examples": [
+                "arn:aws:sqs:us-east-2:123456789012:mystack-myqueue-15PG5C2FC1CW8."
+            ]
+        },
         "ContentBasedDeduplication": {
             "type": "boolean",
             "description": "For first-in-first-out (FIFO) queues, specifies whether to enable content-based deduplication."
@@ -73,6 +80,13 @@
             "description": "The tags that you want to attach to this queue.",
             "$ref": "../aws.common.types.v1.json#/properties/Tags"
         },
+        "URL": {
+            "type": "string",
+            "description": "The queue URL.",
+            "examples": [
+                "https://sqs.us-east-2.amazonaws.com/123456789012/aa4-MyQueue-Z5NOSZO2PZE9"
+            ]
+        },
         "VisibilityTimeout": {
             "type": "integer",
             "description": "The length of time during which a message will be unavailable after a message is delivered from the queue.",
@@ -81,5 +95,18 @@
             "maximum": 43200
         }
     },
+    "createOnly": [
+        "#/properties/FifoQueue",
+        "#/properties/QueueName"
+    ],
+    "readOnly": [
+        "#/properties/Arn",
+        "#/properties/URL"
+    ],
+    "identifiers": [
+        "#/properties/Arn",
+        "#/properties/QueueName",
+        "#/properties/URL"
+    ],
     "additionalProperties": false
 }

--- a/uluru/data/schema/README.md
+++ b/uluru/data/schema/README.md
@@ -27,9 +27,50 @@ The _shape_ of your resource defines the properties for that resource and how th
 
 Certain properties of a resource are _semantic_ and have special meaning when used in different contexts. For example, a property of a resource may be `readOnly` when read back for state changes - but can be specified in a settable context when used as the target of a `$ref` from a related resource. Because of this semantic difference in how this property metadata should be interpreted, certain aspects of the resource definition are applied to the parent resource definition, rather than at a property level. Those elements are;
 
+* **`identifiers`**: Each property listed in the `identifiers` section must be able to be used to uniquely identify the resource. These properties can be independently provided as keys to a **READ** or **DELETE** request. These properties are usually also marked as `readOnly` and are only returned from **READ** and **LIST** operations.
 * **`readOnly`**: A `readOnly` property cannot be specified in a **CREATE** or **UPDATE** request, and attempting to do so will produce a runtime error from the handler.
 * **`writeOnly`**: A `writeOnly` property cannot be returned in a **READ** or **LIST** request, and can be used to express things like passwords, secrets or other sensitive data. 
 * **`createOnly`**: A `createOnly` property cannot be specified in an **UPDATE** request, and can only be specified in a **CREATE** request. Another way to think about this - these are properties which are 'write-once', such as the [`Engine`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-engine) property for an [`AWS::RDS::DBInstance`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html) and if you wish to change such a property on a live resource, you should replace that resource by creating a new instance of the resource and terminating the old one. This is the behaviour CloudFormation follows for all properties documented as _'Update Requires: Replacement'_. An attempt to supply these properties to an **UPDATE** request will produce a runtime error from the handler. 
+
+#### Application
+
+When defining resource semantics like `createOnly`, `identifiers` you are expected to use a `$ref` to a property definition in the same resource document. This is not enforced directly by the meta-schema but is enforced at runtime and can be checked with the RPDK CLI `validate` command.
+
+The following (truncated) example shows some of the semantic definitions for an `AWS::S3::Bucket` resource type;
+
+```
+{
+    "$id": "aws.s3.bucket.v1.json",
+    "typeName": "AWS::S3::Bucket",
+    "definitions": { ... },
+    "properties": {
+        "Arn": {
+            "$ref": "../aws.common.types.v1.json#/definitions/Arn"
+        },
+        "BucketName": {
+            "type": "string"
+        }
+    },
+    "createOnly": [
+        {
+            "$ref": "#/properties/BucketName"
+        }
+    ],
+    "readOnly": [
+        {
+            "$ref": "#/properties/Arn"
+        }
+    ],
+    "identifiers": [
+        {
+            "$ref": "#/properties/Arn"
+        },
+        {
+            "$ref": "#/properties/BucketName"
+        }
+    ]
+}
+```
 
 ## Divergence From JSON Schema
 

--- a/uluru/data/schema/provider.definition.schema.v1.json
+++ b/uluru/data/schema/provider.definition.schema.v1.json
@@ -4,6 +4,14 @@
     "title": "CloudFormation Resource Provider Definition MetaSchema",
     "description": "This schema validates a CloudFormation resource provider definition.",
     "definitions": {
+        "jsonPointerArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "string",
+                "format": "json-pointer"
+            }
+        },
         "schemaArray": {
             "type": "array",
             "minItems": 1,
@@ -230,16 +238,20 @@
             "minProperties": 1
         },
         "readOnly": {
-            "description": "A list of properties that are able to be found in a Read request but unable to be specified by the customer",
-            "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+            "description": "A list of JSON pointers to properties that are able to be found in a Read request but unable to be specified by the customer",
+            "$ref": "#/definitions/jsonPointerArray"
         },
         "writeOnly": {
-            "description": "A list of properties (typically sensitive) that are able to be specified by the customer but unable to be returned in a Read request",
-            "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+            "description": "A list of JSON pointers to properties (typically sensitive) that are able to be specified by the customer but unable to be returned in a Read request",
+            "$ref": "#/definitions/jsonPointerArray"
         },
         "createOnly": {
-            "description": "A list of properties that are only able to be specified by the customer when creating a resource. Conversely, any property *not* in this list can be applied to an Update request.",
-            "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+            "description": "A list of JSON pointers to properties that are only able to be specified by the customer when creating a resource. Conversely, any property *not* in this list can be applied to an Update request.",
+            "$ref": "#/definitions/jsonPointerArray"
+        },
+        "identifiers": {
+            "description": "A list of JSON pointers to properties used to uniquely identify the resource. Note that multiple properties may serve as identifiers.",
+            "$ref": "#/definitions/jsonPointerArray"
         },
         "required": {
             "$ref": "http://json-schema.org/draft-07/schema#/properties/required"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-cloudformation-rpdk/issues/47

*Description of changes:* This PR introduces the `identifiers` semantic behaviour to the resource meta-schema. Documentation for this property has been added to the meta-schema README.md file.

I've also modified the constraints to require `schemaArray` for the semantic property lists, which will at least encourage that they reference properties in the definition. This can be post-validated by the RPDK `validate` behaviour.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
