### PR TITLE
Make traverse method general purpose

### DIFF
--- a/uluru/jsonutils/inliner.py
+++ b/uluru/jsonutils/inliner.py
@@ -65,10 +65,11 @@ class RefInliner(RefResolver):
             LOG.debug("Rewriting refs in '%s' (%s)", rename, base_uri)
             document = self.store[base_uri]
             for from_ref, to_ref in self.ref_graph.items():
+                base, *parts = from_ref
                 # only process refs in this file
-                if from_ref[0] != rename:
+                if base != rename:
                     continue
-                current = traverse(document, from_ref)
+                current = traverse(document, parts)
                 new_ref = rewrite_ref(to_ref)
                 LOG.debug("  '%s' -> '%s'", current["$ref"], new_ref)
                 current["$ref"] = new_ref
@@ -89,7 +90,7 @@ class RefInliner(RefResolver):
                 # convert the parts into one flattened reference
                 if parts:
                     key = "/".join(parts)
-                    local_defs[key] = traverse(document, to_ref)
+                    local_defs[key] = traverse(document, parts)
                     LOG.debug("  %s#%s", base, key)
                 else:
                     local_defs.update(document)

--- a/uluru/jsonutils/utils.py
+++ b/uluru/jsonutils/utils.py
@@ -50,7 +50,7 @@ def rewrite_ref(ref):
     return fragment_encode(parts)
 
 
-def traverse(document, ref):
+def traverse(document, path_parts):
     """Traverse the document according to the reference.
 
     Since the document is presumed to be the reference's base, the base is
@@ -58,28 +58,28 @@ def traverse(document, ref):
 
     :raises ValueError, LookupError: the reference is invalid for this document
 
-    >>> traverse({"foo": {"bar": [42]}}, (BASE,))
+    >>> traverse({"foo": {"bar": [42]}}, tuple())
     {'foo': {'bar': [42]}}
-    >>> traverse({"foo": {"bar": [42]}}, (BASE, "foo"))
+    >>> traverse({"foo": {"bar": [42]}}, ["foo"])
     {'bar': [42]}
-    >>> traverse({"foo": {"bar": [42]}}, (BASE, "foo", "bar"))
+    >>> traverse({"foo": {"bar": [42]}}, ("foo", "bar"))
     [42]
-    >>> traverse({"foo": {"bar": [42]}}, (BASE, "foo", "bar", "0"))
+    >>> traverse({"foo": {"bar": [42]}}, ("foo", "bar", "0"))
     42
-    >>> traverse({}, (BASE, "foo"))
+    >>> traverse({}, ["foo"])
     Traceback (most recent call last):
     ...
     KeyError: 'foo'
-    >>> traverse([], (BASE, "foo"))
+    >>> traverse([], ["foo"])
     Traceback (most recent call last):
     ...
     ValueError: invalid literal for int() with base 10: 'foo'
-    >>> traverse([], (BASE, 0))
+    >>> traverse([], [0])
     Traceback (most recent call last):
     ...
     IndexError: list index out of range
     """
-    for part in ref[1:]:
+    for part in path_parts:
         if isinstance(document, Sequence):
             part = int(part)
         document = document[part]


### PR DESCRIPTION
*Issue #, if available:* see #27 

*Description of changes:* Make `uluru.jsonutils.utils.traverse` method general purpose

Instead of taking a sequence where the first element is the document origin (as used in the inliner), the sequence is now just the path in the document. (Also, technically it's now an iterable as it doesn't need to support indexing.)

For the inliner code, it's trivial to split the path parts from the document origin. this should make the `traverse` method more general purpose (e.g. for json schema normalisation).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
