### PR TITLE
Use git ls-files for linting

### DIFF
--- a/json_lint
+++ b/json_lint
@@ -32,10 +32,7 @@ def main():
     )
     args = parser.parse_args()
 
-    tree = check_output(
-        ["git", "ls-tree", "--full-tree", "--name-only", "-r", "-z", "HEAD"],
-        stderr=STDOUT,
-    )
+    tree = check_output(["git", "ls-files", "-z"], stderr=STDOUT)
     # note: filenames are kept as bytes where possible to avoid having to deal
     # with the OS'/filesystem's encoding
     return_code = 0

--- a/newline_lint
+++ b/newline_lint
@@ -42,10 +42,7 @@ def main():
     )
     args = parser.parse_args()
 
-    tree = check_output(
-        ["git", "ls-tree", "--full-tree", "--name-only", "-r", "-z", "HEAD"],
-        stderr=STDOUT,
-    )
+    tree = check_output(["git", "ls-files", "-z"], stderr=STDOUT)
     # note: filenames and content are kept as bytes where possible
     # to avoid having to deal with the filesystem's and files' encoding
     return_code = 0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use `git ls-files` for linting, as this includes staged files. We could eventually move to `--modified` to only check modified files, but for now this is fine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
