### PR TITLE
Suppress `redefined-outer-name` locally

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,7 +12,6 @@ disable=
     bad-continuation,           # clashes with black
     duplicate-code,             # finds dupes between tests and plugins
     too-few-public-methods,     # triggers when inheriting
-    redefined-outer-name,       # problematic with pytest fixtures
 
 [BASIC]
 

--- a/uluru/tests/contract_tests.py
+++ b/uluru/tests/contract_tests.py
@@ -1,3 +1,5 @@
+# fixture and parameter have the same name
+# pylint: disable=redefined-outer-name
 import json
 import time
 from collections import deque


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Suppress `redefined-outer-name` locally, not globally. It's quite a useful linting rule outside the unit tests where it clashes with fixture naming, and worth the pain IMO.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
