### PR TITLE
Make `generate` command create the output-directory

### DIFF
--- a/uluru/languages/java/codegen.py
+++ b/uluru/languages/java/codegen.py
@@ -70,9 +70,8 @@ class JavaLanguagePlugin(LanguagePlugin):
 
     def generate(self, resource_def, project_settings):
         LOG.info("Setting up package directories...")
-        output_directory = Path(project_settings["output_directory"]).resolve(
-            strict=True
-        )
+        output_directory = Path(project_settings["output_directory"])
+        output_directory.mkdir(exist_ok=True)
 
         package_components = project_settings["packageName"].split(".")
         src_main_dir = output_directory.joinpath("generated-src", *package_components)


### PR DESCRIPTION
Rather than fail with errors if the specified `--output-directory` does not exist, it's a better developer experience to just create it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
