### PR TITLE
Nice help for test subcommand

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ branch = True
 omit = */tests/*,**/contract_tests.py
 
 [report]
-fail_under = 82
+fail_under = 83

--- a/tests/test_subcommands.py
+++ b/tests/test_subcommands.py
@@ -14,6 +14,12 @@ EXPECTED_PYTEST_ARGS = [
 ]
 
 
+def test_test_command_help():
+    with mock.patch("rpdk.test.local_lambda", autospec=True) as mock_lambda_command:
+        main(args_in=["test"])
+    mock_lambda_command.assert_not_called()
+
+
 def test_test_command():
     with mock.patch("rpdk.test.local_lambda", autospec=True) as mock_lambda_command:
         test_resource_file = tempfile.NamedTemporaryFile()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Before and after:

```bash
$ uluru-cli -vv test 
usage: uluru-cli [-h] [-v] {init,validate,generate,project-settings,test} ...

This tool provides support for creating CloudFormation resource providers.

positional arguments:
  {init,validate,generate,project-settings,test}

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         Increase the output verbosity. Can be specified
                        multiple times.
$ uluru-cli -vv test 
usage: uluru-cli test [-h] {local-lambda} ...

This sub command tests basic functionality of the resource handler given a
test resource and an endpoint.

positional arguments:
  {local-lambda}  Type of transport to use for testing

optional arguments:
  -h, --help      show this help message and exit
$
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
