### PR TITLE
Minor fixes to some documentation domains

### DIFF
--- a/src/rpdk/cli.py
+++ b/src/rpdk/cli.py
@@ -15,6 +15,7 @@ from .validate import setup_subparser as validate_setup_subparser
 
 
 def setup_logging(verbosity=0):
+    """Configure logging with a variable verbosity level (0, 1, 2)."""
     if verbosity > 1:
         level = logging.DEBUG
     elif verbosity > 0:
@@ -30,6 +31,7 @@ def setup_logging(verbosity=0):
 
 
 def main(args_in=None):
+    """The entry point for the CLI."""
     # see docstring of this file
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(

--- a/src/rpdk/filters.py
+++ b/src/rpdk/filters.py
@@ -36,7 +36,7 @@ def resource_type_namespace(resource_type):
     """Gets the namespace from a resource type.
 
     :exc:`ValueError` is raised if the resource type is invalid, see
-    :function:`parse_resource_type`.
+    :func:`parse_resource_type`.
 
     >>> resource_type_namespace('AWS::ECS::Instance')
     'AWS'
@@ -49,7 +49,7 @@ def resource_type_service(resource_type):
     """Gets the service name from a resource type.
 
     :exc:`ValueError` is raised if the resource type is invalid, see
-    :function:`parse_resource_type`.
+    :func:`parse_resource_type`.
 
     >>> resource_type_service('AWS::ECS::Instance')
     'ECS'
@@ -62,7 +62,7 @@ def resource_type_resource(resource_type):
     """Gets the resource name from a resource type.
 
     :exc:`ValueError` is raised if the resource type is invalid, see
-    :function:`parse_resource_type`.
+    :func:`parse_resource_type`.
 
     >>> resource_type_resource('AWS::ECS::Instance')
     'Instance'

--- a/src/rpdk/jsonutils/utils.py
+++ b/src/rpdk/jsonutils/utils.py
@@ -15,6 +15,7 @@ class BaseRefPlaceholder:
         return "<BASE>"
 
 
+#: The sentinel instance representing a reference inside the base document.
 BASE = BaseRefPlaceholder()
 
 
@@ -22,7 +23,7 @@ def rewrite_ref(ref):
     """Rewrite a reference to be inside of the base document. A relative JSON
     pointer is returned (in URI fragment identifier representation).
 
-    If the reference is already inside the base document (:ref:`BASE`), the parts
+    If the reference is already inside the base document (:const:`BASE`), the parts
     are simply encoded into a pointer.
 
     If the reference is outside of the base document, a unique pointer inside


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Minor fixes to some [Sphinx documentation domains](https://www.sphinx-doc.org/en/1.8/usage/restructuredtext/domains.html#cross-referencing-python-objects). It will be useful when we do the documentation (#30).

Unfortunately, as far as I can see, CodeBuild/CodePipeline doesn't have HTML report support (like e.g. [Jenkins](https://www.cloudbees.com/blog/publishing-html-reports-pipeline)). Might have to hack something together using e.g. Lambda, but it's a bit of a bummer not being able to see the doco as part of the CI run, which is why I haven't done it yet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
