### PR TITLE
Convenience methods to load package resource data (correctly)

### DIFF
--- a/src/rpdk/cli.py
+++ b/src/rpdk/cli.py
@@ -4,9 +4,7 @@ import argparse
 import logging
 from logging.config import dictConfig
 
-import pkg_resources
-import yaml
-
+from .data_loaders import resource_yaml
 from .generate import setup_subparser as generate_setup_subparser
 from .init import setup_subparser as init_setup_subparser
 from .project_settings import setup_subparser as project_settings_setup_subparser
@@ -23,9 +21,7 @@ def setup_logging(verbosity=0):
     else:
         level = logging.WARNING
 
-    logging_config = yaml.safe_load(
-        pkg_resources.resource_stream(__name__, "data/logging/logging.yaml")
-    )
+    logging_config = resource_yaml(__name__, "data/logging/logging.yaml")
     logging_config["handlers"]["console"]["level"] = level
     dictConfig(logging_config)
 

--- a/src/rpdk/init.py
+++ b/src/rpdk/init.py
@@ -3,12 +3,9 @@
 import argparse
 import logging
 import os
-import shutil
 from pathlib import Path
 
-import pkg_resources
-
-from .data_loaders import load_project_settings
+from .data_loaders import copy_resource, load_project_settings
 from .plugin_registry import PLUGIN_REGISTRY, add_language_argument
 
 LOG = logging.getLogger(__name__)
@@ -25,13 +22,11 @@ def init(args):
     output_path = Path(args.output_directory)
     output_path.mkdir(exist_ok=True)
 
-    sample_schema_stream = pkg_resources.resource_stream(
-        __name__, "data/examples/resource/initech.tps.report.v1.json"
+    copy_resource(
+        __name__,
+        "data/examples/resource/initech.tps.report.v1.json",
+        output_path / "initech.tps.report.v1.json",
     )
-    sample_schema_out = output_path / "initech.tps.report.v1.json"
-    with sample_schema_out.open("wb") as f:
-        shutil.copyfileobj(sample_schema_stream, f)
-
     plugin.init(project_settings)
 
 

--- a/src/rpdk/languages/java/codegen.py
+++ b/src/rpdk/languages/java/codegen.py
@@ -4,8 +4,7 @@ import logging
 import shutil
 from pathlib import Path
 
-import pkg_resources
-
+from rpdk.data_loaders import copy_resource
 from rpdk.filters import resource_type_resource
 from rpdk.jsonutils.jsonschema_normalizer import JsonSchemaNormalizer
 from rpdk.plugin_base import LanguagePlugin
@@ -45,25 +44,23 @@ class JavaLanguagePlugin(LanguagePlugin):
         intellij_conf_dir = project_settings["output_directory"] / ".idea"
         intellij_conf_dir.mkdir(exist_ok=True)
 
-        resource_schema_stream = pkg_resources.resource_stream(
-            "rpdk", "data/schema/provider.definition.schema.v1.json"
-        )
         resource_schema_out = (
             project_settings["output_directory"] / "provider.definition.schema.v1.json"
         )
-        with resource_schema_out.open("wb") as f:
-            shutil.copyfileobj(resource_schema_stream, f)
+
+        copy_resource(
+            "rpdk",
+            "data/schema/provider.definition.schema.v1.json",
+            resource_schema_out,
+        )
 
         misc_template = self.env.get_template("intellij/misc.xml")
         with open(intellij_conf_dir / "misc.xml", "w", encoding="utf-8") as f:
             f.write(misc_template.render(project_settings))
 
-        json_schemas_stream = pkg_resources.resource_stream(
-            __name__, "data/jsonSchemas.xml"
+        copy_resource(
+            __name__, "data/jsonSchemas.xml", intellij_conf_dir / "jsonSchemas.xml"
         )
-        json_schemas_out = intellij_conf_dir / "jsonSchemas.xml"
-        with json_schemas_out.open("wb") as f:
-            shutil.copyfileobj(json_schemas_stream, f)
 
     def _initialize_maven(self, project_settings):
         output_pom = project_settings["output_directory"] / "pom.xml"

--- a/src/rpdk/languages/java/tests/test_pojo_resolver.py
+++ b/src/rpdk/languages/java/tests/test_pojo_resolver.py
@@ -1,8 +1,8 @@
 # fixture and parameter have the same name
 # pylint: disable=redefined-outer-name,protected-access
-import pkg_resources
 import pytest
-import yaml
+
+from rpdk.data_loaders import resource_yaml
 
 from ..pojo_resolver import JavaPojoResolver
 
@@ -14,17 +14,12 @@ REF_TO_CLASS_MAP = {
 
 
 @pytest.fixture
-def normalized_schema():
-    resource = pkg_resources.resource_stream(__name__, "normalized_schema.json")
-    return yaml.safe_load(resource)
-
-
-@pytest.fixture
 def empty_resolver():
     return JavaPojoResolver({}, "Object")
 
 
-def test_resolver(normalized_schema):
+def test_resolver():
+    normalized_schema = resource_yaml(__name__, "normalized_schema.json")
     resolver = JavaPojoResolver(normalized_schema, "areaDescription")
     expected_pojos = {
         "AreaDescription": {

--- a/src/rpdk/plugin_base.py
+++ b/src/rpdk/plugin_base.py
@@ -1,9 +1,8 @@
-import json
 from abc import ABC, abstractmethod
 
-import pkg_resources
 from jinja2 import Environment, PackageLoader, select_autoescape
 
+from .data_loaders import resource_json, resource_stream
 from .filters import FILTER_REGISTRY
 
 
@@ -23,15 +22,12 @@ class LanguagePlugin(ABC):
         This is so the project settings can be copied without loss of e.g. comments;
         if the project settings were parsed this would not be possible.
         """
-        return pkg_resources.resource_stream(
-            self._module_name, "data/project_defaults.yaml"
-        )
+        return resource_stream(self._module_name, "data/project_defaults.yaml")
 
     @abstractmethod
     def project_settings_schema(self):
         """Return the project settings schema."""
-        f = pkg_resources.resource_stream(self._module_name, "data/project_schema.json")
-        return json.load(f)
+        return resource_json(self._module_name, "data/project_schema.json")
 
     def _setup_jinja_env(self, **options):
         if "loader" not in options:

--- a/tests/jsonutils/test_jsonschema_normalizer.py
+++ b/tests/jsonutils/test_jsonschema_normalizer.py
@@ -1,29 +1,23 @@
 # fixture and parameter have the same name
 # pylint: disable=redefined-outer-name
 # pylint: disable=protected-access
-import pkg_resources
 import pytest
-import yaml
 
+from rpdk.data_loaders import resource_json
 from rpdk.jsonutils.jsonschema_normalizer import (
     JsonSchemaNormalizer,
     NormalizationError,
 )
 
 
-def load_test_yaml(name):
-    resource = pkg_resources.resource_stream(__name__, "data/" + name)
-    return yaml.safe_load(resource)
-
-
 @pytest.fixture
 def test_provider_schema():
-    return load_test_yaml("area_definition.json")
+    return resource_json(__name__, "data/area_definition.json")
 
 
 @pytest.fixture
 def normalized_schema():
-    return load_test_yaml("area_definition_normalized.json")
+    return resource_json(__name__, "data/area_definition_normalized.json")
 
 
 @pytest.fixture
@@ -104,8 +98,10 @@ def test_collapse_ref_type_nested(normalizer, normalized_schema):
 
 
 def test_circular_reference():
-    schema_normalized = load_test_yaml("circular_reference_normalized.json")
-    schema = load_test_yaml("circular_reference.json")
+    schema_normalized = resource_json(
+        __name__, "data/circular_reference_normalized.json"
+    )
+    schema = resource_json(__name__, "data/circular_reference.json")
     resolved_schema = JsonSchemaNormalizer(schema).collapse_and_resolve_schema()
     assert resolved_schema == schema_normalized
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* We have to load many package resources. It's a pain. Here are some convenience methods:

* `resource_stream`: load a resource, but with encoding (obviously "utf-8" by default)
* `resource_json`: load a JSON resource (using `resource_stream`)
* `resource_yaml`: load a YAML resource (using `resource_stream`)
* `copy_resource`: copy a resource to a file (binary, for now - our linting and test should catch any weird encodings)

The UTF-8 thing is kind of important. [By default](https://docs.python.org/3/library/io.html#io.TextIOWrapper), text I/O may use `locale.getpreferredencoding()`, which can cause annoying and hard to diagnose errors on some systems. I'm not even sure what PyYAML would use by default.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
