### PR TITLE
fix buildspec to not lint extraneous files

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,7 +9,7 @@ phases:
       - ./json_lint --check
       - ./newline_lint --check
       - isort --check-only --verbose --recursive "."
-      - black --check "."
+      - black --check "setup.py" "run_lint" "json_lint" "newline_lint" "src/" "tests/"
       - flake8 "."
       - pylint "setup.py" "run_lint" "json_lint" "newline_lint" "src/" "tests/"
       - bandit -r "src/" --exclude "tests"

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,10 @@ exclude =
     *.egg-info,
     .cache,
     .eggs,
-    .tox
+    .tox,
+    env,
+    .vscode,
+    .idea,
 max-complexity = 10
 max-line-length = 80
 select = C,E,F,W,B,B950


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
flake8 and isort didn't need their commands to be changed because they can explicitly exclude extraneous files in the setup.cfg

However, black requires some other "pyproject.toml" file which we don't need


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
