### PR TITLE
Position independent verbose argument

### DIFF
--- a/src/rpdk/cli.py
+++ b/src/rpdk/cli.py
@@ -30,24 +30,29 @@ def main(args_in=None):
     """The entry point for the CLI."""
     # see docstring of this file
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
+    # the default command just prints the help message
+    # subparsers should set their own default commands
+    # also need to set verbose here because now it only gets set if a
+    # subcommand is run (which is okay, the help doesn't need it)
+    parser.set_defaults(command=lambda args: parser.print_help(), verbose=0)
+
+    base_subparser = argparse.ArgumentParser(add_help=False)
+    # shared arguments
+    base_subparser.add_argument(
         "-v",
         "--verbose",
         action="count",
         default=0,
         help="Increase the output verbosity. Can be specified multiple times.",
     )
-
-    # the default command just prints the help message
-    # subparsers should set their own default commands
-    parser.set_defaults(command=lambda args: parser.print_help())
+    parents = [base_subparser]
 
     subparsers = parser.add_subparsers(dest="subparser_name")
-    init_setup_subparser(subparsers)
-    validate_setup_subparser(subparsers)
-    generate_setup_subparser(subparsers)
-    project_settings_setup_subparser(subparsers)
-    test_setup_subparser(subparsers)
+    init_setup_subparser(subparsers, parents)
+    validate_setup_subparser(subparsers, parents)
+    generate_setup_subparser(subparsers, parents)
+    project_settings_setup_subparser(subparsers, parents)
+    test_setup_subparser(subparsers, parents)
     args = parser.parse_args(args=args_in)
 
     setup_logging(args.verbose)

--- a/src/rpdk/generate.py
+++ b/src/rpdk/generate.py
@@ -32,9 +32,9 @@ def generate(args):
     LOG.info("Generation complete.")
 
 
-def setup_subparser(subparsers):
+def setup_subparser(subparsers, parents):
     # see docstring of this file
-    parser = subparsers.add_parser("generate", description=__doc__)
+    parser = subparsers.add_parser("generate", description=__doc__, parents=parents)
     parser.set_defaults(command=generate)
     parser.add_argument(
         "resource_def_file",

--- a/src/rpdk/init.py
+++ b/src/rpdk/init.py
@@ -30,9 +30,9 @@ def init(args):
     plugin.init(project_settings)
 
 
-def setup_subparser(subparsers):
+def setup_subparser(subparsers, parents):
     # see docstring of this file
-    parser = subparsers.add_parser("init", description=__doc__)
+    parser = subparsers.add_parser("init", description=__doc__, parents=parents)
     parser.set_defaults(command=init)
     parser.add_argument(
         "--output-directory",

--- a/src/rpdk/project_settings.py
+++ b/src/rpdk/project_settings.py
@@ -15,9 +15,11 @@ def project_settings(args):
     args.output.write(settings)
 
 
-def setup_subparser(subparsers):
+def setup_subparser(subparsers, parents):
     # see docstring of this file
-    parser = subparsers.add_parser("project-settings", description=__doc__)
+    parser = subparsers.add_parser(
+        "project-settings", description=__doc__, parents=parents
+    )
     parser.set_defaults(command=project_settings)
     add_language_argument(parser)
     parser.add_argument(

--- a/src/rpdk/test.py
+++ b/src/rpdk/test.py
@@ -32,9 +32,9 @@ def local_lambda(args):
     )
 
 
-def setup_subparser(subparsers):
+def setup_subparser(subparsers, parents):
     # see docstring of this file
-    parser = subparsers.add_parser("test", description=__doc__)
+    parser = subparsers.add_parser("test", description=__doc__, parents=parents)
     # need to set this, so the help of this specific subparser is printed,
     # not the parent's help
     parser.set_defaults(command=lambda args: parser.print_help())

--- a/src/rpdk/validate.py
+++ b/src/rpdk/validate.py
@@ -19,8 +19,8 @@ def validate(args):
         LOG.info("Validation succeeded.")
 
 
-def setup_subparser(subparsers):
-    parser = subparsers.add_parser("validate", description=__doc__)
+def setup_subparser(subparsers, parents):
+    parser = subparsers.add_parser("validate", description=__doc__, parents=parents)
     parser.set_defaults(command=validate)
     parser.add_argument(
         "resource_spec_file",


### PR DESCRIPTION
*Issue #, if available:*  #22 

*Description of changes:* This allows the `-v`/`--verbose` flags to be specified on subcommands, e.g. `uluru-cli test -vv`. Previously this didn't work. The flip side is that `uluru-cli -vv test` no longer works, but that was weird anyway.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
