### PR TITLE
Fast fail if SAM CLI is not running

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ branch = True
 omit = */tests/*,*/contract/suite/*
 
 [report]
-fail_under = 89.5
+fail_under = 90

--- a/src/rpdk/test.py
+++ b/src/rpdk/test.py
@@ -59,16 +59,17 @@ def local_lambda(args):
             "Verify that the local lambda service from SAM CLI is running",
             args.endpoint,
         )
-        return
+        raise SystemExit(1)
     except ClientError as e:
-        if "Function not found" in e.args[0]:
+        msg = str(e)
+        if all(s in msg for s in ("ResourceNotFound", "Invoke", args.function_name)):
             LOG.error(
                 "Function with name '%s' not found running on local lambda service. "
                 "Verify that the function name matches "
                 "the logical name in the SAM Template. ",
                 args.function_name,
             )
-            return
+            raise SystemExit(1)
         raise
     invoke_pytest(transport, args)
 


### PR DESCRIPTION
#70 

Added a fast fail to check if SAM local lambda service is running and if a function exists with the specified function name. This skips testing entirely if either condition is not met. Complete with unit tests. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
