### PR TITLE
Fixed example schema to work with current codegen

### DIFF
--- a/src/rpdk/data/examples/resource/initech.tps.report.v1.json
+++ b/src/rpdk/data/examples/resource/initech.tps.report.v1.json
@@ -40,22 +40,10 @@
             "type": "string"
         },
         "TestCode": {
-            "anyOf": [
-                {
-                    "type": "string",
-                    "enum": [
-                        "NOT_STARTED",
-                        "CANCELLED"
-                    ]
-                },
-                {
-                    "type": "integer",
-                    "enum": [
-                        123,
-                        456,
-                        789
-                    ]
-                }
+            "type": "string",
+            "enum": [
+                "NOT_STARTED",
+                "CANCELLED"
             ]
         },
         "Authors": {


### PR DESCRIPTION
*Description of changes:* The current example schema used an `anyOf` to combine mutually-exclusive schemas which is currently not supported by the CodeGen. Removed this from the example.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
