### PR TITLE
Improved Java CodeGen

### DIFF
--- a/src/rpdk/init.py
+++ b/src/rpdk/init.py
@@ -17,6 +17,7 @@ def init(args):
     LOG.info("Loading the project settings...")
     project_settings = load_project_settings(plugin, args.project_settings_file)
     project_settings["output_directory"] = args.output_directory
+    project_settings["schemaFileName"] = "initech.tps.report.v1.json"
 
     LOG.info("Initializing project files...")
     output_path = Path(args.output_directory)
@@ -25,7 +26,7 @@ def init(args):
     copy_resource(
         __name__,
         "data/examples/resource/initech.tps.report.v1.json",
-        output_path / "initech.tps.report.v1.json",
+        output_path / project_settings["schemaFileName"],
     )
     plugin.init(project_settings)
 

--- a/src/rpdk/languages/java/templates/handlers/StubHandler.java
+++ b/src/rpdk/languages/java/templates/handlers/StubHandler.java
@@ -7,15 +7,18 @@
 package {{ packageName }}.handlers;
 
 import {{ packageName }}.messages.HandlerRequest;
+import {{ packageName }}.messages.HandlerStatus;
 import {{ packageName }}.messages.ProgressEvent;
 import {{ packageName }}.models.{{ pojo_name }};
-import {{ packageName }}.interfaces.ResourceHandler;
 
-public abstract class {{ operation }}Handler extends Base{{ operation }}Handler<{{ pojo_name }}> {
+public class {{ operation }}Handler extends Base{{ operation }}Handler {
 
-    public override ProgressEvent<{{ pojo_name }}> do{{ operation }}(final HandlerRequest<{{ pojo_name }}> request) {
+    @Override
+    public ProgressEvent<{{ pojo_name }}> do{{ operation }}(final HandlerRequest<{{ pojo_name }}> request) {
 
         // TODO : put your code here
+        return new ProgressEvent<{{ pojo_name }}>()
+            .withStatus(HandlerStatus.COMPLETE);
 
     }
 }

--- a/src/rpdk/languages/java/templates/maven/pom.xml
+++ b/src/rpdk/languages/java/templates/maven/pom.xml
@@ -39,13 +39,53 @@
         </dependency>
     </dependencies>
     <build>
+        <sourceDirectory>src</sourceDirectory>
+        <testSourceDirectory>tst</testSourceDirectory>
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>uluru-cli</executable>
+                    <arguments>
+                        <argument>generate</argument>
+                        <argument>{{schemaFileName}}</argument>
+                    </arguments>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/generated-src</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.3</version>
                 <configuration>
-                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <createDependencyReducedPom>false
+                    </createDependencyReducedPom>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
These changes now support a successful build for the following workflow

```
> uluru-cli init
> mvn compile
```

- updated pom.xml to declare src/tst folders
- included Maven plugin to generate sources (by running `uluru-cli generate`)
- included Maven plugin to add the generated-src folder to the build
- fixed some defects in the Java template leading to compile errors after generate
- allowed for future enhancement to name the sample schema document

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
