### PR TITLE
Worst case friendly error display

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ branch = True
 omit = */tests/*,*/contract/suite/*
 
 [report]
-fail_under = 90
+fail_under = 91

--- a/src/rpdk/cli.py
+++ b/src/rpdk/cli.py
@@ -2,6 +2,7 @@
 """
 import argparse
 import logging
+import sys
 import time
 from logging.config import dictConfig
 
@@ -29,6 +30,10 @@ def setup_logging(verbosity):
     logging_config = resource_yaml(__name__, "data/logging.yaml")
     logging_config["handlers"]["console"]["level"] = level
     dictConfig(logging_config)
+
+
+def unittest_patch_setup_subparser(_subparsers, _parents):
+    pass
 
 
 def main(args_in=None):
@@ -60,6 +65,7 @@ def main(args_in=None):
         generate_setup_subparser(subparsers, parents)
         project_settings_setup_subparser(subparsers, parents)
         test_setup_subparser(subparsers, parents)
+        unittest_patch_setup_subparser(subparsers, parents)
         args = parser.parse_args(args=args_in)
 
         setup_logging(args.verbose)
@@ -68,14 +74,20 @@ def main(args_in=None):
         log.debug("Logging set up successfully")
 
         args.command(args)
-    except Exception:
-        print("=== Unhandled exception ===")
-        print("Issue tracker: https://github.com/awslabs/aws-cloudformation-rpdk/issues")
+    except Exception:  # pylint: disable=broad-except
+        print("=== Unhandled exception ===", file=sys.stderr)
+        print("Please report this issue to the team.", file=sys.stderr)
+        print(
+            "Issue tracker: "
+            "https://github.com/awslabs/aws-cloudformation-rpdk/issues",
+            file=sys.stderr,
+        )
 
         if log:
-            print("Please include the log file 'rpdk.log'")
+            print("Please include the log file 'rpdk.log'", file=sys.stderr)
             log.debug("Unhandled exception", exc_info=True)
         else:
-            print("Please include this information:")
+            print("Please include this information:", file=sys.stderr)
             import traceback
+
             traceback.print_exc()


### PR DESCRIPTION
*Issue #, if available:* #112 (partially)

*Description of changes:* Worst case friendly error display. Let me know what you think. The first case is if the logging could not be set up yet, we'd print a stack trace. Otherwise, if the logging has been set up, we log the exception/stack trace to the rotating file and tell the customer to upload the log file. For the case of `-vv` (level 2 verbosity), the exception & stack trace is also printed to stdout:

```
$ uluru-cli init
=== Unhandled exception ===
Issue tracker: https://github.com/awslabs/aws-cloudformation-rpdk/issues
Please include this information:
Traceback (most recent call last):
  File "/workplace/tobflem/aws-cloudformation-rpdk/src/rpdk/cli.py", line 65, in main
    raise ValueError()
ValueError
$ uluru-cli init
=== Unhandled exception ===
Issue tracker: https://github.com/awslabs/aws-cloudformation-rpdk/issues
Please include the log file 'rpdk.log'
$ uluru-cli init -v
=== Unhandled exception ===
Issue tracker: https://github.com/awslabs/aws-cloudformation-rpdk/issues
Please include the log file 'rpdk.log'
$ uluru-cli init -vv
Logging set up successfully
=== Unhandled exception ===
Issue tracker: https://github.com/awslabs/aws-cloudformation-rpdk/issues
Please include the log file 'rpdk.log'
Unhandled exception
Traceback (most recent call last):
  File "/workplace/tobflem/aws-cloudformation-rpdk/src/rpdk/cli.py", line 70, in main
    args.command(args)
  File "/workplace/tobflem/aws-cloudformation-rpdk/src/rpdk/init.py", line 15, in init
    plugin = get_plugin(args.language)
  File "/workplace/tobflem/aws-cloudformation-rpdk/src/rpdk/plugin_registry.py", line 22, in get_plugin
    return PLUGIN_REGISTRY[language]()()
KeyError: 'java'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
