### PR TITLE
Resource gen support for combiners

### DIFF
--- a/src/rpdk/jsonutils/utils.py
+++ b/src/rpdk/jsonutils/utils.py
@@ -159,11 +159,7 @@ def schema_merge(target, src, path):
             try:
                 target[key] = schema_merge(target_schema, src_schema, next_path)
             except TypeError:
-                if (
-                    isinstance(target_schema, list)
-                    and isinstance(src_schema, list)
-                    and key == "required"
-                ):
+                if key == "required":
                     target[key] = list(set(target_schema) | set(src_schema))
                 else:
                     if key in ("type", "$ref") and target_schema != src_schema:

--- a/tests/contract/test_resource_generator.py
+++ b/tests/contract/test_resource_generator.py
@@ -100,16 +100,13 @@ def test_generate_object_strategy():
         example["second"]
 
 
-def test_generate_object_strategy_no_required():
+def test_generate_empty_object_strategy():
     schema = {
         "type": "object",
-        "required": ["first"],
         "properties": {"first": {"type": "object"}, "second": {"type": "object"}},
     }
     example = generate_schema_strategy(schema).example()
-    assert example["first"] is None
-    with pytest.raises(KeyError):
-        example["second"]
+    assert example == {}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Issue #, if available:* #118 

*Description of changes:* This adds resource generation support for schemas that include anyOf, oneOf, and allOf combiners. For anyOf and oneOf combiners, a strategy is created from each schema in the list being merged into the parent schema. The `one_of` strategy is then used to arbitrarily pick one of these strategies during resource generation. For allOf combiners, all items are merged into the parent schema to generate a strategy. This required changes to the `schema_merge` util, which now takes the union of two `required` arrays instead of simply overwriting one of them.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
