### PR TITLE
Non-zero return code if exception occurred

### DIFF
--- a/src/rpdk/cli.py
+++ b/src/rpdk/cli.py
@@ -13,6 +13,8 @@ from .project_settings import setup_subparser as project_settings_setup_subparse
 from .test import setup_subparser as test_setup_subparser
 from .validate import setup_subparser as validate_setup_subparser
 
+EXIT_UNHANDLED_EXCEPTION = 127
+
 
 class UTCFormatter(logging.Formatter):
     converter = time.gmtime
@@ -91,4 +93,4 @@ def main(args_in=None):
             import traceback
 
             traceback.print_exc()
-        raise SystemExit(1)
+        raise SystemExit(EXIT_UNHANDLED_EXCEPTION)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from rpdk.cli import main, setup_logging
+from rpdk.cli import EXIT_UNHANDLED_EXCEPTION, main, setup_logging
 
 from .test_init import chdir
 
@@ -99,7 +99,7 @@ def test_main_unhandled_exception_before_logging(capsys):
     ) as mock_hook:
         with pytest.raises(SystemExit) as excinfo:
             main(args_in=[])
-    assert excinfo.value.code == 1
+    assert excinfo.value.code == EXIT_UNHANDLED_EXCEPTION
     mock_hook.assert_called_once()
     out, err = capsys.readouterr()
     assert not out
@@ -123,7 +123,7 @@ def test_main_unhandled_exception_after_logging(capsys):
     ) as mock_hook:
         with pytest.raises(SystemExit) as excinfo:
             main(args_in=["fail"])
-    assert excinfo.value.code == 1
+    assert excinfo.value.code == EXIT_UNHANDLED_EXCEPTION
     mock_hook.assert_called_once()
     out, err = capsys.readouterr()
     assert not out


### PR DESCRIPTION
*Issue #, if available:* #61

*Description of changes:* Return non-zero exit code if an exception occurred, so it works properly when e.g. integrated with Maven. For unhandled exceptions, I'm using 127, we shouldn't use this for anything else, but it'll let us check in the unit tests whether it was expected `SystemExit` (e.g. invalid file), or unexpected `SystemExit` (e.g. uncaught exception).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
