### PR TITLE
Use lombok.Data for POJOs

### DIFF
--- a/src/rpdk/languages/java/templates/POJO.java
+++ b/src/rpdk/languages/java/templates/POJO.java
@@ -1,33 +1,16 @@
 // This is a generated file. Modifications will be overwritten.
 package {{ package_name }};
 
+import lombok.Data;
 import java.util.Map;
 import java.util.List;
 import java.util.Set;
 
-public class {{ pojo_name|uppercase_first_letter }} {
 
+@Data
+public class {{ pojo_name|uppercase_first_letter }} {
     {% for name, type in properties.items() %}
     private {{ type }} {{ name|lowercase_first_letter }};
 
     {% endfor %}
-
-    {% for name, type in properties.items() %}
-    {%- set lower = name|lowercase_first_letter %}
-    {%- set upper = name|uppercase_first_letter %}
-    public {{ type }} get{{ upper }}() {
-        return this.{{ lower }};
-    }
-
-    public void set{{ upper }}({{ type }} {{ lower }}) {
-        this.{{ lower }} = {{ lower }};
-    }
-
-    public {{ pojo_name }} with{{ upper }}({{ type }} {{ lower }}) {
-        this.{{ lower }} = {{ lower }};
-        return this;
-    }
-    {% endfor %}
-
-    public {{ pojo_name }}() { }
 }

--- a/src/rpdk/languages/java/templates/README.md
+++ b/src/rpdk/languages/java/templates/README.md
@@ -11,3 +11,7 @@ Congratulations on starting development! Next steps:
 
 Please don't modify files under `target/generated-sources/rpdk`, as they will be
 automatically overwritten.
+
+The code use [Lombok](https://projectlombok.org/), and [you may have to install
+IDE integrations](https://projectlombok.org/) to enable auto-complete for
+Lombok-annotated classes.

--- a/src/rpdk/languages/java/templates/pom.xml
+++ b/src/rpdk/languages/java/templates/pom.xml
@@ -19,11 +19,20 @@
     </properties>
 
     <dependencies>
+        <!-- https://github.com/awslabs/aws-cloudformation-rpdk-java-plugin/ -->
         <dependency>
             <groupId>com.aws.cfn</groupId>
             <artifactId>ResourceProviderExample</artifactId>
             <version>1.0</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.4</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
*Issue #, if available:*  https://github.com/awslabs/aws-cloudformation-rpdk/pull/139/files#r239666164

*Description of changes:* By using [@Data](https://projectlombok.org/features/Data) from Lombok, we get a bunch of nice things for idiomatic Java POJOs, so we don't have to generate them via codegen.

Provided the IDE has Lombok support (tested in IntelliJ), then auto-complete works perfectly.

Resulting POJO (some line-breaks removed):
```java
// This is a generated file. Modifications will be overwritten.
package com.aws.color.red;

import lombok.Data;
import java.util.Map;
import java.util.List;
import java.util.Set;

@Data
public class ResourceModel {
    private String tPSCode;
    private String title;
    private Boolean coverSheetIncluded;
    private String dueDate;
    private String approvalDate;
    private String memo;
    private String secondCopyOfMemo;
    private String testCode;
    private List<String> authors;
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
