### PR TITLE
Add comments with code coverage to PR

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,4 +1,7 @@
 version: 0.2
+env:
+  parameter-store:
+    GITHUB_OAUTH: /CodeBuild/aws-cloudformation-rpdk-comments-oauth
 phases:
   pre_build:
     commands:
@@ -7,3 +10,22 @@ phases:
   build:
     commands:
       - ./run_lint
+  post_build:
+    commands:
+      - echo "CODEBUILD_WEBHOOK_TRIGGER $CODEBUILD_WEBHOOK_TRIGGER"
+      - PR=$(echo "$CODEBUILD_WEBHOOK_TRIGGER" | perl -ne 'm|pr/(\d+)| && print "$1";')
+      - >
+        if [ -n "$PR" ]; then
+          COV=$(coverage report | grep -v "100%")
+          echo "$COV"
+          if [ $(echo "$COV" | wc -l) -gt 4 ]; then
+            COV=$(echo "$COV" | perl -pe 's/\n/\\n/g')
+            curl \
+              --verbose \
+              --request "POST" \
+              --header "Authorization: token $GITHUB_OAUTH" \
+              --header "Content-Type: application/json" \
+              --data '{"body": "```\n'"$COV"'```"}' \
+              "https://api.github.com/repos/awslabs/aws-cloudformation-rpdk/issues/$PR/comments"
+          fi
+        fi


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Since CodeBuild can't display HTML reports, I figure this is a quick-ish way for reviewers to see code coverage issues. See more about `CODEBUILD_WEBHOOK_TRIGGER` in the [CodeBuild docs](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html), but TL;DR, for PRs it's set to "pr/1234".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
