### PR TITLE
Init wizard for type name and plugin choice

### DIFF
--- a/src/rpdk/init.py
+++ b/src/rpdk/init.py
@@ -1,10 +1,119 @@
 """This sub command generates IDE and build files for a given language.
 """
 import logging
+import re
+from functools import wraps
 
+from .plugin_registry import PLUGIN_CHOICES
 from .project import Project
 
 LOG = logging.getLogger(__name__)
+
+
+TYPE_NAME_REGEX = r"^[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}$"
+
+
+class AbortError(Exception):
+    pass
+
+
+class ValidationError(Exception):
+    pass
+
+
+def input_with_validation(prompt, validate):
+    while True:
+        response = input(prompt)
+        try:
+            return validate(response)
+        except ValidationError as e:
+            print(str(e))
+
+
+def validate_type_name(value):
+    match = re.match(TYPE_NAME_REGEX, value)
+    if match:
+        return value
+    LOG.debug("'%s' did not match '%s'", value, TYPE_NAME_REGEX)
+    raise ValidationError("Please enter a value matching '{}'".format(TYPE_NAME_REGEX))
+
+
+def validate_yes(value):
+    return value.lower() in ("y", "yes")
+
+
+class ValidatePluginChoice:
+    def __init__(self, choices):
+        self.choices = tuple(choices)
+        self.max = len(self.choices)
+
+        pretty = "\n".join(
+            "[{}] {}".format(i, choice) for i, choice in enumerate(self.choices, 1)
+        )
+        self.message = "Select a language for code generation:\n" + pretty
+
+    def __call__(self, value):
+        try:
+            choice = int(value)
+        except ValueError:
+            raise ValidationError("Please enter an integer")
+        choice -= 1
+        if choice < 0 or choice >= self.max:
+            raise ValidationError("Please select a choice")
+        return self.choices[choice]
+
+
+validate_plugin_choice = ValidatePluginChoice(  # pylint: disable=invalid-name
+    PLUGIN_CHOICES
+)
+
+
+def check_for_existing_project(project):
+    try:
+        project.load_settings()
+    except FileNotFoundError:
+        return  # good path
+
+    if project.overwrite:
+        LOG.warning("Overwriting settings file: %s", project.settings_path)
+    else:
+        LOG.debug(
+            "Settings file for '%s' already exists: %s",
+            project.type_name,
+            project.settings_path,
+        )
+        project.overwrite = input_with_validation(
+            "Overwrite existing settings (y/N)? ", validate_yes
+        )
+        LOG.debug("Overwrite response: %s", project.overwrite)
+        if not project.overwrite:
+            raise AbortError()
+
+
+def input_typename():
+    type_name = input_with_validation(
+        "Enter resource type identifier (Organization::Service::Resource): ",
+        validate_type_name,
+    )
+    LOG.debug("Resource type identifier: %s", type_name)
+    return type_name
+
+
+def input_language():
+    # language/plugin
+    if validate_plugin_choice.max < 1:
+        LOG.critical("No language plugins found")
+        raise AbortError()
+
+    if validate_plugin_choice.max == 1:
+        language = validate_plugin_choice.choices[0]
+        LOG.warning("One language plugin found, defaulting to %s", language)
+    else:
+        language = input_with_validation(
+            validate_plugin_choice.message, validate_plugin_choice
+        )
+    LOG.debug("Language plugin: %s", language)
+    return language
 
 
 def init(args):
@@ -12,15 +121,31 @@ def init(args):
 
     LOG.warning("Initializing new project")
 
-    project.init("AWS::Color::Red", "java")
-    project.load_schema()
+    check_for_existing_project(project)
+
+    type_name = input_typename()
+    language = input_language()
+
+    project.init(type_name, language)
     project.generate()
+
+
+def ignore_abort(function):
+    @wraps(function)
+    def wrapper(args):
+        try:
+            function(args)
+        except (KeyboardInterrupt, AbortError):
+            print("\naborted")
+            raise SystemExit(1)
+
+    return wrapper
 
 
 def setup_subparser(subparsers, parents):
     # see docstring of this file
     parser = subparsers.add_parser("init", description=__doc__, parents=parents)
-    parser.set_defaults(command=init)
+    parser.set_defaults(command=ignore_abort(init))
 
     parser.add_argument(
         "--force", action="store_true", help="Force files to be overwritten."

--- a/src/rpdk/languages/java/tests/test_codegen.py
+++ b/src/rpdk/languages/java/tests/test_codegen.py
@@ -45,7 +45,6 @@ def test_generate(project):
         clear=True,
     ):
         project.init("AWS::Foo::{}".format(RESOURCE), "test")
-    project.load_schema()
 
     generated_root = project._plugin._get_generated_root(project)
 

--- a/src/rpdk/project.py
+++ b/src/rpdk/project.py
@@ -82,12 +82,12 @@ class Project:  # pylint: disable=too-many-instance-attributes
         self.settings = raw_settings.get("settings", {})
 
     def _write_example_schema(self):
-        schema = resource_json(
+        self.schema = resource_json(
             __name__, "data/examples/resource/initech.tps.report.v1.json"
         )
-        schema["$id"] = self.schema_filename
-        schema["typeName"] = self.type_name
-        self.safewrite(self.schema_path, json.dumps(schema, indent=4))
+        self.schema["$id"] = self.schema_filename
+        self.schema["typeName"] = self.type_name
+        self.safewrite(self.schema_path, json.dumps(self.schema, indent=4))
 
     def _write_settings(self, language):
         raw_settings = {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,14 +1,250 @@
-from unittest.mock import patch
+from unittest.mock import ANY, Mock, PropertyMock, patch
 
 import pytest
 
-from rpdk.cli import main
+from rpdk.cli import EXIT_UNHANDLED_EXCEPTION, main
+from rpdk.init import (
+    AbortError,
+    ValidatePluginChoice,
+    ValidationError,
+    check_for_existing_project,
+    ignore_abort,
+    init,
+    input_language,
+    input_typename,
+    input_with_validation,
+    validate_type_name,
+    validate_yes,
+)
+from rpdk.project import Project
+
+PROMPT = "MECVGD"
+ERROR = "TUJFEL"
 
 
 def test_init_command_help(capsys):
     with patch("rpdk.init.init", autospec=True) as mock_init:
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as excinfo:
             main(args_in=["init", "--help"])  # init has no required params
+    assert excinfo.value.code != EXIT_UNHANDLED_EXCEPTION
     out, _ = capsys.readouterr()
     assert "--help" in out
     mock_init.assert_not_called()
+
+
+def test_init_method():
+    type_name = object()
+    language = object()
+
+    args = Mock(spec_set=["force"])
+    args.force = False
+
+    mock_project = Mock(spec=Project)
+    mock_project.load_settings.side_effect = FileNotFoundError
+    mock_project.settings_path = ""
+
+    patch_project = patch("rpdk.init.Project", return_value=mock_project)
+    patch_tn = patch("rpdk.init.input_typename", return_value=type_name)
+    patch_l = patch("rpdk.init.input_language", return_value=language)
+
+    with patch_project, patch_tn as mock_tn, patch_l as mock_l:
+        init(args)
+
+    mock_tn.assert_called_once_with()
+    mock_l.assert_called_once_with()
+
+    mock_project.load_settings.assert_called_once_with()
+    mock_project.init.assert_called_once_with(type_name, language)
+    mock_project.generate.assert_called_once_with()
+
+
+def test_input_with_validation_valid_first_try():
+    sentinel1 = object()
+    sentinel2 = object()
+
+    validator = Mock(return_value=sentinel1)
+    with patch("rpdk.init.input", return_value=sentinel2) as mock_input:
+        ret = input_with_validation(PROMPT, validator)
+
+    mock_input.assert_called_once_with(PROMPT)
+    validator.assert_called_once_with(sentinel2)
+    assert ret is sentinel1
+
+
+def test_input_with_validation_valid_second_try(capsys):
+    def mock_validator(value):
+        if value == ERROR:
+            raise ValidationError(ERROR)
+        return value
+
+    sentinel = object()
+
+    with patch("rpdk.init.input", side_effect=(ERROR, sentinel)) as mock_input:
+        ret = input_with_validation(PROMPT, mock_validator)
+
+    assert mock_input.call_count == 2
+    assert ret is sentinel
+
+    out, err = capsys.readouterr()
+    assert not err
+    assert ERROR in out
+
+
+def test_validate_type_name_valid():
+    assert validate_type_name("AWS::Color::Red") == "AWS::Color::Red"
+
+
+def test_validate_type_name_invalid():
+    with pytest.raises(ValidationError):
+        validate_type_name("AWS-Color-Red")
+
+
+@pytest.mark.parametrize("value", ("y", "yes", "Y", "YES", "yEs", "YeS"))
+def test_validate_yes_yes(value):
+    assert validate_yes(value)
+
+
+@pytest.mark.parametrize("value", ("n", "N", "no", "NO", "yesn't"))
+def test_validate_yes_no(value):
+    assert not validate_yes(value)
+
+
+def test_validate_plugin_choice_not_an_int():
+    validator = ValidatePluginChoice(["test"])
+    with pytest.raises(ValidationError) as excinfo:
+        validator("a")
+    assert "integer" in str(excinfo.value)
+
+
+def test_validate_plugin_choice_less_than_zero():
+    validator = ValidatePluginChoice(["test"])
+    with pytest.raises(ValidationError) as excinfo:
+        validator("-1")
+    assert "select" in str(excinfo.value)
+
+
+def test_validate_plugin_choice_greater_than_choice():
+    choices = range(3)
+    validator = ValidatePluginChoice(choices)
+    with pytest.raises(ValidationError) as excinfo:
+        validator(str(len(choices) + 1))  # index is 1 based for input
+    assert "select" in str(excinfo.value)
+
+
+def test_validate_plugin_choice_valid():
+    choices = ["1", PROMPT, "2"]
+    validator = ValidatePluginChoice(choices)
+    assert validator("2") == PROMPT
+
+
+def test_check_for_existing_project_good_path():
+    project = Mock(spec=Project)
+    project.load_settings.side_effect = FileNotFoundError
+    type(project).overwrite = mock_overwrite = PropertyMock()
+
+    check_for_existing_project(project)
+
+    project.load_settings.assert_called_once_with()
+    mock_overwrite.assert_not_called()
+
+
+def test_check_for_existing_project_bad_path_overwrite():
+    project = Mock(spec=Project)
+    project.overwrite = True
+    project.settings_path = ""  # not sure why this doesn't get specced?
+
+    with patch("rpdk.init.input_with_validation", autospec=True) as mock_input:
+        check_for_existing_project(project)
+
+    mock_input.assert_not_called()
+
+
+def test_check_for_existing_project_bad_path_ask_yes():
+    project = Mock(spec=Project)
+    project.overwrite = False
+    project.settings_path = ""
+
+    patch_input = patch(
+        "rpdk.init.input_with_validation", autospec=True, return_value=True
+    )
+    with patch_input as mock_input:
+        check_for_existing_project(project)
+
+    mock_input.assert_called_once_with(ANY, validate_yes)
+    assert project.overwrite
+
+
+def test_check_for_existing_project_bad_path_ask_no():
+    project = Mock(spec=Project)
+    project.overwrite = False
+    project.settings_path = ""
+
+    patch_input = patch(
+        "rpdk.init.input_with_validation", autospec=True, return_value=False
+    )
+    with patch_input as mock_input:
+        with pytest.raises(AbortError):
+            check_for_existing_project(project)
+
+    mock_input.assert_called_once_with(ANY, validate_yes)
+    assert not project.overwrite
+
+
+def test_ignore_abort_ok():
+    sentinel = object()
+    function = Mock()
+    wrapped = ignore_abort(function)
+
+    wrapped(sentinel)
+    function.assert_called_once_with(sentinel)
+
+
+def test_ignore_abort_keyboard_interrupt():
+    sentinel = object()
+    function = Mock(side_effect=KeyboardInterrupt)
+    wrapped = ignore_abort(function)
+
+    with pytest.raises(SystemExit):
+        wrapped(sentinel)
+    function.assert_called_once_with(sentinel)
+
+
+def test_ignore_abort_abort():
+    sentinel = object()
+    function = Mock(side_effect=AbortError)
+    wrapped = ignore_abort(function)
+
+    with pytest.raises(SystemExit):
+        wrapped(sentinel)
+    function.assert_called_once_with(sentinel)
+
+
+def test_input_typename():
+    type_name = "AWS::Color::Red"
+    patch_input = patch("rpdk.init.input", return_value=type_name)
+    with patch_input as mock_input:
+        assert input_typename() == type_name
+    mock_input.assert_called_once()
+
+
+def test_input_language_no_plugins():
+    validator = ValidatePluginChoice([])
+    with patch("rpdk.init.validate_plugin_choice", validator):
+        with pytest.raises(AbortError):
+            input_language()
+
+
+def test_input_language_one_plugin():
+    validator = ValidatePluginChoice([PROMPT])
+    with patch("rpdk.init.validate_plugin_choice", validator):
+        assert input_language() == PROMPT
+
+
+def test_input_language_several_plugins():
+    validator = ValidatePluginChoice(["1", PROMPT, "2"])
+    patch_validator = patch("rpdk.init.validate_plugin_choice", validator)
+    patch_input = patch("rpdk.init.input", return_value="2")
+    with patch_validator, patch_input as mock_input:
+        assert input_language() == PROMPT
+
+    mock_input.assert_called_once()


### PR DESCRIPTION
*Issue #, if available:* #61 

*Description of changes:* Add a wizard on init that prompts for type name and language. As with any user input, quite a lot of care went into validation, or bad path behaviour if users type e.g. `Ctrl+C`.

The java plugin still needs a wizard step to prompt for the package name, but I thought I'd keep it separate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
