### PR TITLE
Modified generated pom.xml to exclude the wrapper

### DIFF
--- a/src/rpdk/languages/java/templates/pom.xml
+++ b/src/rpdk/languages/java/templates/pom.xml
@@ -48,6 +48,11 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.3</version>
                 <configuration>
+                    <artifactSet>
+                        <excludes>
+                            <exclude>com.aws.cfn:ResourceProviderExample</exclude>
+                        </excludes>
+                    </artifactSet>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                 </configuration>
                 <executions>


### PR DESCRIPTION
*Description of changes:*

The Lambda wrapper package built from **aws-cloudformation-rpdk-java-plugin** will now be deployed as a Lambda Layer and can be excluded from the handler package during packaging.

Relates to https://github.com/awslabs/aws-cloudformation-rpdk-java-plugin/pull/17

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
