### PR TITLE
Update dependencies (Dec 2018)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # better interactive session, debugger
-ipython>=7.1.1
+ipython>=7.2.0
 ipdb>=0.11
 # for previewing the README.rst
 docutils>=0.14
@@ -13,15 +13,15 @@ flake8-builtins>=1.4.1
 flake8-commas>=2.0.0
 flake8-comprehensions>=1.4.1
 flake8-debugger>=3.1.0
-flake8-isort>=2.5
+flake8-isort>=2.6.0
 flake8-pep3101>=1.2.1
-pylint>=2.1.1
+pylint>=2.2.2
 bandit>=1.5.1
 
 # testing tools
-coverage>=4.5.1
-pytest>=3.10.0
+coverage>=4.5.2
+pytest>=4.0.2
 pytest-cov>=2.6.0
-hypothesis>=3.82.1
-pytest-localserver>=0.4.1
-pytest-random-order>=1.0.3
+hypothesis>=3.83.1
+pytest-localserver>=0.5.0
+pytest-random-order>=1.0.4

--- a/setup.py
+++ b/setup.py
@@ -37,13 +37,13 @@ setup(
     zip_safe=True,
     install_requires=[
         "awscli>=1.16",
-        "boto3>=1.9",  # fmt: off
-        "Jinja2>=2.9",  # fmt: off
-        "jsonschema>=3.0.0a3",  # fmt: off
-        "pytest>=3.7",  # fmt: off
-        "Werkzeug>=0.14",  # fmt: off
-        "PyYAML>=3.13",  # fmt: off
-        "requests>=2.19",  # fmt: off
+        "boto3>=1.9",
+        "Jinja2>=2.10",
+        "jsonschema>=3.0.0a3",
+        "pytest>=4.0",
+        "Werkzeug>=0.14",
+        "PyYAML>=3.13",
+        "requests>=2.20",
     ],
     entry_points={
         "console_scripts": ["uluru-cli = rpdk.cli:main"],
@@ -59,8 +59,6 @@ setup(
         "Topic :: Software Development :: Code Generators",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ),


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Update dependencies (Dec 2018). Since we aren't testing on 3.4 or 3.5, I've removed these from the metadata also. If we wanted to support this, we'd have to test with different environments, which is tricky in CodeBuild/we'd probably have to use CodePipeline instead. Don't think it's currently a priority at all? In future, if we use TravisCI, that has [pretty easy tox support](https://github.com/tox-dev/tox-travis), which is the standard way to do it for Python.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.