### PR TITLE
Add termination protection on handler and infrastructure stacks

### DIFF
--- a/src/rpdk/package_utils.py
+++ b/src/rpdk/package_utils.py
@@ -84,6 +84,9 @@ class Packager:
         else:
             self.stack_wait(stack_name, "stack_create_complete")
             LOG.info("Stack '%s' successfully created", stack_name)
+            self.client.update_termination_protection(
+                EnableTerminationProtection=True, StackName=stack_name
+            )
 
     def stack_wait(self, stack_name, terminal_state):
         # waits for stack with name stack_name to be in state terminal_state


### PR DESCRIPTION
*Issue #, if available:* #150 

*Description of changes:* Adds a call that enables termination protection on infrastructure stack creation and whenever the handler stack is deployed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
