### PR TITLE
RefInliner producing incorrect refs

### DIFF
--- a/src/rpdk/jsonutils/utils.py
+++ b/src/rpdk/jsonutils/utils.py
@@ -44,20 +44,20 @@ def rewrite_ref(ref):
 
     If the reference is outside of the base document, a unique pointer inside
     the base document is made by namespacing the reference under the remote base
-    name inside the definitions section.
+    name inside the remote section.
 
     >>> rewrite_ref((BASE, "foo", "bar"))
     '#/foo/bar'
     >>> rewrite_ref((BASE,))
     '#'
     >>> rewrite_ref(("remote", "foo", "bar"))
-    '#/definitions/remote/foo/bar'
+    '#/remote/remote/foo/bar'
     >>> rewrite_ref(("remote",))
-    '#/definitions/remote'
+    '#/remote/remote'
     """
     base, *parts = ref
     if base is not BASE:
-        parts = ["definitions", base] + parts
+        parts = ["remote", base] + parts
     return fragment_encode(parts)
 
 

--- a/tests/jsonutils/test_inliner.py
+++ b/tests/jsonutils/test_inliner.py
@@ -88,7 +88,7 @@ def test_refinliner_remote_refs_simple_are_walked_and_inlined(httpserver):
     inliner = make_inliner({"type": "object", "properties": {"foo": {"$ref": ref}}})
     schema = inliner.inline()
     assert schema["remote"]["schema0"]["nested"]["bar"] == target
-    assert schema["properties"]["foo"]["$ref"] == "#/definitions/schema0/nested/bar"
+    assert schema["properties"]["foo"]["$ref"] == "#/remote/schema0/nested/bar"
     assert len(inliner.ref_graph) == 1
 
 
@@ -104,7 +104,7 @@ def test_refinliner_remote_refs_circular_are_walked_and_inlined(httpserver):
     )
     schema = inliner.inline()
     assert schema["remote"]["schema0"]["nested"]["bar"]["$ref"] == ref_a
-    assert schema["properties"]["foo"]["$ref"] == "#/definitions/schema0/nested/bar"
+    assert schema["properties"]["foo"]["$ref"] == "#/remote/schema0/nested/bar"
     assert len(inliner.ref_graph) == 2
 
 
@@ -121,7 +121,7 @@ def test_refinliner_remote_refs_on_filesystem_are_inlined(tmpdir):
     )
     schema = inliner.inline()
     assert schema["remote"]["schema0"]["nested"]["bar"] == target
-    assert schema["properties"]["foo"]["$ref"] == "#/definitions/schema0/nested/bar"
+    assert schema["properties"]["foo"]["$ref"] == "#/remote/schema0/nested/bar"
     assert len(inliner.ref_graph) == 1
 
 


### PR DESCRIPTION
*Issue #, if available:* #153

*Description of changes:* During the review of #56, we decided to move inlined schemas from under #/definitions to #/remote, but some code was missed, specifically the code that rewrites references, so all the refs were wrong.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
