### PR TITLE
Rework example resource schemas for easier codegen use

### DIFF
--- a/examples/schema/aws-ec2-instance.json
+++ b/examples/schema/aws-ec2-instance.json
@@ -1,5 +1,5 @@
 {
-    "$id": "aws.ec2.instance.v1.json",
+    "$id": "aws-ec2-instance.json",
     "typeName": "AWS::EC2::Instance",
     "definitions": {
         "Ebs": {
@@ -90,7 +90,7 @@
             "type": "object",
             "properties": {
                 "Ipv6Address": {
-                    "$ref": "../common.types.v1.json#/definitions/ipv6Address"
+                    "$ref": "common.types.v1.json#/definitions/ipv6Address"
                 }
             },
             "additionalProperties": false,
@@ -123,7 +123,7 @@
                     "type": "boolean"
                 },
                 "PrivateIpAddress": {
-                    "$ref": "../common.types.v1.json#/definitions/ipv4Address"
+                    "$ref": "common.types.v1.json#/definitions/ipv4Address"
                 }
             },
             "additionalProperties": false,
@@ -166,7 +166,7 @@
                     "type": "string"
                 },
                 "PrivateIpAddress": {
-                    "$ref": "../common.types.v1.json#/definitions/ipv4Address"
+                    "$ref": "common.types.v1.json#/definitions/ipv4Address"
                 },
                 "PrivateIpAddresses": {
                     "type": "array",
@@ -264,7 +264,7 @@
             ]
         },
         "AvailabilityZone": {
-            "$ref": "../aws.common.types.v1.json#/definitions/AvailabilityZone"
+            "$ref": "aws.common.types.v1.json#/definitions/AvailabilityZone"
         },
         "BlockDeviceMappings": {
             "type": "array",
@@ -306,8 +306,8 @@
         "InstanceType": {
             "type": "string",
             "default": "m1.small",
-            "$comment": "defined in ../aws.common.types.v1.json#/definitions/InstanceType",
-            "$ref": "../aws.common.types.v1.json#/definitions/InstanceType"
+            "$comment": "defined in aws.common.types.v1.json#/definitions/InstanceType",
+            "$ref": "aws.common.types.v1.json#/definitions/InstanceType"
         },
         "Ipv6AddressCount": {
             "type": "integer"
@@ -340,7 +340,7 @@
             "type": "string"
         },
         "PrivateIpAddress": {
-            "$ref": "../common.types.v1.json#/definitions/ipv4Address"
+            "$ref": "common.types.v1.json#/definitions/ipv4Address"
         },
         "RamdiskId": {
             "type": "string"
@@ -370,7 +370,7 @@
             "type": "string"
         },
         "Tags": {
-            "$ref": "../aws.common.types.v1.json#/definitions/Tags"
+            "$ref": "aws.common.types.v1.json#/definitions/Tags"
         },
         "Tenancy": {
             "type": "string",

--- a/examples/schema/aws-s3-bucket.json
+++ b/examples/schema/aws-s3-bucket.json
@@ -1,5 +1,5 @@
 {
-    "$id": "aws.s3.bucket.v1.json",
+    "$id": "aws-s3-bucket.json",
     "typeName": "AWS::S3::Bucket",
     "definitions": {
         "AccelerateConfiguration": {
@@ -22,10 +22,10 @@
             "type": "object",
             "properties": {
                 "BucketAccountId": {
-                    "$ref": "../aws.common.types.v1.json#/definitions/AccountId"
+                    "$ref": "aws.common.types.v1.json#/definitions/AccountId"
                 },
                 "BucketArn": {
-                    "$ref": "../aws.common.types.v1.json#/definitions/Arn"
+                    "$ref": "aws.common.types.v1.json#/definitions/Arn"
                 },
                 "Format": {
                     "type": "string"
@@ -294,7 +294,7 @@
                     "type": "string"
                 },
                 "TransitionDate": {
-                    "$ref": "../common.types.v1.json#/definitions/iso8601UTC"
+                    "$ref": "common.types.v1.json#/definitions/iso8601UTC"
                 },
                 "TransitionInDays": {
                     "type": "integer"
@@ -324,7 +324,7 @@
                     "$ref": "#/definitions/AbortIncompleteMultipartUpload"
                 },
                 "ExpirationDate": {
-                    "$ref": "../common.types.v1.json#/definitions/iso8601UTC"
+                    "$ref": "common.types.v1.json#/definitions/iso8601UTC"
                 },
                 "ExpirationInDays": {
                     "type": "integer"
@@ -515,7 +515,7 @@
                     "$ref": "#/definitions/NotificationFilter"
                 },
                 "Function": {
-                    "$ref": "../aws.common.types.v1.json#/definitions/Arn"
+                    "$ref": "aws.common.types.v1.json#/definitions/Arn"
                 }
             },
             "additionalProperties": false,
@@ -534,7 +534,7 @@
                     "$ref": "#/definitions/NotificationFilter"
                 },
                 "Queue": {
-                    "$ref": "../aws.common.types.v1.json#/definitions/Arn"
+                    "$ref": "aws.common.types.v1.json#/definitions/Arn"
                 }
             },
             "additionalProperties": false,
@@ -553,7 +553,7 @@
                     "$ref": "#/definitions/NotificationFilter"
                 },
                 "Topic": {
-                    "$ref": "../aws.common.types.v1.json#/definitions/Arn"
+                    "$ref": "aws.common.types.v1.json#/definitions/Arn"
                 }
             },
             "additionalProperties": false,
@@ -602,7 +602,7 @@
             "type": "object",
             "properties": {
                 "ReplicaKmsKeyID": {
-                    "$ref": "../aws.common.types.v1.json#/definitions/Arn"
+                    "$ref": "aws.common.types.v1.json#/definitions/Arn"
                 }
             },
             "additionalProperties": false,
@@ -617,7 +617,7 @@
                     "$ref": "#/definitions/AccessControlTranslation"
                 },
                 "Account": {
-                    "$ref": "../aws.common.types.v1.json#/definitions/AccountId"
+                    "$ref": "aws.common.types.v1.json#/definitions/AccountId"
                 },
                 "Bucket": {
                     "type": "string"
@@ -857,7 +857,7 @@
         },
         "Arn": {
             "description": "The Amazon Resource Name (ARN) of the specified bucket.",
-            "$ref": "../aws.common.types.v1.json#/definitions/Arn",
+            "$ref": "aws.common.types.v1.json#/definitions/Arn",
             "examples": [
                 "arn:aws:s3:::mybucket"
             ]
@@ -922,7 +922,7 @@
         },
         "Tags": {
             "description": "An arbitrary set of tags (key-value pairs) for this S3 bucket.",
-            "$ref": "../aws.common.types.v1.json#/definitions/Tags"
+            "$ref": "aws.common.types.v1.json#/definitions/Tags"
         },
         "VersioningConfiguration": {
             "description": "Enables multiple variants of all objects in this bucket.",

--- a/examples/schema/aws-sqs-queue.json
+++ b/examples/schema/aws-sqs-queue.json
@@ -1,10 +1,10 @@
 {
-    "$id": "aws.sqs.queue.v1.json",
+    "$id": "aws-sqs-queue.json",
     "typeName": "AWS::SQS::Queue",
     "properties": {
         "Arn": {
             "description": "The Amazon Resource Name (ARN) of the queue.",
-            "$ref": "../aws.common.types.v1.json#/definitions/Arn",
+            "$ref": "aws.common.types.v1.json#/definitions/Arn",
             "examples": [
                 "arn:aws:sqs:us-east-2:123456789012:mystack-myqueue-15PG5C2FC1CW8."
             ]
@@ -68,7 +68,7 @@
             "description": "Specifies an existing dead letter queue to receive messages after the source queue (this queue) fails to process a message a specified number of times.",
             "properties": {
                 "deadLetterTargetArn": {
-                    "$ref": "../aws.common.types.v1.json#/definitions/Arn"
+                    "$ref": "aws.common.types.v1.json#/definitions/Arn"
                 },
                 "maxReceiveCount": {
                     "type": "integer"
@@ -78,7 +78,7 @@
         },
         "Tags": {
             "description": "The tags that you want to attach to this queue.",
-            "$ref": "../aws.common.types.v1.json#/definitions/Tags"
+            "$ref": "aws.common.types.v1.json#/definitions/Tags"
         },
         "URL": {
             "type": "string",

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -58,12 +58,12 @@ def test_load_resource_spec_empty_object_is_invalid():
         load_resource_spec(yaml_s({}))
 
 
-def json_files_params(path):
-    return tuple(pytest.param(p, id=p.name) for p in path.glob("*.json"))
+def json_files_params(path, glob="*.json"):
+    return tuple(pytest.param(p, id=p.name) for p in path.glob(glob))
 
 
 @pytest.mark.parametrize(
-    "example", json_files_params(BASEDIR.parent / "examples" / "schema" / "resource")
+    "example", json_files_params(BASEDIR.parent / "examples" / "schema", "*-*-*.json")
 )
 def test_load_resource_spec_example_spec_is_valid(example):
     with example.open("r", encoding="utf-8") as f:


### PR DESCRIPTION
*Issue #, if available:* #153

*Description of changes:* Slightly tweak the example resource schemas so they can be dropped into the codegen very easily:

```console
$ uluru-cli init
Initializing new project
Enter resource type identifier (Organization::Service::Resource): AWS::SQS::Queue
One language plugin found, defaulting to java
$ cp ../aws-cloudformation-rpdk/examples/schema/*.json .
$ mvn package
[...]
[INFO] Compiling 9 source files to /workplace/tobflem/uluru-test/target/classes
[...]
[INFO] BUILD SUCCESS
[...]
```

```console
$ uluru-cli init
Initializing new project
Enter resource type identifier (Organization::Service::Resource): AWS::EC2::Instance
One language plugin found, defaulting to java
$ cp ../aws-cloudformation-rpdk/examples/schema/*.json .
$ mvn package
[...]
[INFO] Compiling 19 source files to /workplace/tobflem/uluru-test/target/classes
[...]
[INFO] BUILD SUCCESS
[...]
```

```console
$ uluru-cli init
Initializing new project
Enter resource type identifier (Organization::Service::Resource): AWS::S3::Bucket
One language plugin found, defaulting to java
$ cp ../aws-cloudformation-rpdk/examples/schema/*.json .
$ mvn package
[...]
[INFO] Compiling 47 source files to /workplace/tobflem/uluru-test/target/classes
[...]
[INFO] BUILD SUCCESS
[...]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
