### PR TITLE
Bug Fix: Add back null as acceptable handlerArn

### DIFF
--- a/src/rpdk/project.py
+++ b/src/rpdk/project.py
@@ -19,7 +19,7 @@ SETTINGS_VALIDATOR = Draft6Validator(
             "language": {"type": "string"},
             "typeName": {"type": "string", "pattern": TYPE_NAME_REGEX},
             "settings": {"type": "object"},
-            "handlerArn": {"type": ["string"]},
+            "handlerArn": {"type": ["string", "null"]},
         },
         "required": ["language", "typeName"],
         "additionalProperties": False,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Whenever I made changes in #148, I mistakenly removed `null` from the handlerARN type array. This adds it back and un-breaks the cli 😅


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
