### PR TITLE
Move common packaging logic from plugin to project

### DIFF
--- a/src/rpdk/plugin_base.py
+++ b/src/rpdk/plugin_base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from jinja2 import Environment, PackageLoader, select_autoescape
+from jinja2 import ChoiceLoader, Environment, PackageLoader, select_autoescape
 
 from .filters import FILTER_REGISTRY
 
@@ -16,7 +16,12 @@ class LanguagePlugin(ABC):
 
     def _setup_jinja_env(self, **options):
         if "loader" not in options:
-            options["loader"] = PackageLoader(self._module_name, "templates/")
+            options["loader"] = ChoiceLoader(
+                [
+                    PackageLoader(self._module_name, "templates/"),
+                    PackageLoader(__name__, "templates/"),
+                ]
+            )
         if "autoescape" not in options:
             options["autoescape"] = select_autoescape(["html", "htm", "xml"])
 

--- a/src/rpdk/project.py
+++ b/src/rpdk/project.py
@@ -6,6 +6,7 @@ from jsonschema import Draft6Validator
 from jsonschema.exceptions import ValidationError
 
 from .data_loaders import load_resource_spec, resource_json
+from .packager import package_handler
 from .plugin_registry import load_plugin
 
 LOG = logging.getLogger(__name__)
@@ -143,5 +144,9 @@ class Project:  # pylint: disable=too-many-instance-attributes
         return self._plugin.generate(self)
 
     def package(self):
-        self.handler_arn = self._plugin.package(self)
+        self._plugin.package(self)
+
+        handler_stack_name = "{}-stack".format(self.hypenated_name)
+        self.handler_arn = package_handler(handler_stack_name)
+
         self._write_settings(self._plugin.NAME)

--- a/src/rpdk/templates/Handler.yaml
+++ b/src/rpdk/templates/Handler.yaml
@@ -3,9 +3,6 @@ Transform: AWS::Serverless-2016-10-31
 Description: "Handler template for the {{ resource_type }} resource type"
 
 Parameters:
-  HandlerEntry:
-    Type: String
-    Description: "The name of the function that Lambda executes"
   EncryptionKey:
     Type: String
     Description: "The ARN of the key used to encrypt/decrypt requests"
@@ -17,18 +14,16 @@ Resources:
   ResourceHandler:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./target/{{ resource_type }}-handler-1.0-SNAPSHOT.jar
       Description: "Handler lambda function for the {{ resource_type }} resource type"
-      FunctionName: {{ resource_type }}-handler
-      Handler:
-        Ref: HandlerEntry
       KmsKeyArn:
         Ref: EncryptionKey
       Role:
         Ref: LambdaRole
-      Runtime: {{ runtime }}
       Timeout: 60
       MemorySize: 128
+      {% for key, value in handler_params.items() %}
+      {{ key }}: {{ value }}
+      {% endfor %}
 
   CloudFormationPermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
*Issue #, if available:* #167, also sort of related to #166 

*Description of changes:* Move common packaging logic from the Java plugin to the project class, so other plugins don't have to re-implement it. Can't test it e2e due to #166, but I'm getting to that and wanted to keep this work separate. Linting confirms the handler files still make sense:

```
$ cfn-lint --debug Handler.yaml
[...]
2018-12-24 03:36:25,942 - cfnlint - DEBUG - Completed linting of file: Handler.yaml
$ sam validate -t Handler.yaml
2018-12-24 03:36:58 Found credentials in environment variables.
/workplace/tobflem/uluru-test/Handler.yaml is a valid SAM Template
```

[Gist of the Handler.yaml file](https://gist.github.com/tobywf/31b50c82b283a9110b0d063ae293c097)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
