### PR TITLE
Suppress s3transfer output

### DIFF
--- a/src/rpdk/data/logging.yaml
+++ b/src/rpdk/data/logging.yaml
@@ -31,6 +31,9 @@ loggers:
   urllib3:
     level: ERROR
     # propagate: no
+  s3transfer:
+    level: ERROR
+    # propagate: no
 root:
   level: DEBUG
   handlers:


### PR DESCRIPTION
*Issue #, if available:* #166 

*Description of changes:* Suppress some of the spammy s3transfer output. Specifically picked an example where an exception is thrown to show we still get the important information:

After:

```
$ uluru-cli package -vv
Logging set up successfully
Root directory: /workplace/tobflem/uluru-test
Loading project file '/workplace/tobflem/uluru-test/.rpdk-config'
Creating stack 'CFNResourceHandlerInfrastructure'
Stack 'CFNResourceHandlerInfrastructure' already exists. Attempting to update stack
No updates are to be performed for stack 'CFNResourceHandlerInfrastructure'
Uploading local code package to bucket 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea' and outputting modified template
Unable to export
Traceback (most recent call last):
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/awscli/customizations/s3uploader.py", line 119, in upload
    future.result()
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/s3transfer/futures.py", line 73, in result
    return self._coordinator.result()
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/s3transfer/futures.py", line 233, in result
    raise self._exception
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/s3transfer/tasks.py", line 126, in __call__
    return self._execute_main(kwargs)
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/s3transfer/tasks.py", line 150, in _execute_main
    return_value = self._main(**kwargs)
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/s3transfer/tasks.py", line 333, in _main
    Bucket=bucket, Key=key, **extra_args)
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/botocore/client.py", line 661, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.NoSuchBucket: An error occurred (NoSuchBucket) when calling the CreateMultipartUpload operation: The specified bucket does not exist
```

Before:
```
$ uluru-cli package -vv
Logging set up successfully
Root directory: /workplace/tobflem/uluru-test
Loading project file '/workplace/tobflem/uluru-test/.rpdk-config'
Creating stack 'CFNResourceHandlerInfrastructure'
Stack 'CFNResourceHandlerInfrastructure' already exists. Attempting to update stack
No updates are to be performed for stack 'CFNResourceHandlerInfrastructure'
Uploading local code package to bucket 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea' and outputting modified template
Acquiring 0
UploadSubmissionTask(transfer_id=0, {'transfer_future': <s3transfer.futures.TransferFuture object at 0x1104ed9e8>}) about to wait for the following futures []
UploadSubmissionTask(transfer_id=0, {'transfer_future': <s3transfer.futures.TransferFuture object at 0x1104ed9e8>}) done waiting for dependent futures
Executing task UploadSubmissionTask(transfer_id=0, {'transfer_future': <s3transfer.futures.TransferFuture object at 0x1104ed9e8>}) with kwargs {'client': <botocore.client.S3 object at 0x1104b4a58>, 'config': <s3transfer.manager.TransferConfig
 object at 0x1104bee48>, 'osutil': <s3transfer.utils.OSUtils object at 0x1104bee80>, 'request_executor': <s3transfer.futures.BoundedExecutor object at 0x1104c3048>, 'transfer_future': <s3transfer.futures.TransferFuture object at 0x1104ed9e8>}
Submitting task CreateMultipartUploadTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'extra_args': {'ServerSideEncryption': 'AES256'}}) to executor <s3t
ransfer.futures.BoundedExecutor object at 0x1104c3048> for transfer request: 0.
Acquiring 0
CreateMultipartUploadTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'extra_args': {'ServerSideEncryption': 'AES256'}}) about to wait for the following
futures []
Submitting task UploadPartTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'part_number': 1, 'extra_args': {}}) to executor <s3transfer.futures.BoundedEx
ecutor object at 0x1104c3048> for transfer request: 0.
CreateMultipartUploadTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'extra_args': {'ServerSideEncryption': 'AES256'}}) done waiting for dependent futur
es
Acquiring 0
Executing task CreateMultipartUploadTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'extra_args': {'ServerSideEncryption': 'AES256'}}) with kwargs {'cli
ent': <botocore.client.S3 object at 0x1104b4a58>, 'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'extra_args': {'ServerSideEncryption': 'AES256'}}
UploadPartTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'part_number': 1, 'extra_args': {}}) about to wait for the following futures [<s3transfer.futu
res.ExecutorFuture object at 0x1104edac8>]
Submitting task UploadPartTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'part_number': 2, 'extra_args': {}}) to executor <s3transfer.futures.BoundedEx
ecutor object at 0x1104c3048> for transfer request: 0.
UploadPartTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'part_number': 1, 'extra_args': {}}) about to wait for <s3transfer.futures.ExecutorFuture obje
ct at 0x1104edac8>
Acquiring 0
UploadPartTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'part_number': 2, 'extra_args': {}}) about to wait for the following futures [<s3transfer.futu
res.ExecutorFuture object at 0x1104edac8>]
Submitting task CompleteMultipartUploadTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'extra_args': {}}) to executor <s3transfer.futures.BoundedExecuto
r object at 0x1104c3048> for transfer request: 0.
UploadPartTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'part_number': 2, 'extra_args': {}}) about to wait for <s3transfer.futures.ExecutorFuture obje
ct at 0x1104edac8>
Acquiring 0
CompleteMultipartUploadTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'extra_args': {}}) about to wait for the following futures [<s3transfer.futures.E
xecutorFuture object at 0x1104edac8>, <s3transfer.futures.ExecutorFuture object at 0x1104ed208>, <s3transfer.futures.ExecutorFuture object at 0x1104f0908>]
Releasing acquire 0/None
CompleteMultipartUploadTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'extra_args': {}}) about to wait for <s3transfer.futures.ExecutorFuture object at
 0x1104edac8>
Exception raised.
Traceback (most recent call last):
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/s3transfer/tasks.py", line 126, in __call__
    return self._execute_main(kwargs)
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/s3transfer/tasks.py", line 150, in _execute_main
    return_value = self._main(**kwargs)
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/s3transfer/tasks.py", line 333, in _main
    Bucket=bucket, Key=key, **extra_args)
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/botocore/client.py", line 661, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.NoSuchBucket: An error occurred (NoSuchBucket) when calling the CreateMultipartUpload operation: The specified bucket does not exist
Releasing acquire 0/None
UploadPartTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'part_number': 1, 'extra_args': {}}) done waiting for dependent futures
UploadPartTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'part_number': 2, 'extra_args': {}}) done waiting for dependent futures
CompleteMultipartUploadTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'extra_args': {}}) about to wait for <s3transfer.futures.ExecutorFuture object at
 0x1104ed208>
Releasing acquire 0/None
Releasing acquire 0/None
CompleteMultipartUploadTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'extra_args': {}}) about to wait for <s3transfer.futures.ExecutorFuture object at
 0x1104f0908>
CompleteMultipartUploadTask(transfer_id=0, {'bucket': 'cfnresourcehandlerinfrastructure-artifactbucket-uncli3jfa2ea', 'key': 'dec181be2192e40d9a760b2815836607', 'extra_args': {}}) done waiting for dependent futures
Releasing acquire 0/None
Unable to export
Traceback (most recent call last):
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/awscli/customizations/s3uploader.py", line 119, in upload
    future.result()
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/s3transfer/futures.py", line 73, in result
    return self._coordinator.result()
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/s3transfer/futures.py", line 233, in result
    raise self._exception
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/s3transfer/tasks.py", line 126, in __call__
    return self._execute_main(kwargs)
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/s3transfer/tasks.py", line 150, in _execute_main
    return_value = self._main(**kwargs)
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/s3transfer/tasks.py", line 333, in _main
    Bucket=bucket, Key=key, **extra_args)
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/tobflem/.cache/rpdk/lib/python3.7/site-packages/botocore/client.py", line 661, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.NoSuchBucket: An error occurred (NoSuchBucket) when calling the CreateMultipartUpload operation: The specified bucket does not exist
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
