### PR TITLE
$ref for draft-07 changed to HTTPS endpoints

### DIFF
--- a/src/rpdk/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/data/schema/provider.definition.schema.v1.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "$id": "provider.definition.schema.v1.json",
     "title": "CloudFormation Resource Provider Definition MetaSchema",
     "description": "This schema validates a CloudFormation resource provider definition.",
@@ -58,53 +58,53 @@
                         },
                         "readOnly": {
                             "description": "A list of properties that are able to be found in a Read request but unable to be specified by the customer",
-                            "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+                            "$ref": "https://json-schema.org/draft-07/schema#/definitions/stringArray"
                         },
                         "writeOnly": {
                             "description": "A list of properties (typically sensitive) that are able to be specified by the customer but unable to be returned in a Read request",
-                            "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+                            "$ref": "https://json-schema.org/draft-07/schema#/definitions/stringArray"
                         },
                         "$ref": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/$ref"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/$ref"
                         },
                         "$comment": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/$comment"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/$comment"
                         },
                         "title": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/title"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/title"
                         },
                         "description": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/description"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/description"
                         },
                         "examples": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/examples"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/examples"
                         },
                         "default": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/default"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/default"
                         },
                         "multipleOf": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/multipleOf"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/multipleOf"
                         },
                         "maximum": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/maximum"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/maximum"
                         },
                         "exclusiveMaximum": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMaximum"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/exclusiveMaximum"
                         },
                         "minimum": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/minimum"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/minimum"
                         },
                         "exclusiveMinimum": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/exclusiveMinimum"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/exclusiveMinimum"
                         },
                         "maxLength": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/maxLength"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/maxLength"
                         },
                         "minLength": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/minLength"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/minLength"
                         },
                         "pattern": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/pattern"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/pattern"
                         },
                         "items": {
                             "$comment": "Redefined as just a schema. A list of schemas is not allowed",
@@ -112,25 +112,25 @@
                             "default": {}
                         },
                         "maxItems": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/maxItems"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/maxItems"
                         },
                         "minItems": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/minItems"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/minItems"
                         },
                         "uniqueItems": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/uniqueItems"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/uniqueItems"
                         },
                         "contains": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/contains"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/contains"
                         },
                         "maxProperties": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/maxProperties"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/maxProperties"
                         },
                         "minProperties": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/minProperties"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/minProperties"
                         },
                         "required": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/required"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/required"
                         },
                         "properties": {
                             "type": "object",
@@ -163,22 +163,22 @@
                                         "$ref": "#/definitions/properties"
                                     },
                                     {
-                                        "$ref": "http://json-schema.org/draft-07/schema#/definitions/stringArray"
+                                        "$ref": "https://json-schema.org/draft-07/schema#/definitions/stringArray"
                                     }
                                 ]
                             }
                         },
                         "const": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/const"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/const"
                         },
                         "enum": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/enum"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/enum"
                         },
                         "type": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/type"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/type"
                         },
                         "format": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/format"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/format"
                         },
                         "allOf": {
                             "$ref": "#/definitions/schemaArray"
@@ -198,7 +198,7 @@
     "type": "object",
     "properties": {
         "$id": {
-            "$ref": "http://json-schema.org/draft-07/schema#/properties/$id"
+            "$ref": "https://json-schema.org/draft-07/schema#/properties/$id"
         },
         "typeName": {
             "$comment": "Resource Type Identifier",
@@ -211,13 +211,13 @@
             "pattern": "^[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}$"
         },
         "$comment": {
-            "$ref": "http://json-schema.org/draft-07/schema#/properties/$comment"
+            "$ref": "https://json-schema.org/draft-07/schema#/properties/$comment"
         },
         "title": {
-            "$ref": "http://json-schema.org/draft-07/schema#/properties/title"
+            "$ref": "https://json-schema.org/draft-07/schema#/properties/title"
         },
         "description": {
-            "$ref": "http://json-schema.org/draft-07/schema#/properties/description"
+            "$ref": "https://json-schema.org/draft-07/schema#/properties/description"
         },
         "sourceUrl": {
             "$comment": "Source Code Location (e.g; .git URL)",
@@ -260,7 +260,7 @@
                     "type": "object",
                     "properties": {
                         "$comment": {
-                            "$ref": "http://json-schema.org/draft-07/schema#/properties/$comment"
+                            "$ref": "https://json-schema.org/draft-07/schema#/properties/$comment"
                         },
                         "properties": {
                             "$ref": "#/properties/properties"
@@ -291,7 +291,7 @@
             "$ref": "#/definitions/jsonPointerArray"
         },
         "required": {
-            "$ref": "http://json-schema.org/draft-07/schema#/properties/required"
+            "$ref": "https://json-schema.org/draft-07/schema#/properties/required"
         },
         "allOf": {
             "$ref": "#/definitions/schemaArray"


### PR DESCRIPTION
*Description of changes:*
 
Starting to build out validation logic in handlers and hit some issues with certain libraries trying to hit HTTP endpoints. That can be fixed in the code, but since there's a valid HTTPS endpoint for the JSON Schema it made sense to flip to that as this also fixes the problem and avoids others having same issues later.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
