### PR TITLE
Renaming `readOnly` and `writeOnly` block

### DIFF
--- a/examples/schema/aws-s3-bucket.json
+++ b/examples/schema/aws-s3-bucket.json
@@ -942,10 +942,10 @@
             ]
         }
     },
-    "createOnly": [
+    "createOnlyProperties": [
         "/properties/BucketName"
     ],
-    "readOnly": [
+    "readOnlyProperties": [
         "/properties/Arn",
         "/properties/DomainName",
         "/properties/DualStackDomainName",

--- a/examples/schema/aws-sqs-queue.json
+++ b/examples/schema/aws-sqs-queue.json
@@ -95,11 +95,11 @@
             "maximum": 43200
         }
     },
-    "createOnly": [
+    "createOnlyProperties": [
         "/properties/FifoQueue",
         "/properties/QueueName"
     ],
-    "readOnly": [
+    "readOnlyProperties": [
         "/properties/Arn",
         "/properties/URL"
     ],

--- a/src/rpdk/data/examples/resource/initech.tps.report.v1.json
+++ b/src/rpdk/data/examples/resource/initech.tps.report.v1.json
@@ -57,7 +57,7 @@
         "/properties/Title",
         "/properties/DueDate"
     ],
-    "readOnly": [
+    "readOnlyProperties": [
         "/properties/tps_code"
     ],
     "identifiers": [

--- a/src/rpdk/data/schema/README.md
+++ b/src/rpdk/data/schema/README.md
@@ -27,10 +27,10 @@ The _shape_ of your resource defines the properties for that resource and how th
 
 Certain properties of a resource are _semantic_ and have special meaning when used in different contexts. For example, a property of a resource may be `readOnly` when read back for state changes - but can be specified in a settable context when used as the target of a `$ref` from a related resource. Because of this semantic difference in how this property metadata should be interpreted, certain aspects of the resource definition are applied to the parent resource definition, rather than at a property level. Those elements are;
 
-* **`identifiers`**: Each property listed in the `identifiers` section must be able to be used to uniquely identify the resource. These properties can be independently provided as keys to a **READ** or **DELETE** request. These properties are usually also marked as `readOnly` and are only returned from **READ** and **LIST** operations.
-* **`readOnly`**: A `readOnly` property cannot be specified in a **CREATE** or **UPDATE** request, and attempting to do so will produce a runtime error from the handler.
-* **`writeOnly`**: A `writeOnly` property cannot be returned in a **READ** or **LIST** request, and can be used to express things like passwords, secrets or other sensitive data.
-* **`createOnly`**: A `createOnly` property cannot be specified in an **UPDATE** request, and can only be specified in a **CREATE** request. Another way to think about this - these are properties which are 'write-once', such as the [`Engine`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-engine) property for an [`AWS::RDS::DBInstance`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html) and if you wish to change such a property on a live resource, you should replace that resource by creating a new instance of the resource and terminating the old one. This is the behaviour CloudFormation follows for all properties documented as _'Update Requires: Replacement'_. An attempt to supply these properties to an **UPDATE** request will produce a runtime error from the handler.
+* **`identifiers`**: Each property listed in the `identifiers` section must be able to be used to uniquely identify the resource. These properties can be independently provided as keys to a **READ** or **DELETE** request. These properties are usually also marked as `readOnlyProperties` and are only returned from **READ** and **LIST** operations.
+* **`readOnlyProperties`**: A property in the `readOnlyProperties` list cannot be specified in a **CREATE** or **UPDATE** request, and attempting to do so will produce a runtime error from the handler.
+* **`writeOnlyProperties`**: A property in the `writeOnlyProperties` cannot be returned in a **READ** or **LIST** request, and can be used to express things like passwords, secrets or other sensitive data.
+* **`createOnlyProperties`**: A property in the `createOnlyProperties` cannot be specified in an **UPDATE** request, and can only be specified in a **CREATE** request. Another way to think about this - these are properties which are 'write-once', such as the [`Engine`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-engine) property for an [`AWS::RDS::DBInstance`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html) and if you wish to change such a property on a live resource, you should replace that resource by creating a new instance of the resource and terminating the old one. This is the behaviour CloudFormation follows for all properties documented as _'Update Requires: Replacement'_. An attempt to supply these properties to an **UPDATE** request will produce a runtime error from the handler.
 
 #### Application
 
@@ -51,23 +51,15 @@ The following (truncated) example shows some of the semantic definitions for an 
             "type": "string"
         }
     },
-    "createOnly": [
-        {
-            "$ref": "#/properties/BucketName"
-        }
+    "createOnlyProperties": [
+        "/properties/BucketName"
     ],
-    "readOnly": [
-        {
-            "$ref": "#/properties/Arn"
-        }
+    "readOnlyProperties": [
+        "/properties/Arn"
     ],
     "identifiers": [
-        {
-            "$ref": "#/properties/Arn"
-        },
-        {
-            "$ref": "#/properties/BucketName"
-        }
+        "/properties/Arn",
+        "/properties/BucketName"
     ]
 }
 ```

--- a/src/rpdk/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/data/schema/provider.definition.schema.v1.json
@@ -274,15 +274,15 @@
             },
             "additionalProperties": false
         },
-        "readOnly": {
+        "readOnlyProperties": {
             "description": "A list of JSON pointers to properties that are able to be found in a Read request but unable to be specified by the customer",
             "$ref": "#/definitions/jsonPointerArray"
         },
-        "writeOnly": {
+        "writeOnlyProperties": {
             "description": "A list of JSON pointers to properties (typically sensitive) that are able to be specified by the customer but unable to be returned in a Read request",
             "$ref": "#/definitions/jsonPointerArray"
         },
-        "createOnly": {
+        "createOnlyProperties": {
             "description": "A list of JSON pointers to properties that are only able to be specified by the customer when creating a resource. Conversely, any property *not* in this list can be applied to an Update request.",
             "$ref": "#/definitions/jsonPointerArray"
         },


### PR DESCRIPTION
*Description of changes:*

After further study of the JSON Schema RFC, in particular section 10.3 related to validation annotations, I discovered that the `readOnly` and `writeOnly` keywords are part of the schema validation vocabulary and cannot be re-purposed as schema property keywords in the way we had done.

As such, this commit renames the semantic keywords to something without conflicts in the JSON Schema vocabulary, and updates the README and examples to reflect this change.

SEE: https://json-schema.org/draft-07/json-schema-validation.html#rfc.section.10.3

*Issue #, if available:* #46


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
