### PR TITLE
Use empty creds for unit tests

### DIFF
--- a/run_lint
+++ b/run_lint
@@ -12,4 +12,11 @@ pylint "${files[@]}"
 # have to skip B101, contract tests use it and there's no way to skip for specific files
 # have to skip B322, as bandit apparently isn't clever enough to detect we're running Python 3
 bandit -r "src/" --skip "B101,B322" --exclude "tests"
+# although we mock SDK calls, these must be set, otherwise the credential-checking code
+# in boto_helpers.py fails. this probably needs fixing properly in future.
+# on the other hand, this means that exported creds aren't honoured when running tests,
+# also a good thing
+AWS_ACCESS_KEY_ID="" \
+AWS_SECRET_ACCESS_KEY="" \
+AWS_SESSION_TOKEN="" \
 pytest --cov="src/" --doctest-modules --random-order-bucket="parent" "src/" "tests/"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Intermittently, unit tests fail on dev boxes. While the unit tests don't need credentials (because all calls are mocked), in #171 we introduced checks that the credentials have been specified. Maybe there's a better fix for this, but it's pretty good and also means the unit tests don't accidentally use credentials that were exported earlier.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
