### PR TITLE
Increased Lambda MemorySize to 256MB

### DIFF
--- a/src/rpdk/templates/Handler.yaml
+++ b/src/rpdk/templates/Handler.yaml
@@ -20,7 +20,7 @@ Resources:
       Role:
         Ref: LambdaRole
       Timeout: 60
-      MemorySize: 128
+      MemorySize: 256
       {% for key, value in handler_params.items() %}
       {{ key }}: {{ value }}
       {% endfor %}


### PR DESCRIPTION
*Description of changes:*

128MB was insufficient for a stub Java handler; OutOfMemoryErrors occurred initialising dependencies.

#frugalityfail

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
