### PR TITLE
Passing a logger interface to the handlers

### DIFF
--- a/src/rpdk/languages/java/templates/BaseHandler.java
+++ b/src/rpdk/languages/java/templates/BaseHandler.java
@@ -1,6 +1,7 @@
 // This is a generated file. Modifications will be overwritten.
 package {{ package_name }};
 
+import com.aws.cfn.proxy.Logger;
 import com.aws.cfn.proxy.ProgressEvent;
 import com.aws.cfn.proxy.RequestContext;
 import com.aws.cfn.proxy.ResourceHandlerRequest;
@@ -9,6 +10,7 @@ public abstract class BaseHandler {
 
     public abstract ProgressEvent handleRequest(
         final ResourceHandlerRequest<{{ pojo_name }}> request,
-        final RequestContext context);
+        final RequestContext context,
+        final Logger logger);
 
 }

--- a/src/rpdk/languages/java/templates/HandlerWrapper.java
+++ b/src/rpdk/languages/java/templates/HandlerWrapper.java
@@ -6,6 +6,7 @@ import com.aws.cfn.LambdaWrapper;
 import com.aws.cfn.metrics.MetricsPublisher;
 import com.aws.cfn.proxy.CallbackAdapter;
 import com.aws.cfn.proxy.HandlerRequest;
+import com.aws.cfn.proxy.LoggerProxy;
 import com.aws.cfn.proxy.ProgressEvent;
 import com.aws.cfn.proxy.RequestContext;
 import com.aws.cfn.proxy.ResourceHandlerRequest;
@@ -53,9 +54,11 @@ public final class HandlerWrapper extends LambdaWrapper<{{ pojo_name }}> {
         if (!handlers.containsKey(action))
             throw new RuntimeException("Unknown action " + actionName);
 
+        final LoggerProxy loggerProxy = new LoggerProxy(this.logger);
+
         final BaseHandler handler = handlers.get(action);
 
-        return handler.handleRequest(request, context);
+        return handler.handleRequest(request, context, loggerProxy);
     }
 
     @Override

--- a/src/rpdk/languages/java/templates/StubHandler.java
+++ b/src/rpdk/languages/java/templates/StubHandler.java
@@ -1,5 +1,6 @@
 package {{ package_name }};
 
+import com.aws.cfn.proxy.Logger;
 import com.aws.cfn.proxy.ProgressEvent;
 import com.aws.cfn.proxy.ProgressStatus;
 import com.aws.cfn.proxy.RequestContext;
@@ -10,7 +11,8 @@ public class {{ operation }}Handler extends BaseHandler {
     @Override
     public ProgressEvent handleRequest(
         final ResourceHandlerRequest<{{ pojo_name }}> request,
-        final RequestContext context) {
+        final RequestContext context,
+        final Logger logger) {
 
         final ResourceModel model = request.getDesiredResourceState();
 


### PR DESCRIPTION
Description of changes:

Passing a logger interface to the handlers so they can emit diagnostics, which we proxy to the LambdaLogger in this runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
