### PR TITLE
CloudFormation Integration Changes

### DIFF
--- a/src/rpdk/data/CloudFormationHandlerInfrastructure.yaml
+++ b/src/rpdk/data/CloudFormationHandlerInfrastructure.yaml
@@ -50,6 +50,14 @@ Resources:
                   - "events:PutRule"
                   - "events:RemoveTargets"
                 Resource: "*"
+        - PolicyName: "CloudFormationProgressPolicy"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "cloudformation:RecordHandlerProgress"
+                Resource: "*"
 
   EncryptionKey:
     Type: AWS::KMS::Key

--- a/src/rpdk/project.py
+++ b/src/rpdk/project.py
@@ -152,6 +152,10 @@ class Project:  # pylint: disable=too-many-instance-attributes
 
     def register(self, handler_arn):
         handler_arns = {op: handler_arn for op in HANDLER_OPS}
+        self.schema["identifiers"] = [
+            [identifier] if isinstance(identifier, str) else identifier
+            for identifier in self.schema["identifiers"]
+        ]
 
         registry_args = {
             "TypeName": self.type_name,

--- a/src/rpdk/templates/Handler.yaml
+++ b/src/rpdk/templates/Handler.yaml
@@ -57,6 +57,16 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: cloudformation.amazonaws.com
 
+  CloudWatchPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName:
+        Ref: ResourceHandler
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn:
+        Fn::Sub: "arn:aws:events:${AWS::Region}:${AWS::AccountId}:*"
+
 Outputs:
   ResourceHandlerArn:
     Value:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -18,7 +18,7 @@ LANGUAGE = "BQHDBC"
 CONTENTS_UTF8 = "💣"
 TYPE_NAME = "AWS::Color::Red"
 ARN = "SOMEARN"
-SCHEMA = {}
+SCHEMA = {"identifiers": []}
 EXPECTED_REGISTRY_ARGS = {
     "TypeName": TYPE_NAME,
     "Schema": json.dumps(SCHEMA),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Encompassing PR that tweaks rpdk to account for CloudFormation integration. Changes include:

* Adding a policy to the lambda policies to report back progress to CloudFormation
* Before submitting, transforming identifiers in schema so that single property identifiers are converted into a list containing solely that identifier property. This is how CloudFormation expects the identifiers.
* Adding permission in handler CloudFormation template to allow EventRules to invoke the handler Lambda function


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
