### PR TITLE
Move JSONSchema dependency to stable release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "awscli>=1.16",
         "boto3>=1.9.71,<1.10.0",
         "Jinja2>=2.10",
-        "jsonschema>=3.0.0a3",
+        "jsonschema>=3.0.1",
         "pytest>=4.0",
         "Werkzeug>=0.14",
         "PyYAML>=3.13",


### PR DESCRIPTION
*Issue #, if available:* #17 

*Description of changes:* 3.0.0 was released February 23 and 3.0.1 was released March 1: https://pypi.org/project/jsonschema/#history

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
