### PR TITLE
Logging dateformat should use %m (month) instead of %M (minutes)

### DIFF
--- a/src/rpdk/core/data/logging.yaml
+++ b/src/rpdk/core/data/logging.yaml
@@ -4,7 +4,7 @@ formatters:
     format: "%(message)s"
   detailed:
     format: "[%(asctime)s] %(levelname)-8s - %(message)s"
-    datefmt: "%Y-%M-%dT%H:%M:%SZ"
+    datefmt: "%Y-%m-%dT%H:%M:%SZ"
     class: rpdk.core.cli.UTCFormatter
 handlers:
   console:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Logging dateformat was using `%Y-%M-%d`, which lead to some **interesting** timestamps:

```
[2019-57-06T19:57:15Z] DEBUG    - Rewriting refs in '<BASE>' (http://localhost/)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
