### PR TITLE
Adding custom KMS Key to allow CloudFormation to copy objects

### DIFF
--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -19,6 +19,7 @@ Resources:
           - ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: aws:kms
+                KMSMasterKeyID: !Ref EncryptionKey
           - ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: AES256
@@ -46,6 +47,34 @@ Resources:
             Resource:
               - !Sub "arn:${AWS::Partition}:s3:::${ArtifactBucket}"
               - !Sub "arn:${AWS::Partition}:s3:::${ArtifactBucket}/*"
+
+  EncryptionKey:
+    Condition: KMSSupported
+    Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    Properties:
+      Description: KMS key used to encrypt the resource type artifacts
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+        - Sid: Enable full access for owning account
+          Effect: Allow
+          Principal:
+            AWS: !Ref AWS::AccountId
+          Action: kms:*
+          Resource: "*"
+        - Sid: Enable access for cloudformation to copy encrypted objects
+          Effect: Allow
+          Principal:
+            Service: cloudformation.amazonaws.com
+          Action:
+            - "kms:Encrypt"
+            - "kms:Decrypt"
+            - "kms:ReEncrypt*"
+            - "kms:GenerateDataKey*"
+            - "kms:DescribeKey"
+          Resource: "*"
 
 Outputs:
   CloudFormationManagedUploadBucketName:


### PR DESCRIPTION
*Issue #, if available:*  #219

*Description of changes:* Instead of removing encryption, creating a custom key and giving the CloudFormation service principal permissions allows us to copy over the deployment packages across accounts. Tested running associated services locally.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
