### PR TITLE
Renamed `uluru-cli` to `cfn-cli` for launch.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
-AWS CloudFormation RPDK
+AWS CloudFormation CLI
 Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 AWS CloudFormation Resource Provider Development Kit
 ====================================================
 
-The CloudFormation Resource Provider Development Kit (RPDK) allows you to author your own resource providers that can be used by CloudFormation.
+The CloudFormation CLI (cfn-cli) allows you to author your own resource providers that can be used by CloudFormation.
 
 Development
 -----------
@@ -48,7 +48,7 @@ the Python Package Index (PyPI). It requires Python 3.
 
 .. code-block:: bash
 
-    pip3 install uluru-cli
+    pip3 install cfn-cli
 
 Command: init
 ^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ To create a project in the current directory, use the ``init`` command. A wizard
 
 .. code-block:: bash
 
-    uluru-cli init
+    cfn-cli init
 
 Command: generate
 ^^^^^^^^^^^^^^^^^
@@ -66,7 +66,7 @@ To refresh auto-generated code, use the ``generate`` command. Usually, plugins t
 
 .. code-block:: bash
 
-    uluru-cli generate
+    cfn-cli generate
 
 Plugin system
 -------------

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "PyYAML<=3.13,>=3.10",
         "requests>=2.20",
     ],
-    entry_points={"console_scripts": ["uluru-cli = rpdk.core.cli:main"]},
+    entry_points={"console_scripts": ["cfn-cli = rpdk.core.cli:main"]},
     license="Apache License 2.0",
     classifiers=(
         "Development Status :: 2 - Pre-Alpha",

--- a/src/rpdk/core/data/schema/README.md
+++ b/src/rpdk/core/data/schema/README.md
@@ -34,7 +34,7 @@ Certain properties of a resource are _semantic_ and have special meaning when us
 
 #### Application
 
-When defining resource semantics like `createOnly`, `identifiers` you are expected to use a `$ref` to a property definition in the same resource document. This is not enforced directly by the meta-schema but is enforced at runtime and can be checked with the RPDK CLI `validate` command.
+When defining resource semantics like `createOnly`, `identifiers` you are expected to use a `$ref` to a property definition in the same resource document. This is not enforced directly by the meta-schema but is enforced at runtime and can be checked with the CloudFormation CLI `validate` command.
 
 The following (truncated) example shows some of the semantic definitions for an `AWS::S3::Bucket` resource type;
 


### PR DESCRIPTION
*Description of changes:* Renamed `uluru-cli` to `cfn-cli` for launch.

Will require another follow up to rename the repo and make 'resource provider' development a part of the overall CLI branding.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
