### PR TITLE
Differentiate overwrite attribute from method

### DIFF
--- a/src/rpdk/core/init.py
+++ b/src/rpdk/core/init.py
@@ -73,7 +73,7 @@ def check_for_existing_project(project):
     except FileNotFoundError:
         return  # good path
 
-    if project.overwrite:
+    if project.overwrite_enabled:
         LOG.warning("Overwriting settings file: %s", project.settings_path)
     else:
         LOG.debug(
@@ -81,11 +81,11 @@ def check_for_existing_project(project):
             project.type_name,
             project.settings_path,
         )
-        project.overwrite = input_with_validation(
+        project.overwrite_enabled = input_with_validation(
             "Overwrite existing settings (y/N)? ", validate_yes
         )
-        LOG.debug("Overwrite response: %s", project.overwrite)
-        if not project.overwrite:
+        LOG.debug("Overwrite response: %s", project.overwrite_enabled)
+        if not project.overwrite_enabled:
             raise WizardAbortError()
 
 

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -49,8 +49,8 @@ SETTINGS_VALIDATOR = Draft6Validator(
 
 
 class Project:  # pylint: disable=too-many-instance-attributes
-    def __init__(self, overwrite=False, root=None):
-        self._overwrite = overwrite
+    def __init__(self, overwrite_enabled=False, root=None):
+        self.overwrite_enabled = overwrite_enabled
         self.root = Path(root) if root else Path.cwd()
         self.settings_path = self.root / SETTINGS_FILENAME
         self.type_info = None
@@ -158,7 +158,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
             f.write(contents)
 
     def safewrite(self, path, contents):
-        if self._overwrite:
+        if self.overwrite_enabled:
             self.overwrite(path, contents)
         else:
             try:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -130,7 +130,7 @@ def test_validate_plugin_choice_valid():
 def test_check_for_existing_project_good_path():
     project = Mock(spec=Project)
     project.load_settings.side_effect = FileNotFoundError
-    type(project).overwrite = mock_overwrite = PropertyMock()
+    type(project).overwrite_enabled = mock_overwrite = PropertyMock()
 
     check_for_existing_project(project)
 
@@ -140,7 +140,7 @@ def test_check_for_existing_project_good_path():
 
 def test_check_for_existing_project_bad_path_overwrite():
     project = Mock(spec=Project)
-    project.overwrite = True
+    project.overwrite_enabled = True
     project.settings_path = ""  # not sure why this doesn't get specced?
 
     with patch("rpdk.core.init.input_with_validation", autospec=True) as mock_input:
@@ -151,7 +151,7 @@ def test_check_for_existing_project_bad_path_overwrite():
 
 def test_check_for_existing_project_bad_path_ask_yes():
     project = Mock(spec=Project)
-    project.overwrite = False
+    project.overwrite_enabled = False
     project.settings_path = ""
 
     patch_input = patch(
@@ -161,12 +161,12 @@ def test_check_for_existing_project_bad_path_ask_yes():
         check_for_existing_project(project)
 
     mock_input.assert_called_once_with(ANY, validate_yes)
-    assert project.overwrite
+    assert project.overwrite_enabled
 
 
 def test_check_for_existing_project_bad_path_ask_no():
     project = Mock(spec=Project)
-    project.overwrite = False
+    project.overwrite_enabled = False
     project.settings_path = ""
 
     patch_input = patch(
@@ -177,7 +177,7 @@ def test_check_for_existing_project_bad_path_ask_no():
             check_for_existing_project(project)
 
     mock_input.assert_called_once_with(ANY, validate_yes)
-    assert not project.overwrite
+    assert not project.overwrite_enabled
 
 
 def test_ignore_abort_ok():

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -106,7 +106,7 @@ def test_safewrite_overwrite(project):
     path = object()
     contents = object()
 
-    patch_attr = patch.object(project, "_overwrite", True)
+    patch_attr = patch.object(project, "overwrite_enabled", True)
     patch_meth = patch.object(project, "overwrite", autospec=True)
     with patch_attr, patch_meth as mock_overwrite:
         project.safewrite(path, contents)
@@ -117,7 +117,7 @@ def test_safewrite_overwrite(project):
 def test_safewrite_doesnt_exist(project, tmpdir):
     path = Path(tmpdir.join("test")).resolve()
 
-    with patch.object(project, "_overwrite", False):
+    with patch.object(project, "overwrite_enabled", False):
         project.safewrite(path, CONTENTS_UTF8)
 
     with path.open("r", encoding="utf-8") as f:
@@ -130,7 +130,7 @@ def test_safewrite_exists(project, tmpdir, caplog):
     with path.open("w", encoding="utf-8") as f:
         f.write(CONTENTS_UTF8)
 
-    with patch.object(project, "_overwrite", False):
+    with patch.object(project, "overwrite_enabled", False):
         project.safewrite(path, CONTENTS_UTF8)
 
     last_record = caplog.records[-1]


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Discovered during UX review. On init, the wrong `overwrite` was being used, which was always truthy and caused it to never prompt if files should be overwritten. but since `_overwrite` was still false, no source files were actually overwritten except for the project file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
