### PR TITLE
Allow multiple functions/handlers to be defined in the SAM template

### DIFF
--- a/src/rpdk/core/templates/template.yml
+++ b/src/rpdk/core/templates/template.yml
@@ -1,11 +1,21 @@
+{% macro function(name, params) %}
+  {{ name }}:
+    Type: AWS::Serverless::Function
+    Properties:
+      Timeout: 60  # docker start-up times can be long for SAM CLI
+      {% for key, value in params.items() %}
+      {{ key }}: {{ value }}
+      {% endfor %}
+{% endmacro %}
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: AWS SAM template for the {{ resource_type }} resource type
 
 Resources:
-  TypeFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      {% for key, value in handler_params.items() %}
-      {{ key }}: {{ value }}
-      {% endfor %}
+{% if functions %}
+{% for name, params in functions.items() %}
+{{ function(name, params) }}
+{% endfor %}
+{% else %}
+{{ function("TypeFunction", handler_params) }}
+{% endif %}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Allow multiple functions/handlers to be defined in the SAM template. This change is backwards compatible, if `functions` is not specified, it falls back to the previous behaviour. Also increase the default timeout, if the docker image has to be pulled first, even 60 seconds may not be enough (but it's a reasonable limit for now, and we can change it centrally).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
