### PR TITLE
Ensure schema and project settings end with newlines

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,7 @@
 # fixture and parameter have the same name
 # pylint: disable=redefined-outer-name,useless-super-delegation,protected-access
 import json
+import os
 import random
 import string
 import zipfile
@@ -167,8 +168,18 @@ def test_init(project):
     with project.settings_path.open("r", encoding="utf-8") as f:
         assert json.load(f)
 
+    # ends with newline
+    with project.settings_path.open("rb") as f:
+        f.seek(-1, os.SEEK_END)
+        assert f.read() == b"\n"
+
     with project.schema_path.open("r", encoding="utf-8") as f:
         assert json.load(f)
+
+    # ends with newline
+    with project.schema_path.open("rb") as f:
+        f.seek(-1, os.SEEK_END)
+        assert f.read() == b"\n"
 
 
 def test_load_invalid_schema(project):


### PR DESCRIPTION
*Issue #, if available:* #239 

*Description of changes:* Ensure schema and project settings end with newlines. Could have been done by concatenating `"\n"` to the JSON dumps, but I've changed the `overwrite` and `safewrite` methods to accept a callable which can then perform multiple write operations - should come in handy for plugins, too. Hexdump to verify only one newline is added:

```
$ pre-commit run --files aws-color-red.json .rpdk-config 
isort................................................(no files to check)Skipped
black................................................(no files to check)Skipped
Check for case conflicts.................................................Passed
Fix End of Files.........................................................Passed
Mixed line ending........................................................Passed
Trim Trailing Whitespace.................................................Passed
Flake8...............................................(no files to check)Skipped
Pretty format JSON.......................................................Passed
Check for merge conflicts................................................Passed
Check blanket noqa...................................(no files to check)Skipped
check for not-real mock methods......................(no files to check)Skipped
use logger.warning(..................................(no files to check)Skipped
bandit...............................................(no files to check)Skipped
$ tail -c 3 .rpdk-config | hexdump -C
00000000  0a 7d 0a                                          |.}.|
00000003
$ tail -c 3 aws-color-red.json | hexdump -C
00000000  0a 7d 0a                                          |.}.|
00000003
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
