### PR TITLE
additionalIdentifiers also checked for writeable-ness

### DIFF
--- a/src/rpdk/core/contract/suite/handler_misc.py
+++ b/src/rpdk/core/contract/suite/handler_misc.py
@@ -36,12 +36,10 @@ def contract_crud_exerciser(resource_client):
         status, response = resource_client.call(Action.CREATE, request)
         resource_client.assert_success(status, response)
 
-        # if the primary identifier is provided by the handler, then multiple
-        # requests with the same model can succeed
-        if resource_client.primary_identifier_is_read_only():
-            LOG.debug("primary identifier is read only; skipping CREATE test")
-        else:
-            LOG.debug("primary identifier is writeable; performing CREATE test")
+        # if no identifiers are writeable, then multiple requests with the same
+        # model can succeed
+        if resource_client.has_writable_identifier():
+            LOG.debug("at least one identifier is writeable; performing CREATE test")
             # CREATE (not idempotent, because different clientRequestToken)
             second_request = resource_client.make_request(create_model, None)
             status, response = resource_client.call(Action.CREATE, second_request)
@@ -49,6 +47,8 @@ def contract_crud_exerciser(resource_client):
             assert (
                 error_code == HandlerErrorCode.AlreadyExists
             ), "creating the same resource should not be possible"
+        else:
+            LOG.debug("no identifiers are writeable; skipping CREATE test")
 
     finally:
         # DELETE

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -142,7 +142,7 @@ def test_generate_create_example(resource_client):
     assert example == {"a": 1}
 
 
-def test_primary_identifier_is_read_only(resource_client):
+def test_has_writable_identifier_primary_is_read_only(resource_client):
     resource_client._update_schema(
         {
             "primaryIdentifier": ["/properties/foo"],
@@ -150,13 +150,49 @@ def test_primary_identifier_is_read_only(resource_client):
         }
     )
 
-    assert resource_client.primary_identifier_is_read_only()
+    assert not resource_client.has_writable_identifier()
 
 
-def test_primary_identifier_is_not_read_only(resource_client):
+def test_has_writable_identifier_primary_is_writeable(resource_client):
     resource_client._update_schema({"primaryIdentifier": ["/properties/foo"]})
 
-    assert not resource_client.primary_identifier_is_read_only()
+    assert resource_client.has_writable_identifier()
+
+
+def test_has_writable_identifier_primary_and_additional_are_read_only(resource_client):
+    resource_client._update_schema(
+        {
+            "primaryIdentifier": ["/properties/foo"],
+            "additionalIdentifiers": [["/properties/bar"]],
+            "readOnlyProperties": ["/properties/foo", "/properties/bar"],
+        }
+    )
+
+    assert not resource_client.has_writable_identifier()
+
+
+def test_has_writable_identifier_additional_is_writeable(resource_client):
+    resource_client._update_schema(
+        {
+            "primaryIdentifier": ["/properties/foo"],
+            "additionalIdentifiers": [["/properties/bar"]],
+            "readOnlyProperties": ["/properties/foo"],
+        }
+    )
+
+    assert resource_client.has_writable_identifier()
+
+
+def test_has_writable_identifier_compound_is_writeable(resource_client):
+    resource_client._update_schema(
+        {
+            "primaryIdentifier": ["/properties/foo"],
+            "additionalIdentifiers": [["/properties/bar", "/properties/baz"]],
+            "readOnlyProperties": ["/properties/foo", "/properties/baz"],
+        }
+    )
+
+    assert resource_client.has_writable_identifier()
 
 
 def test__make_payload(resource_client):


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* ...in create contract test.

Test run where `Title` is a writable identifier:
```
  },
  "callbackContext": null
}
Received response
{'callbackDelaySeconds': 0, 'resourceModel': {'Description': 'UOyJBBwtODuVImkLaUjBGaZh', 'Title': 'fgaxqgZyubxzxLAuoLyZXTemPKJgCnUd'}, 'status': 'SUCCESS'}
at least one identifier is writeable; performing CREATE test
Sending request
{
  "credentials": {
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
