### PR TITLE
Remove contract test randomization

### DIFF
--- a/src/rpdk/core/data/pytest-contract.ini
+++ b/src/rpdk/core/data/pytest-contract.ini
@@ -1,7 +1,6 @@
 [pytest]
 addopts =
     --pyargs "rpdk.core.contract.suite"
-    --random-order-bucket "parent"
     --verbose
     --no-print-logs
 python_files = handler_*.py


### PR DESCRIPTION
*Issue #, if available:* N/A, blocking contract tests running on machines without dev dependencies installed.

*Description of changes:* Remove contract test randomization. That feature is provided by a dependency we only install for development, so it wasn't caught. I think it's better to remove it for now instead of adding another dependency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
