### PR TITLE
Catch possible ClientError on RegisterType

### DIFF
--- a/src/rpdk/core/upload.py
+++ b/src/rpdk/core/upload.py
@@ -139,8 +139,7 @@ class Uploader:
             self.s3_client.upload_fileobj(fileobj, bucket, key)
         except ClientError as e:
             LOG.debug("S3 upload resulted in unknown ClientError", exc_info=e)
-            LOG.critical("Failed to upload artifacts to S3")
-            raise UploadError("Failed to upload artifacts to S3: " + str(e)) from e
+            raise DownstreamError("Failed to upload artifacts to S3") from e
 
         LOG.debug("Upload complete")
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -127,7 +127,7 @@ def test_upload_s3_clienterror(uploader):
     )
 
     with patch_stack as mock_stack:
-        with pytest.raises(UploadError):
+        with pytest.raises(DownstreamError):
             uploader.upload("foo", fileobj)
 
     mock_stack.assert_called_once_with(ANY)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Catch possible boto3 error when calling `register_type`. Convert error during S3 upload from `UploadError` to `DownstreamError`, to allow users to see error message and potentially self-help depending on the error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
