### PR TITLE
Adds logging infra and includes LoggingConfig

### DIFF
--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -65,6 +65,35 @@ Resources:
             - "kms:DescribeKey"
           Resource: "*"
 
+  LogAndMetricsDeliveryRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: cloudformation.amazonaws.com
+          Action: sts:AssumeRole
+      Path: "/"
+      Policies:
+      - PolicyName: LogAndMetricsDeliveryRolePolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:DescribeLogGroups
+            - logs:DescribeLogStreams
+            - logs:PutLogEvents
+            - cloudwatch:ListMetrics
+            - cloudwatch:PutMetricData
+            Resource: "*"
+
 Outputs:
   CloudFormationManagedUploadBucketName:
     Value: !Ref ArtifactBucket
+  LogAndMetricsDeliveryRoleArn:
+    Value: !GetAtt LogAndMetricsDeliveryRole.Arn


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* An IAM::Role with required CloudWatch permissions is now included in the managed-upload-infrastructure stack and the ARN of the role is passed to the CloudFormation RegisterType API as part of `cfn-cli submit`. A log group name is created for the type (e.g; initech-tps-report-logs) as part of the API.

I have verified in us-west-2 with the out-of-box type that I am now receiving logs to my own account from the published types.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
