### PR TITLE
General-purpose model (type) resolver

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,6 +84,7 @@ repos:
       env AWS_ACCESS_KEY_ID=""
       AWS_SECRET_ACCESS_KEY=""
       AWS_SESSION_TOKEN=""
+      AWS_DEFAULT_REGION="us-east-1"
       pytest
       --cov="rpdk.core"
       --doctest-modules

--- a/src/rpdk/core/data/examples/resource/initech.tps.report.v1.json
+++ b/src/rpdk/core/data/examples/resource/initech.tps.report.v1.json
@@ -7,6 +7,17 @@
             "$comment": "Use the `definitions` block to provide shared resource property schemas",
             "type": "string",
             "format": "date-time"
+        },
+        "Memo": {
+            "type": "object",
+            "properties": {
+                "Heading": {
+                    "type": "string"
+                },
+                "Body": {
+                    "type": "string"
+                }
+            }
         }
     },
     "properties": {
@@ -32,11 +43,11 @@
             "$ref": "#/definitions/InitechDateFormat"
         },
         "Memo": {
-            "type": "string"
+            "$ref": "#/definitions/Memo"
         },
         "SecondCopyOfMemo": {
             "description": "In case you didn't get the first one.",
-            "type": "string"
+            "$ref": "#/definitions/Memo"
         },
         "TestCode": {
             "type": "string",

--- a/src/rpdk/core/exceptions.py
+++ b/src/rpdk/core/exceptions.py
@@ -48,3 +48,7 @@ class ContractTestError(RPDKBaseException):
 
 class InvalidRequestError(ContractTestError):
     pass
+
+
+class ModelResolverError(RPDKBaseException):
+    pass

--- a/src/rpdk/core/jsonutils/resolver.py
+++ b/src/rpdk/core/jsonutils/resolver.py
@@ -1,0 +1,210 @@
+from enum import Enum, auto
+
+from ..exceptions import ModelResolverError
+from ..filters import uppercase_first_letter
+from .flattener import JsonSchemaFlattener
+from .utils import BASE, fragment_encode
+
+UNDEFINED = "undefined"
+
+
+class ContainerType(Enum):
+    PRIMITIVE = auto()
+    MODEL = auto()
+    DICT = auto()
+    LIST = auto()
+    SET = auto()
+
+
+class ResolvedType:
+    def __init__(self, container, item_type):
+        self.container = container
+        self.type = item_type
+
+    def __repr__(self):
+        return f"<ResolvedType({self.container}, {self.type})>"
+
+    def __eq__(self, other):
+        return self.container == other.container and self.type == other.type
+
+
+class ModelResolver:
+    """This class takes in a flattened schema map (output of the JsonSchemaFlattener),
+    and builds a full set of models using the pseudo-types ``primitive``, ``"dict"``,
+    ``"list"``, ``"set"``, and ``"model"``` for container information,
+    and JSON Schema types ``"string"``, ``"integer"``, ``"boolean"``, ``"number"``,
+    plus an undefined sentinel value (``"undefined"``) for value types.
+
+    This makes it easy for plugins to map the resolved (pseudo-)types to language
+    types during templating.
+    """
+
+    def __init__(self, flattened_schema_map, base_model_name="ResourceModel"):
+        self.flattened_schema_map = flattened_schema_map
+        self._base_model_name = base_model_name
+        self._models = {}
+        self._models_from_refs()
+
+    def _models_from_refs(self):
+        """Creates a model name for each ref_path in the flattened schema map."""
+        for ref_path in self.flattened_schema_map.keys():
+            # cannot convert this into list comprehension as self._models is used
+            # during the loop
+            self._models[ref_path] = self._get_model_name_from_ref(ref_path)
+
+    def _get_model_name_from_ref(self, ref_path):
+        """Given a json schema ref, returns the best guess at a model name."""
+        if ref_path == ():
+            return self._base_model_name
+
+        class_name = base_class_from_ref(ref_path)
+        try:
+            dupe_path = next(
+                path for path, name in self._models.items() if name == class_name
+            )
+        except StopIteration:
+            return class_name
+
+        raise ModelResolverError(
+            "Model name conflict. "
+            f"'{class_name}' found at {dupe_path} and {ref_path}"
+        )
+
+    def resolve_models(self):
+        """Iterate through each schema and create a model mapping.
+
+        :return: A mapping of models names and properties. Properties are
+        a mapping of property names and property types.
+
+        .. seealso:: :func:`_schema_to_lang_type`
+        """
+        models = {}
+        for ref_path, sub_schema in self.flattened_schema_map.items():
+            class_name = self._models[ref_path]
+            models[class_name] = {
+                prop_name: self._schema_to_lang_type(prop_schema)
+                for prop_name, prop_schema in sub_schema["properties"].items()
+            }
+        return models
+
+    def _schema_to_lang_type(self, property_schema):
+        """Return the language-specific type for a flattened schema.
+
+        If the schema is a ref, the class is determined from ``_models``.
+        """
+        try:
+            ref_path = property_schema["$ref"]
+        except KeyError:
+            pass  # we are not dealing with a ref, move on
+        else:
+            return ResolvedType(ContainerType.MODEL, self._models[ref_path])
+
+        schema_type = property_schema.get("type", "object")
+        if schema_type == "array":
+            return self._get_array_lang_type(property_schema)
+        if schema_type == "object":
+            return self._get_object_lang_type(property_schema)
+        return self._get_primitive_lang_type(schema_type)
+
+    @staticmethod
+    def _get_array_container_type(property_schema):
+        """Return True if an array has array semantics, or False for set semantics."""
+        insertion_order = property_schema.get("insertionOrder", False)
+        unique_items = property_schema.get("uniqueItems", False)
+
+        if insertion_order or not unique_items:
+            return ContainerType.LIST
+        return ContainerType.SET
+
+    @staticmethod
+    def _get_primitive_lang_type(schema_type):
+        return ResolvedType(ContainerType.PRIMITIVE, schema_type)
+
+    def _get_array_lang_type(self, property_schema):
+        container = self._get_array_container_type(property_schema)
+
+        try:
+            items = property_schema["items"]
+        except KeyError:
+            items = self._get_primitive_lang_type(UNDEFINED)
+        else:
+            items = self._schema_to_lang_type(items)
+
+        return ResolvedType(container, items)
+
+    def _get_object_lang_type(self, property_schema):
+        """Resolves an object type.
+
+        * In JSON, objects must have string keys, so we are resolving the value type.
+        * If patternProperties is defined, the value type is determined by the schema
+          for the pattern. We do not care about the pattern itself, since that is only
+          used for validation.
+        * The object will never have nested properties, as that was taken care of by
+          flattening the schema (this isn't at all obvious from the code).
+        * If there are no patternProperties, it must be an arbitrary JSON type, so
+          we set the value type to the UNDEFINED constant for language implementations
+          to distinguish it from a JSON object.
+        """
+        items = self._get_primitive_lang_type(UNDEFINED)
+        try:
+            pattern_properties = list(property_schema["patternProperties"].items())
+        except KeyError:
+            # no pattern properties == undefined type
+            pass
+        else:
+            # multiple pattern props == bad schema definition == undefined type
+            if len(pattern_properties) == 1:
+                items = self._schema_to_lang_type(pattern_properties[0][1])
+
+        return ResolvedType(ContainerType.DICT, items)
+
+
+def base_class_from_ref(ref_path):
+    """This method determines the class_name from a ref_path
+    It uses json-schema heuristics to properly determine the class name
+
+    >>> base_class_from_ref(("definitions", "Foo"))
+    'Foo'
+    >>> base_class_from_ref(("properties", "foo", "items"))
+    'Foo'
+    >>> base_class_from_ref(("properties", "foo", "items", "patternProperties", "a"))
+    'Foo'
+    >>> base_class_from_ref(("properties", "items"))
+    'Items'
+    >>> base_class_from_ref(("properties", "patternProperties"))
+    'PatternProperties'
+    >>> base_class_from_ref(("properties", "properties"))
+    'Properties'
+    >>> base_class_from_ref(("definitions",))
+    'Definitions'
+    >>> base_class_from_ref(("definitions", "properties"))
+    'Properties'
+    >>> base_class_from_ref(())   # doctest: +NORMALIZE_WHITESPACE
+    Traceback (most recent call last):
+    ...
+    core.exceptions.ModelResolverError:
+    Could not create a valid class from schema at '#'
+    """
+    parent_keywords = ("properties", "definitions")
+    schema_keywords = ("items", "patternProperties", "properties")
+
+    ref_parts = ref_path[::-1]
+    ref_parts_with_root = ref_parts + (BASE,)
+    for idx, elem in enumerate(ref_parts):
+        parent = ref_parts_with_root[idx + 1]
+        if parent in parent_keywords or (
+            elem not in schema_keywords and parent != "patternProperties"
+        ):
+            return uppercase_first_letter(elem.rpartition("/")[2])
+
+    raise ModelResolverError(
+        "Could not create a valid class from schema at '{}'".format(
+            fragment_encode(ref_path)
+        )
+    )
+
+
+def resolve_models(schema, base_model_name="ResourceModel"):
+    objects = JsonSchemaFlattener(schema).flatten_schema()
+    model_resolver = ModelResolver(objects, base_model_name)
+    return model_resolver.resolve_models()

--- a/tests/jsonutils/test_resolver.py
+++ b/tests/jsonutils/test_resolver.py
@@ -1,0 +1,198 @@
+# pylint: disable=protected-access,redefined-outer-name
+import pytest
+
+from rpdk.core.exceptions import ModelResolverError
+from rpdk.core.jsonutils.resolver import (
+    UNDEFINED,
+    ContainerType,
+    ModelResolver,
+    ResolvedType,
+    resolve_models,
+)
+
+
+def test_resolve_models():
+    # want to avoid a complex test here, since it could hide missed
+    # cases in the more detailed tests
+    models = resolve_models({})
+    assert not models
+
+
+def test_resolved_type_repr():
+    representation = repr(ResolvedType("foo", "bar"))
+    assert "foo" in representation
+    assert "bar" in representation
+
+
+def test_modelresolver_empty_ref_path_results_in_model_name():
+    flattened = {(): {"properties": {"foo": {"type": "string"}}}}
+    resolver = ModelResolver(flattened, "ResourceModel")
+    assert resolver._models == {(): "ResourceModel"}
+
+
+def test_modelresolver_duplicate_model_name():
+    flattened = {
+        (): {"properties": {"ResourceModel": {"type": "object"}}},
+        ("properties", "ResourceModel"): {"type": "object"},
+    }
+    with pytest.raises(ModelResolverError) as excinfo:
+        ModelResolver(flattened)
+
+    assert "ResourceModel" in str(excinfo.value)
+
+
+def test_modelresolver_unique_model_name():
+    unique = {
+        "type": "object",
+        "properties": {"foo": {"type": "string"}, "bar": {"type": "integer"}},
+    }
+    flattened = {
+        (): {
+            "definitions": {"Unique": unique},
+            "properties": {"Unique": {"$ref": ("definitions", "Unique")}},
+        },
+        ("definitions", "Unique"): unique,
+    }
+    resolver = ModelResolver(flattened)
+    assert resolver._models == {
+        (): "ResourceModel",
+        ("definitions", "Unique"): "Unique",
+    }
+
+    models = resolver.resolve_models()
+    assert models == {
+        "ResourceModel": {"Unique": ResolvedType(ContainerType.MODEL, "Unique")},
+        "Unique": {
+            "foo": ResolvedType(ContainerType.PRIMITIVE, "string"),
+            "bar": ResolvedType(ContainerType.PRIMITIVE, "integer"),
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "schema,result",
+    (
+        ({"type": "array"}, ContainerType.LIST),
+        ({"type": "array", "uniqueItems": False}, ContainerType.LIST),
+        ({"type": "array", "uniqueItems": True}, ContainerType.SET),
+        ({"type": "array", "insertionOrder": False}, ContainerType.LIST),  # ?
+        ({"type": "array", "insertionOrder": True}, ContainerType.LIST),
+        (
+            {"type": "array", "insertionOrder": True, "uniqueItems": True},
+            ContainerType.LIST,
+        ),
+        (
+            {"type": "array", "insertionOrder": True, "uniqueItems": False},
+            ContainerType.LIST,
+        ),
+        (
+            {"type": "array", "insertionOrder": False, "uniqueItems": True},
+            ContainerType.SET,
+        ),
+        (
+            {"type": "array", "insertionOrder": False, "uniqueItems": False},
+            ContainerType.LIST,
+        ),
+    ),
+)
+def test_modelresolver__get_array_container_type(schema, result):
+    container_type = ModelResolver._get_array_container_type(schema)
+    assert container_type == result
+
+
+def test_modelresolver__get_primitive_lang_type():
+    sentinel = object()
+    resolved_type = ModelResolver._get_primitive_lang_type(sentinel)
+    assert resolved_type.container == ContainerType.PRIMITIVE
+    assert resolved_type.type is sentinel
+
+
+@pytest.mark.parametrize(
+    "schema,result",
+    (
+        ({"type": "array"}, UNDEFINED),
+        ({"type": "array", "items": {"type": "string"}}, "string"),
+    ),
+)
+def test_modelresolver__get_array_lang_type(schema, result):
+    resolver = ModelResolver({})
+    resolved_type = resolver._get_array_lang_type(schema)
+    assert resolved_type.container == ContainerType.LIST
+    item_type = resolved_type.type
+    assert item_type.container == ContainerType.PRIMITIVE
+    assert item_type.type == result
+
+
+@pytest.mark.parametrize(
+    "schema,result",
+    (
+        ({"type": "object"}, UNDEFINED),
+        ({"type": "object", "patternProperties": {}}, UNDEFINED),
+        (
+            {
+                "type": "object",
+                "patternProperties": {
+                    "^S_": {"type": "string"},
+                    "^I_": {"type": "integer"},
+                },
+            },
+            UNDEFINED,
+        ),
+        (
+            {"type": "object", "patternProperties": {"^S_": {"type": "string"}}},
+            "string",
+        ),
+    ),
+)
+def test_modelresolver__get_object_lang_type(schema, result):
+    resolver = ModelResolver({})
+    resolved_type = resolver._get_object_lang_type(schema)
+    assert resolved_type.container == ContainerType.DICT
+    item_type = resolved_type.type
+    assert item_type.container == ContainerType.PRIMITIVE
+    assert item_type.type == result
+
+
+def test_modelresolver__schema_to_lang_type_ref():
+    resolver = ModelResolver({(): {}})
+    assert resolver._models == {(): "ResourceModel"}
+    resolved_type = resolver._schema_to_lang_type({"$ref": ()})
+    assert resolved_type.container == ContainerType.MODEL
+    assert resolved_type.type == "ResourceModel"
+
+
+def test_modelresolver__schema_to_lang_type_array():
+    # see test_modelresolver__get_array_lang_type_no_item_type
+    resolver = ModelResolver({})
+    resolved_type = resolver._schema_to_lang_type({"type": "array"})
+    assert resolved_type.container == ContainerType.LIST
+    item_type = resolved_type.type
+    assert item_type.container == ContainerType.PRIMITIVE
+    assert item_type.type == UNDEFINED
+
+
+def test_modelresolver__schema_to_lang_type_object():
+    # see test_modelresolver__get_object_lang_type_no_item_type
+    resolver = ModelResolver({})
+    resolved_type = resolver._schema_to_lang_type({"type": "object"})
+    assert resolved_type.container == ContainerType.DICT
+    item_type = resolved_type.type
+    assert item_type.container == ContainerType.PRIMITIVE
+    assert item_type.type == UNDEFINED
+
+
+def test_modelresolver__schema_to_lang_type_undef():
+    # see test_modelresolver__get_object_lang_type_no_item_type
+    resolver = ModelResolver({})
+    resolved_type = resolver._schema_to_lang_type({})
+    assert resolved_type.container == ContainerType.DICT
+    item_type = resolved_type.type
+    assert item_type.container == ContainerType.PRIMITIVE
+    assert item_type.type == UNDEFINED
+
+
+def test_modelresolver__schema_to_lang_type_primitive():
+    resolver = ModelResolver({})
+    resolved_type = resolver._schema_to_lang_type({"type": "string"})
+    assert resolved_type.container == ContainerType.PRIMITIVE
+    assert resolved_type.type == "string"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* General-purpose model (type) resolver. This is an abstraction of the Java POJO/C# Model resolver, which outputs a pseudo-type (ResolvedType) that can easily be used during templating to convert to native language types.

For how easy this is, see:

* Java: https://github.com/aws-cloudformation/aws-cloudformation-rpdk-java-plugin/pull/150
* C#: https://github.com/aws-cloudformation/aws-cloudformation-rpdk-csharp-plugin/pull/7

I also have WIP code for Python.

It's pretty basic right now, in future I could see the model resolver also attaching more information such as if the type is required or not for code-generation to use.

I also made the basic template a bit more complicated, to show how to ref to definitions - this helps downstream with the plugins, too, that the code-gen is handling multiple types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
