### PR TITLE
Fix list pagination bug in contract tests

### DIFF
--- a/src/rpdk/core/contract/suite/handler_misc.py
+++ b/src/rpdk/core/contract/suite/handler_misc.py
@@ -142,6 +142,7 @@ def _test_list_success(resource_client, current_resource_model):
             nextToken=next_token,
         )
         resource_models.extend(next_response["resourceModels"])
+        next_token = next_response.get("nextToken")
     return resource_models
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Next pagination tokens weren't getting tracked so list operations that
correspond to the first returned token got repeated indefinitely. This
change fixes that and was tested against a resource that has enough
items in a list to paginate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
