### PR TITLE
Adding testEntrypoint to settings

### DIFF
--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -47,6 +47,7 @@ SETTINGS_VALIDATOR = Draft6Validator(
             "typeName": {"type": "string", "pattern": TYPE_NAME_REGEX},
             "runtime": {"type": "string", "enum": list(LAMBDA_RUNTIMES)},
             "entrypoint": {"type": ["string", "null"]},
+            "testEntrypoint": {"type": ["string", "null"]},
             "settings": {"type": "object"},
         },
         "required": ["language", "typeName", "runtime", "entrypoint"],
@@ -66,6 +67,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
         self.schema = None
         self.runtime = "noexec"
         self.entrypoint = None
+        self.test_entrypoint = None
 
         LOG.debug("Root directory: %s", self.root)
 
@@ -114,6 +116,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
         self.type_name = raw_settings["typeName"]
         self.runtime = raw_settings["runtime"]
         self.entrypoint = raw_settings["entrypoint"]
+        self.test_entrypoint = raw_settings["testEntrypoint"]
         self._plugin = load_plugin(raw_settings["language"])
         self.settings = raw_settings.get("settings", {})
 
@@ -143,6 +146,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
                     "language": language,
                     "runtime": self.runtime,
                     "entrypoint": self.entrypoint,
+                    "testEntrypoint": self.test_entrypoint,
                     "settings": self.settings,
                 },
                 f,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -73,6 +73,7 @@ def test_load_settings_valid_json(project):
             "language": LANGUAGE,
             "runtime": RUNTIME,
             "entrypoint": None,
+            "testEntrypoint": None,
         }
     )
     patch_load = patch(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This adds a testEntrypoint to the .rpdk-config file that plugins can use to provide the test entrypoint used for contract tests. A plugin can set this value in the same way that it sets the entrypoint.

Tested with a new rpdk workspace running cfn-cli init


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
