### PR TITLE
Updates example schema to reflect current meta-schema

### DIFF
--- a/src/rpdk/core/data/examples/resource/initech.tps.report.v1.json
+++ b/src/rpdk/core/data/examples/resource/initech.tps.report.v1.json
@@ -1,7 +1,7 @@
 {
     "typeName": "Initech::TPS::Report",
     "description": "An example resource schema demonstrating some basic constructs and validation rules.",
-    "sourceUrl": "git@github.com:aws-cloudformation/aws-cloudformation-rpdk.git",
+    "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-rpdk.git",
     "definitions": {
         "InitechDateFormat": {
             "$comment": "Use the `definitions` block to provide shared resource property schemas",
@@ -64,8 +64,8 @@
         }
     },
     "required": [
-        "Title",
-        "DueDate"
+        "TestCode",
+        "Title"
     ],
     "readOnlyProperties": [
         "/properties/TPSCode"


### PR DESCRIPTION
*Issue #, if available:* #270 

*Description of changes:* The working example schema was slightly out of date and was invalid according to current meta-schema. This PR updates the example to latest.

Base schema repo has also been updated: https://github.com/aws-cloudformation/aws-cloudformation-resource-schema/pull/42

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
