### PR TITLE
Add logging role max duration to 70*120 seconds

### DIFF
--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -68,6 +68,7 @@ Resources:
   LogAndMetricsDeliveryRole:
     Type: AWS::IAM::Role
     Properties:
+      MaxSessionDuration: 8400
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Currently in backend workflow we set the duration to 70*120 seconds, the assume role will fail due to the default duration is 1 hour.

This change will change the duration to the same as workflow to unblock the customer.

Ideally we don't need this long time (the max time should be the lambda function execution time, 15 mins), it will be fixed later on with resource execution role.

*Testing*:
Run `cfn-cli submit`, the cloudformation update the role to 8400 seconds. Provision this resource  successful now without manual update the role duration time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
