### PR TITLE
Increase timeout for local Lambda client

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -73,7 +73,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
                 config=Config(
                     signature_version=UNSIGNED,
                     # needs to be long if docker is running on a slow machine
-                    read_timeout=60,
+                    read_timeout=5 * 60,
                     retries={"max_attempts": 0},
                     region_name=self._session.region_name,
                 ),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Increase timeout for local Lambda client.

Java only: Some JAR files become so bloated, it takes SAM a long time to mount them inside the container. This happens on every request.

There is also a timeout value in the SAM template, this can be adjusted by the customer, so I'm leaving it at one minute for now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.