### PR TITLE
Use print to output prompt so colorama can strip escape codes

### DIFF
--- a/src/rpdk/core/init.py
+++ b/src/rpdk/core/init.py
@@ -27,7 +27,8 @@ def input_with_validation(prompt, validate, description=""):
             Style.RESET_ALL,
             sep="",
         )
-        response = input("{}>> {}".format(Fore.YELLOW, Style.RESET_ALL))
+        print(Fore.YELLOW, ">> ", Style.RESET_ALL, sep="", end="")
+        response = input()
         try:
             return validate(response)
         except WizardValidationError as e:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -56,7 +56,7 @@ def test_input_with_validation_valid_first_try(capsys):
     with patch("rpdk.core.init.input", return_value=sentinel2) as mock_input:
         ret = input_with_validation(PROMPT, validator)
 
-    mock_input.assert_called_once()
+    mock_input.assert_called_once_with()
     validator.assert_called_once_with(sentinel2)
     assert ret is sentinel1
 


### PR DESCRIPTION
*Issue #, if available:* #306 

*Description of changes:* Use print to output prompt so colorama can strip escape codes on Windows. Looks the same for me on macOS:

![Screen Shot 2019-10-29 at 4 59 07 PM](https://user-images.githubusercontent.com/2903454/67818180-8cac6b80-fa6d-11e9-9fdb-f58d55f7c3a7.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
