### PR TITLE
Catch invalid references

### DIFF
--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -8,7 +8,7 @@ import pkg_resources
 import requests
 import yaml
 from jsonschema import Draft7Validator, RefResolver
-from jsonschema.exceptions import ValidationError
+from jsonschema.exceptions import RefResolutionError, ValidationError
 
 from .exceptions import InternalError, SpecValidationError
 from .jsonutils.inliner import RefInliner
@@ -113,7 +113,11 @@ def load_resource_spec(resource_spec_file):
     base_uri = get_file_base_uri(resource_spec_file)
 
     inliner = RefInliner(base_uri, resource_spec)
-    inlined = inliner.inline()
+    try:
+        inlined = inliner.inline()
+    except RefResolutionError as e:
+        LOG.debug("Resource spec validation failed", exc_info=True)
+        raise SpecValidationError(str(e)) from e
 
     try:
         validator.validate(inlined)


### PR DESCRIPTION
*Issue #, if available:* #277 

*Description of changes:* Surface errors about invalid references in `load_resource_spec` to user, instead of swallowing them:

```bash
$ cfn-cli validate
Resource specification is invalid: Unresolvable JSON pointer: 'definitions/properties'
$ cfn-cli generate
Resource specification is invalid: Unresolvable JSON pointer: 'definitions/properties'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
