### PR TITLE
Convert '$' to '\Z' for schema regex patterns in resource generation only

### DIFF
--- a/src/rpdk/core/contract/resource_generator.py
+++ b/src/rpdk/core/contract/resource_generator.py
@@ -35,6 +35,12 @@ NEG_INF = float("-inf")
 POS_INF = float("inf")
 
 
+def terminate_regex(regex):
+    if regex.endswith("$"):
+        return regex[:-1] + r"\Z"
+    return regex
+
+
 class ResourceGenerator:
     def __init__(self, schema):
         self.resolver = RefResolver.from_schema(schema)
@@ -239,7 +245,8 @@ class ResourceGenerator:
                 LOG.warning("found minLength used with pattern")
             if "maxLength" in schema:  # pragma: no cover
                 LOG.warning("found maxLength used with pattern")
-            return from_regex(regex)
+
+            return from_regex(terminate_regex(regex))
 
         if "pattern" in schema:  # pragma: no cover
             LOG.warning("found pattern used with format")

--- a/tests/contract/test_resource_generator.py
+++ b/tests/contract/test_resource_generator.py
@@ -9,7 +9,22 @@ from rpdk.core.contract.resource_generator import (
     POS_INF,
     STRING_FORMATS,
     ResourceGenerator,
+    terminate_regex,
 )
+
+
+def test_terminate_regex_end_of_line_like_a_normal_person():
+    original_regex = r"^[a-zA-Z0-9]{1,219}$"
+    assert re.match(original_regex, "dfqh3eqefhq\n")
+    assert re.match(original_regex, "dfqh3eqefhq")
+    modified_regex = terminate_regex(original_regex)
+    assert not re.match(modified_regex, "dfqh3eqefhq\n")
+    assert re.match(modified_regex, "dfqh3eqefhq")
+
+
+def test_terminate_regex_no_termination_needed():
+    original_regex = r"^[a-zA-Z0-9]{1,219}\Z"
+    assert terminate_regex(original_regex) == original_regex
 
 
 @pytest.mark.parametrize("schema_type", ["integer", "number"])


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Python's regex behaves a bit differently to Javascript's. The Java one I'm not sure about either.

At the heart of the problem is that in the Regex variant Python uses, `$` also matches a new line (`\n`), `\Z` doesn't, and `\z` is invalid (in PCRE, `\Z` is the same as `$` and `\z` matches the end of the input without a terminator):

```pycon
>>> regex = re.compile(r"^[a-zA-Z0-9]{1,219}$")
>>> bool(regex.match("dfqh3eqefhq\n"))
True
>>> bool(regex.match("dfqh3eqefhq"))
True
>>> regex = re.compile(r"^[a-zA-Z0-9]{1,219}\Z")
>>> bool(regex.match("dfqh3eqefhq\n"))
False
>>> bool(regex.match("dfqh3eqefhq"))
True
```

This causes issues when we are generating resource blobs. However, in Javascript/ECMA 262, `\Z` and `\z` aren't actually valid, and `$` doesn't match a new line (`\n`). Tested in Firefox 68.2.0esr, Chrome 78.0.3904.70, and Safari 12.1.2:

```javascript
>> let regex = new RegExp("^[a-zA-Z0-9]{1,219}$")
<- undefined
>> regex.test("dfqh3eqefhq\n")
<- false
>> regex.test("dfqh3eqefhq")
<- true
>> 
```

All the JSON schema spec has to say about this is:

> The value of this keyword MUST be a string. This string SHOULD be a valid regular expression, according to the ECMA 262 regular expression dialect.

> A string instance is considered valid if the regular expression matches the instance successfully. Recall: regular expressions are not implicitly anchored.

So I think we're forcing people to do the wrong thing by having to write `\Z` or `\\Z`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
