### PR TITLE
Prune read only properties on delete->create test

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -97,7 +97,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         self._update_strategy = None
 
         self._primary_identifier_paths = self._properties_to_paths("primaryIdentifier")
-        self._read_only_paths = self._properties_to_paths("readOnlyProperties")
+        self.read_only_paths = self._properties_to_paths("readOnlyProperties")
         self._write_only_paths = self._properties_to_paths("writeOnlyProperties")
         self._create_only_paths = self._properties_to_paths("createOnlyProperties")
 
@@ -109,11 +109,11 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
 
     def has_writable_identifier(self):
         for path in self._primary_identifier_paths:
-            if path not in self._read_only_paths:
+            if path not in self.read_only_paths:
                 return True
         for identifier_paths in self._additional_identifiers_paths:
             for path in identifier_paths:
-                if path not in self._read_only_paths:
+                if path not in self.read_only_paths:
                     return True
         return False
 
@@ -129,7 +129,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         # make a copy so the original schema is never modified
         schema = json.loads(json.dumps(self._schema))
 
-        prune_properties(schema, self._read_only_paths)
+        prune_properties(schema, self.read_only_paths)
 
         self._strategy = ResourceGenerator(schema).generate_schema_strategy(schema)
         return self._strategy
@@ -146,7 +146,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         # make a copy so the original schema is never modified
         schema = json.loads(json.dumps(self._schema))
 
-        prune_properties(schema, self._read_only_paths)
+        prune_properties(schema, self.read_only_paths)
         prune_properties(schema, self._create_only_paths)
 
         self._update_strategy = ResourceGenerator(schema).generate_schema_strategy(

--- a/src/rpdk/core/contract/suite/handler_delete.py
+++ b/src/rpdk/core/contract/suite/handler_delete.py
@@ -7,6 +7,7 @@ import pytest
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
 from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
+from rpdk.core.contract.resource_client import prune_properties
 from rpdk.core.contract.suite.handler_commons import (
     test_create_success,
     test_delete_failure_not_found,
@@ -78,8 +79,11 @@ def contract_delete_delete(resource_client, deleted_resource):
 @pytest.mark.create
 @pytest.mark.delete
 def contract_delete_create(resource_client, deleted_resource):
-    _deleted_model, request = deleted_resource
-    test_create_success(resource_client, request)
+    deleted_model, request = deleted_resource
+    response = test_create_success(resource_client, request)
+
     # read-only properties should be excluded from the comparison
-    # https://github.com/aws-cloudformation/aws-cloudformation-rpdk/issues/329
-    # assert deleted_model == response["resourceModel"]
+    prune_properties(deleted_model, resource_client.read_only_paths)
+    prune_properties(response["resourceModel"], resource_client.read_only_paths)
+
+    assert deleted_model == response["resourceModel"]

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -117,7 +117,7 @@ def test__update_schema(resource_client):
     assert resource_client._schema is schema
     assert resource_client._strategy is None
     assert resource_client._primary_identifier_paths == {("properties", "a")}
-    assert resource_client._read_only_paths == {("properties", "b")}
+    assert resource_client.read_only_paths == {("properties", "b")}
     assert resource_client._write_only_paths == {("properties", "c")}
     assert resource_client._create_only_paths == {("properties", "d")}
 


### PR DESCRIPTION
*Issue #, if available:* #329 

*Description of changes:* Prunes the properties when comparing  the two models so that only requested properties are compared.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
