### PR TITLE
don't allow insertionOrder and uniqueItems to be declared differently for a single property

### DIFF
--- a/src/rpdk/core/jsonutils/utils.py
+++ b/src/rpdk/core/jsonutils/utils.py
@@ -156,16 +156,10 @@ def schema_merge(target, src, path):
     declared multiple values for '$ref': found 'a' and 'b'
     >>> a, b = {'$ref': 'a'}, {'type': 'b'}
     >>> schema_merge(a, b, ('foo',)) # doctest: +NORMALIZE_WHITESPACE
-    Traceback (most recent call last):
-    ...
-    core.jsonutils.utils.ConstraintError: Object at path '#/foo'
-    declared multiple types: found type 'b' and object 'a'
+    {'$ref': 'a', 'type': 'b'}
     >>> a, b = {'Foo': {'$ref': 'a'}}, {'Foo': {'type': 'b'}}
     >>> schema_merge(a, b, ('foo',)) # doctest: +NORMALIZE_WHITESPACE
-    Traceback (most recent call last):
-    ...
-    core.jsonutils.utils.ConstraintError: Object at path '#/foo/Foo'
-    declared multiple types: found type 'b' and object 'a'
+    {'Foo': {'$ref': 'a', 'type': 'b'}}
     >>> schema_merge('', {}, ())
     Traceback (most recent call last):
     ...
@@ -203,14 +197,4 @@ def schema_merge(target, src, path):
                         )
                         raise ConstraintError(msg, path, key, target_schema, src_schema)
                     target[key] = src_schema
-        # at this point, the schema is flattened and merged,
-        # which means a $ref will always be to an object
-        type_key = target.get("type", "object")
-        ref_key = target.get("$ref", None)
-        if type_key != "object" and ref_key is not None:
-            msg = (
-                "Object at path '{path}' declared multiple types: "
-                "found type '{}' and object '{}'"
-            )
-            raise ConstraintError(msg, path, type_key, ref_key)
     return target

--- a/tests/jsonutils/test_flattener.py
+++ b/tests/jsonutils/test_flattener.py
@@ -267,18 +267,53 @@ def test_flatten_combiners_no_clobber(combiner):
 
 
 @pytest.mark.parametrize("combiner", COMBINERS)
-def test_flatten_combiners_flattened_before_merge_success(combiner):
-    # if the schema has not been flattened before the combiners are merged,
-    # this would fail since it declares both type and ref
-    ref = ("definitions", "stringType")
+def test_flatten_combiners_resolve_types(combiner):
+    ref = ("definitions", "obj")
     test_schema = {
         "typeName": "AWS::Valid::TypeName",
-        "definitions": {"stringType": {"type": "string"}},
+        "definitions": {"obj": {"type": "object"}},
+        "properties": {
+            "p": {combiner: [{"type": "string"}, {"$ref": fragment_encode(ref)}]}
+        },
+    }
+
+    flattener = JsonSchemaFlattener(test_schema)
+    with pytest.raises(ConstraintError) as excinfo:
+        flattener.flatten_schema()
+    assert "declared multiple values for 'type'" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("combiner", COMBINERS)
+def test_flatten_combiners_resolve_types_object_by_default(combiner):
+    # this should fail, since we declare an object type and string type
+    # https://github.com/aws-cloudformation/aws-cloudformation-rpdk/issues/333
+    ref = ("definitions", "obj")
+    test_schema = {
+        "typeName": "AWS::Valid::TypeName",
+        "definitions": {"obj": {"properties": {"Foo": {"type": "object"}}}},
+        "properties": {
+            "p": {combiner: [{"type": "string"}, {"$ref": fragment_encode(ref)}]}
+        },
+    }
+
+    flattener = JsonSchemaFlattener(test_schema)
+    flattener.flatten_schema()
+    assert ref in flattener._schema_map
+
+
+@pytest.mark.parametrize("combiner", COMBINERS)
+def test_flatten_combiners_resolve_types_nested_should_fail(combiner):
+    # this should fail, since we declare type object and string for the same property
+    # https://github.com/aws-cloudformation/aws-cloudformation-rpdk/issues/333
+    ref = ("definitions", "obj")
+    test_schema = {
+        "typeName": "AWS::Valid::TypeName",
+        "definitions": {"obj": {"properties": {"Foo": {"type": "object"}}}},
         "properties": {
             "p": {
                 combiner: [
-                    {"properties": {"a": {"type": "string"}}},
-                    {"properties": {"a": {"$ref": fragment_encode(ref)}}},
+                    {"properties": {"Foo": {"type": "string"}}},
+                    {"$ref": fragment_encode(ref)},
                 ]
             }
         },
@@ -286,32 +321,8 @@ def test_flatten_combiners_flattened_before_merge_success(combiner):
 
     flattener = JsonSchemaFlattener(test_schema)
     flattener.flatten_schema()
-    assert ref not in flattener._schema_map
-
-
-@pytest.mark.parametrize("combiner", COMBINERS)
-def test_flatten_combiners_flattened_before_merge_failed(combiner):
-    # this should fail, since we declare ref and type string for the same object
-    ref = ("definitions", "obj")
-    test_schema = {
-        "typeName": "AWS::Valid::TypeName",
-        "definitions": {"obj": {"properties": {"a": {"type": "object"}}}},
-        "properties": {
-            "p": {
-                combiner: [
-                    {"properties": {"a": {"type": "string"}}},
-                    {"properties": {"a": {"$ref": fragment_encode(ref)}}},
-                ]
-            }
-        },
-    }
-
-    flattener = JsonSchemaFlattener(test_schema)
-    with pytest.raises(ConstraintError) as excinfo:
-        flattener.flatten_schema()
-    assert "type 'string'" in str(
-        excinfo.value
-    ) and "object '('definitions', 'obj')'" in str(excinfo.value)
+    assert ref in flattener._schema_map
+    assert ("properties", "p") in flattener._schema_map
 
 
 @pytest.mark.parametrize("combiner", COMBINERS)
@@ -329,8 +340,8 @@ def test_flatten_combiners_flattened_before_merge_failed_but_should_not(combiner
         "properties": {
             "p": {
                 combiner: [
-                    {"properties": {"a": {"$ref": fragment_encode(ref)}}},
-                    {"properties": {"a": {"$ref": fragment_encode(ref2)}}},
+                    {"$ref": fragment_encode(ref)},
+                    {"$ref": fragment_encode(ref2)},
                 ]
             }
         },
@@ -340,33 +351,6 @@ def test_flatten_combiners_flattened_before_merge_failed_but_should_not(combiner
     with pytest.raises(ConstraintError) as excinfo:
         flattener.flatten_schema()
     assert "declared multiple values for '$ref'" in str(excinfo.value)
-
-
-@pytest.mark.parametrize("combiner", COMBINERS)
-def test_flatten_combiners_flattened_before_merge_top_level_does_not_throw(combiner):
-    # this should actually raise a constraint error, as the property is declared as
-    # a string and an object.
-    # https://github.com/aws-cloudformation/aws-cloudformation-rpdk/issues/333
-    ref = ("definitions", "obj")
-    test_schema = {
-        "typeName": "AWS::Valid::TypeName",
-        "definitions": {"obj": {"properties": {"a": {"type": "object"}}}},
-        "properties": {
-            "p": {
-                combiner: [
-                    {"properties": {"a": {"type": "string"}}},
-                    {"$ref": fragment_encode(ref)},
-                ]
-            }
-        },
-    }
-
-    flattener = JsonSchemaFlattener(test_schema)
-    flattener.flatten_schema()
-    assert ref in flattener._schema_map
-    assert ("properties", "p") in flattener._schema_map
-    invalid = flattener._schema_map[("properties", "p")]
-    assert "$ref" in invalid and "properties" in invalid
 
 
 def test_contraint_array_additional_items_valid():


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* When flattening the schema, if we see a combiner (`anyOf`, `oneOf`, or `allOf`), we will merge the schemas together in order to create a unified POJO.  We currently validate that you can't declare multiple types for the same property, or use multiple $refs, as they could be to incompatible types.  Because `uniqueItems` and `insertionOrder` are used to declare the type of an array, they should not be allowed to have different values either.

In addition, there are some unit tests in this PR to assert the behavior described in #333 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
