### PR TITLE
Log before and after running a command

### DIFF
--- a/src/rpdk/core/cli.py
+++ b/src/rpdk/core/cli.py
@@ -92,9 +92,12 @@ def main(args_in=None):  # pylint: disable=too-many-statements
 
         log = logging.getLogger(__name__)
         log.debug("Logging set up successfully")
+        log.debug("Running %s: %s", args.subparser_name, args)
 
         with colorama_text():
             args.command(args)
+
+        log.debug("Finished %s", args.subparser_name)
     except SysExitRecommendedError as e:
         # This is to unify exit messages, and avoid throwing SystemExit in
         # library code, which is hard to catch for consumers. (There are still


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Add obvious logging around a command, should make it easier to tell when a command starts and what parameters were passed in:

```
[2019-11-12T22:22:45Z] DEBUG    - Running init: Namespace(command=<function init at 0x11031a5f0>, force=False, subparser_name='init', verbose=0, version=False)
[...]
[2019-11-12T22:22:50Z] DEBUG    - Finished init
[...]
[2019-11-12T22:22:55Z] DEBUG    - Running submit: Namespace(command=<function submit at 0x10ab1cef0>, dry_run=True, endpoint_url=None, region=None, role_arn=None, set_default=False, subparser_name='submit', use_role=True, verbose=0, version=False)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
