### PR TITLE
Non-interactively select language plugin for CI

### DIFF
--- a/src/rpdk/core/init.py
+++ b/src/rpdk/core/init.py
@@ -2,6 +2,7 @@
 """
 import logging
 import re
+from argparse import SUPPRESS
 from functools import wraps
 
 from colorama import Fore, Style
@@ -138,7 +139,11 @@ def init(args):
     check_for_existing_project(project)
 
     type_name = input_typename()
-    language = input_language()
+    if args.language:
+        language = args.language
+        LOG.warning("Language plugin '%s' selected non-interactively", language)
+    else:
+        language = input_language()
 
     project.init(type_name, language)
     project.generate()
@@ -166,3 +171,5 @@ def setup_subparser(subparsers, parents):
     parser.add_argument(
         "--force", action="store_true", help="Force files to be overwritten."
     )
+    # this is mainly for CI, so suppress it to keep it simple
+    parser.add_argument("--language", help=SUPPRESS)

--- a/src/rpdk/core/plugin_registry.py
+++ b/src/rpdk/core/plugin_registry.py
@@ -5,7 +5,7 @@ PLUGIN_REGISTRY = {
     for entry_point in pkg_resources.iter_entry_points("rpdk.v1.languages")
 }
 
-PLUGIN_CHOICES = list(PLUGIN_REGISTRY.keys())
+PLUGIN_CHOICES = sorted(PLUGIN_REGISTRY.keys())
 
 
 def load_plugin(language):

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -33,14 +33,16 @@ TYPE_NAME_REGEX = "^[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}$"
 LAMBDA_RUNTIMES = {
     "noexec",  # cannot be executed, schema only
     "java8",
+    "java11",
     "go1.x",
     # python2.7 is EOL soon (2020-01-01)
     "python3.6",
     "python3.7",
-    # dotnetcore1.0 is EOL soon (2019-06-27)
+    "python3.8",
     "dotnetcore2.1",
-    # nodejs8.10 is EOL soon (2019-12-??)
+    # nodejs8.10 is EOL soon (2019-12-31)
     "nodejs10.x",
+    "nodejs12.x",
 }
 
 SETTINGS_VALIDATOR = Draft6Validator(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -21,12 +21,13 @@ PROMPT = "MECVGD"
 ERROR = "TUJFEL"
 
 
-def test_init_method():
+def test_init_method_interactive_language():
     type_name = object()
     language = object()
 
-    args = Mock(spec_set=["force"])
+    args = Mock(spec_set=["force", "language"])
     args.force = False
+    args.language = None
 
     mock_project = Mock(spec=Project)
     mock_project.load_settings.side_effect = FileNotFoundError
@@ -45,6 +46,33 @@ def test_init_method():
 
     mock_project.load_settings.assert_called_once_with()
     mock_project.init.assert_called_once_with(type_name, language)
+    mock_project.generate.assert_called_once_with()
+
+
+def test_init_method_noninteractive_language():
+    type_name = object()
+
+    args = Mock(spec_set=["force", "language"])
+    args.force = False
+    args.language = "rust1.39"
+
+    mock_project = Mock(spec=Project)
+    mock_project.load_settings.side_effect = FileNotFoundError
+    mock_project.settings_path = ""
+    mock_project.root = Path(".")
+
+    patch_project = patch("rpdk.core.init.Project", return_value=mock_project)
+    patch_tn = patch("rpdk.core.init.input_typename", return_value=type_name)
+    patch_l = patch("rpdk.core.init.input_language")
+
+    with patch_project, patch_tn as mock_tn, patch_l as mock_l:
+        init(args)
+
+    mock_tn.assert_called_once_with()
+    mock_l.assert_not_called()
+
+    mock_project.load_settings.assert_called_once_with()
+    mock_project.init.assert_called_once_with(type_name, args.language)
     mock_project.generate.assert_called_once_with()
 
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* With CI that can run against different langauge versions, it will be more important to be able to accurately select the language version. The current approach of echoing the choice is a bit brittle.

```bash
$ cfn init --language "python37"
Initializing new project
What's the name of your resource type?
(Organization::Service::Resource)
>> AWS::Foo::Bar
Language plugin 'python37' selected non-interactively
```

This change also ensures plugin choice list is deterministically sorted and updates some Lambda runtimes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
