### PR TITLE
Fix spacing on plugin table

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,9 +93,9 @@ Supported plugins
 ========  =================  =======================================================================================================================  ============================================================================================
 Language  Status             Github                                                                                                                   PyPI
 ========  =================  =======================================================================================================================  ============================================================================================
-Java      Available          `cloudformation-cli-java-plugin <https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/>`_      `cloudformation-cli-java-plugin <https://pypi.org/project/cloudformation-cli-java-plugin/>`_
-Go        Available          `cloudformation-cli-go-plugin <https://github.com/aws-cloudformation/cloudformation-cli-go-plugin/>`_          `cloudformation-cli-go-plugin <https://pypi.org/project/cloudformation-cli-go-plugin/>`_
-Python    Developer Preview  `cloudformation-cli-python-plugin <https://github.com/aws-cloudformation/cloudformation-cli-python-plugin/>`_  N/A
+Java      Available          `cloudformation-cli-java-plugin <https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/>`_                `cloudformation-cli-java-plugin <https://pypi.org/project/cloudformation-cli-java-plugin/>`_
+Go        Available          `cloudformation-cli-go-plugin <https://github.com/aws-cloudformation/cloudformation-cli-go-plugin/>`_                    `cloudformation-cli-go-plugin <https://pypi.org/project/cloudformation-cli-go-plugin/>`_
+Python    Developer Preview  `cloudformation-cli-python-plugin <https://github.com/aws-cloudformation/cloudformation-cli-python-plugin/>`_            N/A
 ========  =================  =======================================================================================================================  ============================================================================================
 
 License


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* A cell's contents in a table in rst needs to be in the span of the columns. The naming change in #359 moved this around and caused the table to not render. Display the "Source Diff" to see the addition of the table


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
