### PR TITLE
Use $id if defined in schema

### DIFF
--- a/src/rpdk/core/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.v1.json
@@ -210,6 +210,11 @@
         }
     },
     "type": "object",
+    "patternProperties": {
+        "^\\$id$": {
+            "$ref": "https://json-schema.org/draft-07/schema#/properties/$id"
+        }
+    },
     "properties": {
         "$schema": {
             "$ref": "https://json-schema.org/draft-07/schema#/properties/$schema"

--- a/src/rpdk/core/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.v1.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema#",
-    "$id": "provider.definition.schema.v1.json",
+    "$id": "https://schema.cloudformation.us-east-1.amazonaws.com/provider.definition.schema.v1.json",
     "title": "CloudFormation Resource Provider Definition MetaSchema",
     "description": "This schema validates a CloudFormation resource provider definition.",
     "definitions": {
@@ -214,6 +214,33 @@
                     "additionalProperties": false
                 }
             ]
+        },
+        "resourceLink": {
+            "type": "object",
+            "properties": {
+                "$comment": {
+                    "$ref": "https://json-schema.org/draft-07/schema#/properties/$comment"
+                },
+                "templateUri": {
+                    "type": "string",
+                    "pattern": "^(/|https:)"
+                },
+                "mappings": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[A-Za-z0-9]{1,64}$": {
+                            "type": "string",
+                            "format": "json-pointer"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "templateUri",
+                "mappings"
+            ],
+            "additionalProperties": false
         }
     },
     "type": "object",
@@ -373,6 +400,10 @@
         },
         "oneOf": {
             "$ref": "#/definitions/schemaArray"
+        },
+        "resourceLink": {
+            "description": "A template-able link to a resource instance. AWS-internal service links must be relative to the AWS console domain. External service links must be absolute, HTTPS URIs.",
+            "$ref": "#/definitions/resourceLink"
         }
     },
     "required": [

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -89,7 +89,7 @@ def get_file_base_uri(file):
     return path.resolve().as_uri()
 
 
-def load_resource_spec(resource_spec_file):
+def load_resource_spec(resource_spec_file):  # noqa: C901
     """Load a resource provider definition from a file, and validate it."""
     try:
         resource_spec = json.load(resource_spec_file)
@@ -110,7 +110,10 @@ def load_resource_spec(resource_spec_file):
             "Property 'remote' is reserved for CloudFormation use"
         )
 
-    base_uri = get_file_base_uri(resource_spec_file)
+    try:
+        base_uri = resource_spec["$id"]
+    except KeyError:
+        base_uri = get_file_base_uri(resource_spec_file)
 
     inliner = RefInliner(base_uri, resource_spec)
     try:

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -172,7 +172,7 @@ def test_load_resource_spec_file_object_has_name(tmpdir):
 )
 def test_load_resource_spec_uses_id_if_id_is_set(ref_fn):
     @Request.application
-    def application(request):  # pylint: disable=unused-argument
+    def application(_request):
         return Response(json.dumps({"type": "string"}), mimetype="application/json")
 
     with wsgi_serve(application) as server:

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -163,7 +163,14 @@ def test_load_resource_spec_file_object_has_name(tmpdir):
     assert actual == expected
 
 
-def test_load_resource_spec_uses_id_if_id_is_set():
+@pytest.mark.parametrize(
+    "ref_fn",
+    (
+        lambda server: server.url + "/bar",  # absolute
+        lambda _server: "./bar",  # relative
+    ),
+)
+def test_load_resource_spec_uses_id_if_id_is_set(ref_fn):
     @Request.application
     def application(request):  # pylint: disable=unused-argument
         return Response(json.dumps({"type": "string"}), mimetype="application/json")
@@ -172,7 +179,7 @@ def test_load_resource_spec_uses_id_if_id_is_set():
         schema = {
             **BASIC_SCHEMA,
             "$id": server.url + "/foo",
-            "properties": {"foo": {"$ref": server.url + "/bar"}},
+            "properties": {"foo": {"$ref": ref_fn(server)}},
         }
         inlined = load_resource_spec(json_s(schema))
 


### PR DESCRIPTION
*Issue #, if available:* Please see #344 , which hasn't fared too well due to the rename.

*Description of changes:* Now that `$id` is allowed in schemas, make use of it. This will make testing `$ref` to other schemas easier, as they don't need to be present on the local filesystem.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
