### PR TITLE
increase IAM role max session timeouts to support custom stabilization up to 12 hours

### DIFF
--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -68,7 +68,7 @@ Resources:
   LogAndMetricsDeliveryRole:
     Type: AWS::IAM::Role
     Properties:
-      MaxSessionDuration: 8400
+      MaxSessionDuration: 43200
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/src/rpdk/core/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.v1.json
@@ -19,6 +19,13 @@
                         "type": "string"
                     },
                     "additionalItems": false
+                },
+                "timeoutInMinutes": {
+                    "description": "Defines the timeout for the entire operation to be interpreted by the invoker of the handler.  The default is 120 (2 hours).",
+                    "type": "integer",
+                    "minimum": 2,
+                    "maximum": 720,
+                    "default": 120
                 }
             },
             "additionalProperties": false,

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -236,15 +236,11 @@ class Project:  # pylint: disable=too-many-instance-attributes
 
             # calculate IAM role max session timeout based on highest handler timeout
             # with some buffer (70 seconds per minute)
-            cud_handlers = [
-                handlers.get(handler, {})
-                for handler in ["create", "update", "delete"]
-                if handlers.get(handler, None)
-            ]
             max_handler_timeout = max(
                 (
                     handler.get("timeoutInMinutes", DEFAULT_ROLE_TIMEOUT_MINUTES)
-                    for handler in cud_handlers
+                    for operation, handler in handlers.items()
+                    if operation in ["create", "update", "delete"]
                 ),
                 default=DEFAULT_ROLE_TIMEOUT_MINUTES,
             )

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -30,7 +30,9 @@ ROLE_TEMPLATE_FILENAME = "resource-role.yaml"
 TYPE_NAME_REGEX = "^[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}$"
 
 DEFAULT_ROLE_TIMEOUT_MINUTES = 120  # 2 hours
-MIN_ROLE_TIMEOUT_SECONDS = 900  # 15 minutes
+# min and max are according to CreateRole API restrictions
+# https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html
+MIN_ROLE_TIMEOUT_SECONDS = 3600  # 1 hour
 MAX_ROLE_TIMEOUT_SECONDS = 43200  # 12 hours
 
 
@@ -246,7 +248,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
                 ),
                 default=DEFAULT_ROLE_TIMEOUT_MINUTES,
             )
-            # max role session timeout must be between 15 minutes and 12 hours
+            # max role session timeout must be between 1 hour and 12 hours
             role_session_timeout = min(
                 MAX_ROLE_TIMEOUT_SECONDS,
                 max(MIN_ROLE_TIMEOUT_SECONDS, 70 * max_handler_timeout),

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -240,7 +240,6 @@ class Project:  # pylint: disable=too-many-instance-attributes
                 (
                     handler.get("timeoutInMinutes", DEFAULT_ROLE_TIMEOUT_MINUTES)
                     for operation, handler in handlers.items()
-                    if operation in ["create", "update", "delete"]
                 ),
                 default=DEFAULT_ROLE_TIMEOUT_MINUTES,
             )

--- a/src/rpdk/core/templates/resource-role.yml
+++ b/src/rpdk/core/templates/resource-role.yml
@@ -7,7 +7,7 @@ Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      MaxSessionDuration: 8400
+      MaxSessionDuration: 43200
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/src/rpdk/core/templates/resource-role.yml
+++ b/src/rpdk/core/templates/resource-role.yml
@@ -7,7 +7,7 @@ Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      MaxSessionDuration: 43200
+      MaxSessionDuration: {{ role_session_timeout }}
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -242,6 +242,7 @@ def test_generate_handlers_deny_all(project, tmpdir, schema):
             6300,
         ),
         ({"handlers": {"create": {}}}, 8400),
+        ({"handlers": {"create": {"timeoutInMinutes": 90}, "read": {}}}, 8400),
     ),
 )
 def test_generate_handlers_role_session_timeout(project, tmpdir, schema, result):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -232,6 +232,15 @@ def test_generate_handlers_deny_all(project, tmpdir, schema):
         ({"handlers": {"create": {"timeoutInMinutes": 720}}}, 43200),
         ({"handlers": {"create": {"timeoutInMinutes": 2}}}, 900),
         ({"handlers": {"create": {"timeoutInMinutes": 30}}}, 2100),
+        (
+            {
+                "handlers": {
+                    "create": {"timeoutInMinutes": 50},
+                    "update": {"timeoutInMinutes": 30},
+                }
+            },
+            3500,
+        ),
         ({"handlers": {"create": {}}}, 8400),
     ),
 )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -230,16 +230,16 @@ def test_generate_handlers_deny_all(project, tmpdir, schema):
     "schema,result",
     (
         ({"handlers": {"create": {"timeoutInMinutes": 720}}}, 43200),
-        ({"handlers": {"create": {"timeoutInMinutes": 2}}}, 900),
-        ({"handlers": {"create": {"timeoutInMinutes": 30}}}, 2100),
+        ({"handlers": {"create": {"timeoutInMinutes": 2}}}, 3600),
+        ({"handlers": {"create": {"timeoutInMinutes": 90}}}, 6300),
         (
             {
                 "handlers": {
-                    "create": {"timeoutInMinutes": 50},
-                    "update": {"timeoutInMinutes": 30},
+                    "create": {"timeoutInMinutes": 70},
+                    "update": {"timeoutInMinutes": 90},
                 }
             },
-            3500,
+            6300,
         ),
         ({"handlers": {"create": {}}}, 8400),
     ),

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -226,6 +226,35 @@ def test_generate_handlers_deny_all(project, tmpdir, schema):
     mock_plugin.generate.assert_called_once_with(project)
 
 
+@pytest.mark.parametrize(
+    "schema,result",
+    (
+        ({"handlers": {"create": {"timeoutInMinutes": 720}}}, 43200),
+        ({"handlers": {"create": {"timeoutInMinutes": 2}}}, 900),
+        ({"handlers": {"create": {"timeoutInMinutes": 30}}}, 2100),
+        ({"handlers": {"create": {}}}, 8400),
+    ),
+)
+def test_generate_handlers_role_session_timeout(project, tmpdir, schema, result):
+    project.type_name = "Test::Handler::Test"
+    project.schema = schema
+    project.root = tmpdir
+    mock_plugin = MagicMock(spec=["generate"])
+    with patch.object(project, "_plugin", mock_plugin):
+        project.generate()
+
+    role_path = project.root / "resource-role.yaml"
+    with role_path.open("r", encoding="utf-8") as f:
+        template = yaml.safe_load(f.read())
+
+    max_session_timeout = template["Resources"]["ExecutionRole"]["Properties"][
+        "MaxSessionDuration"
+    ]
+    assert max_session_timeout == result
+
+    mock_plugin.generate.assert_called_once_with(project)
+
+
 def test_init(project):
     type_name = "AWS::Color::Red"
 


### PR DESCRIPTION
*Issue #, if available:*

This increases the managed provider IAM role to 12 hours, and generates a value for the resource provider role timeout based on the max handler timeout.  This allows for timeouts up to 12 hours

Related: https://github.com/aws-cloudformation/aws-cloudformation-resource-schema/pull/61

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
