### PR TITLE
Add resource model pruning function and fix contract test

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -38,6 +38,18 @@ def prune_properties(document, paths):
     return document
 
 
+def prune_properties_from_model(model, paths):
+    """Prune given properties from a resource model.
+
+    This assumes the dict passed in is a resources model i.e. solely the properties.
+    This also assumes the paths to remove are prefixed with "/properties",
+    as many of the paths are defined in the schema
+    The function modifies the document in-place, but also returns the document
+    for convenience. (The return value may be ignored.)
+    """
+    return prune_properties({"properties": model}, paths)["properties"]
+
+
 def override_properties(document, overrides):
     """Override given properties from a document."""
     for path, obj in overrides.items():

--- a/src/rpdk/core/contract/suite/handler_delete.py
+++ b/src/rpdk/core/contract/suite/handler_delete.py
@@ -79,7 +79,7 @@ def contract_delete_delete(resource_client, deleted_resource):
 @pytest.mark.create
 @pytest.mark.delete
 def contract_delete_create(resource_client, deleted_resource):
-    if resource_client.has_writable_identifiers():
+    if resource_client.has_writable_identifier():
         deleted_model, request = deleted_resource
         response = test_create_success(resource_client, request)
 

--- a/src/rpdk/core/contract/suite/handler_delete.py
+++ b/src/rpdk/core/contract/suite/handler_delete.py
@@ -7,7 +7,7 @@ import pytest
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
 from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
-from rpdk.core.contract.resource_client import prune_properties
+from rpdk.core.contract.resource_client import prune_properties_from_model
 from rpdk.core.contract.suite.handler_commons import (
     test_create_success,
     test_delete_failure_not_found,
@@ -79,11 +79,16 @@ def contract_delete_delete(resource_client, deleted_resource):
 @pytest.mark.create
 @pytest.mark.delete
 def contract_delete_create(resource_client, deleted_resource):
-    deleted_model, request = deleted_resource
-    response = test_create_success(resource_client, request)
+    if resource_client.has_writable_identifiers():
+        deleted_model, request = deleted_resource
+        response = test_create_success(resource_client, request)
 
-    # read-only properties should be excluded from the comparison
-    prune_properties(deleted_model, resource_client.read_only_paths)
-    prune_properties(response["resourceModel"], resource_client.read_only_paths)
+        # read-only properties should be excluded from the comparison
+        prune_properties_from_model(deleted_model, resource_client.read_only_paths)
+        prune_properties_from_model(
+            response["resourceModel"], resource_client.read_only_paths
+        )
 
-    assert deleted_model == response["resourceModel"]
+        assert deleted_model == response["resourceModel"]
+    else:
+        pytest.skip("No writable identifiers. Skipping test.")

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -11,6 +11,7 @@ from rpdk.core.contract.resource_client import (
     ResourceClient,
     override_properties,
     prune_properties,
+    prune_properties_from_model,
 )
 from rpdk.core.test import (
     DEFAULT_ENDPOINT,
@@ -59,6 +60,25 @@ def test_prune_properties():
         "array": ["first", "second"],
     }
     prune_properties(document, [("foo",), ("spam",), ("not_found",), ("array", "1")])
+    assert document == {"one": "two", "array": ["first"]}
+
+
+def test_prune_properties_from_model():
+    document = {
+        "foo": "bar",
+        "spam": "eggs",
+        "one": "two",
+        "array": ["first", "second"],
+    }
+    prune_properties_from_model(
+        document,
+        [
+            ("properties", "foo"),
+            ("properties", "spam"),
+            ("properties", "not_found"),
+            ("properties", "array", "1"),
+        ],
+    )
     assert document == {"one": "two", "array": ["first"]}
 
 
@@ -523,9 +543,3 @@ def test_has_update_handler(resource_client):
     schema = {"handlers": {"update": {"permissions": ["permission"]}}}
     resource_client._update_schema(schema)
     assert resource_client.has_update_handler()
-
-
-def test_has_update_handler_false(resource_client):
-    schema = {"handlers": {"create": {"permissions": ["permission"]}}}
-    resource_client._update_schema(schema)
-    assert not resource_client.has_update_handler()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Contract tests for certain providers were failing the delete_create duplicate test. It turns out the prune_properties function used to try to remove the readOnly properties from both the deleted model and the newly created model wasn't actually pruning anything because the paths included the "/properties" prefix. This adds a function for pruning models (that do not have a "properties" key) and uses that function in the contract test. 

The test is also skipped if the schema does not contain any writable identifiers/


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
