### PR TITLE
Use PEP451 loader to work around pytest/jinja2 disagreements (#387)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,7 @@ docutils>=0.14
 # testing tools
 pylint>=2.3.1
 coverage>=4.5.4
-# https://github.com/pytest-dev/pytest/issues/5392
-pytest==4.5.0
+pytest>=5.3.5
 pytest-cov>=2.7.1
 pytest-random-order>=1.0.4
 hypothesis>=4.32.3

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "boto3>=1.10.20",
         "Jinja2>=2.10",
         "jsonschema>=3.0.1",
-        "pytest==4.5.0",
+        "pytest>=4.5.0",
         "Werkzeug>=0.15",
         "PyYAML>=5.1",
         "requests>=2.22",

--- a/tests/test_plugin_base.py
+++ b/tests/test_plugin_base.py
@@ -66,3 +66,19 @@ def test_language_plugin_setup_jinja_env_overrides(plugin):
 
     for name in FILTER_REGISTRY:
         assert name in env.filters
+
+
+def test_language_plugin_setup_jinja_env_no_spec(plugin):
+    with patch(
+        "rpdk.core.plugin_base.importlib.util.find_spec", return_value=None
+    ) as mock_spec:
+        env = plugin._setup_jinja_env()
+
+    mock_spec.assert_called_once_with(plugin._module_name)
+    assert env.loader
+    assert env.autoescape
+
+    for name in FILTER_REGISTRY:
+        assert name in env.filters
+
+    # don't assert the template, PackageLoader does not work from pytest


### PR DESCRIPTION
*Issue #, if available:* 387

*Description of changes:* Work around update to Jinja2 that breaks pytest's mangling of module loaders.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
