### PR TITLE
Verify packaging in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ install:
 
 script:
   - pre-commit run --all-files
+  - python setup.py sdist bdist_wheel
+  - twine check ./dist/*
 
 jobs:
   include:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,6 @@ pytest-localserver>=0.5.0
 
 # commit hooks
 pre-commit>=1.18.1
+
+# packaging
+twine>=3.1.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The [`twine check`](https://github.com/pypa/twine/#twine-check)  command verifies that a distribution could be uploaded to PyPI. This will ensure that  generated distributions can be uploaded to PyPI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
