### PR TITLE
Set default type when generating docs to object

### DIFF
--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -416,17 +416,19 @@ class Project:  # pylint: disable=too-many-instance-attributes
         ):
             prop["readonly"] = True
 
-        if prop["type"] in BASIC_TYPE_MAPPINGS:
-            mapped = BASIC_TYPE_MAPPINGS[prop["type"]]
+        prop_type = "object" if "type" not in prop else prop["type"]
+
+        if prop_type in BASIC_TYPE_MAPPINGS:
+            mapped = BASIC_TYPE_MAPPINGS[prop_type]
             prop["jsontype"] = prop["yamltype"] = prop["longformtype"] = mapped
-        elif prop["type"] == "array":
+        elif prop_type == "array":
             prop["arrayitems"] = arrayitems = self._set_docs_properties(
                 propname, prop["items"], proppath
             )
             prop["jsontype"] = f'[ {arrayitems["jsontype"]}, ... ]'
             prop["yamltype"] = f'\n      - {arrayitems["longformtype"]}'
             prop["longformtype"] = f'List of {arrayitems["longformtype"]}'
-        elif prop["type"] == "object":
+        elif prop_type == "object":
             template = self.env.get_template("docs-subproperty.md")
             docs_path = self.root / "docs"
 

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -416,7 +416,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
         ):
             prop["readonly"] = True
 
-        prop_type = "object" if "type" not in prop else prop["type"]
+        prop_type = prop.get("type", "object")
 
         if prop_type in BASIC_TYPE_MAPPINGS:
             mapped = BASIC_TYPE_MAPPINGS[prop_type]

--- a/tests/data/schema/valid/valid_no_type.json
+++ b/tests/data/schema/valid/valid_no_type.json
@@ -1,0 +1,23 @@
+{
+    "typeName": "AWS::Valid::TypeName",
+    "description": "a test schema",
+    "definitions": {
+        "obj1def": {
+            "properties": {
+                "str1": {
+                    "type": "string",
+                    "minLength": 2
+                }
+            }
+        }
+    },
+    "properties": {
+        "property1": {
+            "$ref": "#/definitions/obj1def"
+        }
+    },
+    "primaryIdentifier": [
+        "/properties/property1"
+    ],
+    "additionalProperties": false
+}

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -177,61 +177,29 @@ def test_generate_no_handlers(project):
     mock_plugin.generate.assert_called_once_with(project)
 
 
-def test_generate_no_type_defined(project, tmp_path_factory):
-    project.schema = resource_json(__name__, "data/schema/valid/valid_no_type.json")
+@pytest.mark.parametrize(
+    "schema_path,path",
+    [
+        ("data/schema/valid/valid_no_type.json", "generate_with_no_type_defined"),
+        (
+            "data/schema/valid/valid_type_complex.json",
+            "generate_with_docs_type_complex",
+        ),
+        (
+            "data/schema/valid/valid_nested_property_object.json",
+            "generate_with_docs_nested_object",
+        ),
+        (
+            "data/schema/valid/valid_type_composite_primary_identifier.json",
+            "generate_with_docs_composite_primary_identifier",
+        ),
+    ],
+)
+def test_generate_with_docs(project, tmp_path_factory, schema_path, path):
+    project.schema = resource_json(__name__, schema_path)
     project.type_name = "AWS::Color::Red"
     # tmpdir conflicts with other tests, make a unique one
-    project.root = tmp_path_factory.mktemp("generate_with_no_type_defined")
-    mock_plugin = MagicMock(spec=["generate"])
-    with patch.object(project, "_plugin", mock_plugin):
-        project.generate()
-        project.generate_docs()
-    mock_plugin.generate.assert_called_once_with(project)
-
-    docs_dir = project.root / "docs"
-    readme_file = project.root / "docs" / "README.md"
-
-    assert docs_dir.is_dir()
-    assert readme_file.is_file()
-    with patch.object(project, "_plugin", mock_plugin):
-        project.generate()
-        project.generate_docs()
-    readme_contents = readme_file.read_text(encoding="utf-8")
-    assert project.type_name in readme_contents
-
-
-def test_generate_with_docs(project, tmp_path_factory):
-    project.schema = resource_json(
-        __name__, "data/schema/valid/valid_type_complex.json"
-    )
-    project.type_name = "AWS::Color::Red"
-    # tmpdir conflicts with other tests, make a unique one
-    project.root = tmp_path_factory.mktemp("generate_with_docs")
-    mock_plugin = MagicMock(spec=["generate"])
-    with patch.object(project, "_plugin", mock_plugin):
-        project.generate()
-        project.generate_docs()
-    mock_plugin.generate.assert_called_once_with(project)
-
-    docs_dir = project.root / "docs"
-    readme_file = project.root / "docs" / "README.md"
-
-    assert docs_dir.is_dir()
-    assert readme_file.is_file()
-    with patch.object(project, "_plugin", mock_plugin):
-        project.generate()
-        project.generate_docs()
-    readme_contents = readme_file.read_text(encoding="utf-8")
-    assert project.type_name in readme_contents
-
-
-def test_generate_with_docs_nested_object(project, tmp_path_factory):
-    project.schema = resource_json(
-        __name__, "data/schema/valid/valid_nested_property_object.json"
-    )
-    project.type_name = "AWS::Color::Red"
-    # tmpdir conflicts with other tests, make a unique one
-    project.root = tmp_path_factory.mktemp("generate_with_docs_nested_object")
+    project.root = tmp_path_factory.mktemp(path)
     mock_plugin = MagicMock(spec=["generate"])
     with patch.object(project, "_plugin", mock_plugin):
         project.generate()
@@ -261,33 +229,6 @@ def test_generate_with_docs_invalid_property_type(project, tmp_path_factory):
     with patch.object(project, "_plugin", mock_plugin):
         # skip actual generation
         project.generate_docs()
-
-    docs_dir = project.root / "docs"
-    readme_file = project.root / "docs" / "README.md"
-
-    assert docs_dir.is_dir()
-    assert readme_file.is_file()
-    with patch.object(project, "_plugin", mock_plugin):
-        project.generate()
-        project.generate_docs()
-    readme_contents = readme_file.read_text(encoding="utf-8")
-    assert project.type_name in readme_contents
-
-
-def test_generate_with_docs_composite_primary_identifier(project, tmp_path_factory):
-    project.schema = resource_json(
-        __name__, "data/schema/valid/valid_type_composite_primary_identifier.json"
-    )
-    project.type_name = "AWS::Color::Red"
-    # tmpdir conflicts with other tests, make a unique one
-    project.root = tmp_path_factory.mktemp(
-        "generate_with_docs_composite_primary_identifier"
-    )
-    mock_plugin = MagicMock(spec=["generate"])
-    with patch.object(project, "_plugin", mock_plugin):
-        project.generate()
-        project.generate_docs()
-    mock_plugin.generate.assert_called_once_with(project)
 
     docs_dir = project.root / "docs"
     readme_file = project.root / "docs" / "README.md"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -177,6 +177,29 @@ def test_generate_no_handlers(project):
     mock_plugin.generate.assert_called_once_with(project)
 
 
+def test_generate_no_type_defined(project, tmp_path_factory):
+    project.schema = resource_json(__name__, "data/schema/valid/valid_no_type.json")
+    project.type_name = "AWS::Color::Red"
+    # tmpdir conflicts with other tests, make a unique one
+    project.root = tmp_path_factory.mktemp("generate_with_no_type_defined")
+    mock_plugin = MagicMock(spec=["generate"])
+    with patch.object(project, "_plugin", mock_plugin):
+        project.generate()
+        project.generate_docs()
+    mock_plugin.generate.assert_called_once_with(project)
+
+    docs_dir = project.root / "docs"
+    readme_file = project.root / "docs" / "README.md"
+
+    assert docs_dir.is_dir()
+    assert readme_file.is_file()
+    with patch.object(project, "_plugin", mock_plugin):
+        project.generate()
+        project.generate_docs()
+    readme_contents = readme_file.read_text(encoding="utf-8")
+    assert project.type_name in readme_contents
+
+
 def test_generate_with_docs(project, tmp_path_factory):
     project.schema = resource_json(
         __name__, "data/schema/valid/valid_type_complex.json"


### PR DESCRIPTION
*Description of changes:* `type` is not a required key when declaring a definition/property. When auto-generating the docs, it assumed that `type` would always be specified. This sets the type to object if it is not specified in the schema which is the default.

Tested with a unit test and a personal type. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
