### PR TITLE
Add settings parameter to project init

### DIFF
--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -204,11 +204,11 @@ class Project:  # pylint: disable=too-many-instance-attributes
 
         self.overwrite(self.settings_path, _write)
 
-    def init(self, type_name, language):
+    def init(self, type_name, language, settings=None):
         self.type_name = type_name
         self.language = language
         self._plugin = load_plugin(language)
-        self.settings = {}
+        self.settings = settings or {}
 
         self._write_example_schema()
         self._plugin.init(self)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Allows plugins to initialize project with settings object. This is needed to inject settings directly for the unit tests in the Typescript plugin instead of having to modify generated files. Please, refer to this related code in Typescript plugin repo: https://github.com/eduardomourar/cloudformation-cli-typescript-plugin/blob/0b534882fd961062d47e62f9278d20b5e46a3395/tests/plugin/codegen_test.py#L40-L43


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
