### PR TITLE
Fix update contract test fixture

### DIFF
--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -13,12 +13,12 @@ from rpdk.core.contract.suite.handler_commons import (
 
 @pytest.fixture(scope="module")
 def updated_resource(resource_client):
-    create_request = resource_client.generate_create_example()
+    create_request = model = resource_client.generate_create_example()
     try:
         _status, response, _error = resource_client.call_and_assert(
             Action.CREATE, OperationStatus.SUCCESS, create_request
         )
-        created_model = response["resourceModel"]
+        created_model = model = response["resourceModel"]
         update_request = resource_client.generate_update_example(created_model)
         _status, response, _error = resource_client.call_and_assert(
             Action.UPDATE, OperationStatus.SUCCESS, update_request, created_model
@@ -26,9 +26,7 @@ def updated_resource(resource_client):
         updated_model = response["resourceModel"]
         yield create_request, created_model, update_request, updated_model
     finally:
-        resource_client.call_and_assert(
-            Action.DELETE, OperationStatus.SUCCESS, updated_model
-        )
+        resource_client.call_and_assert(Action.DELETE, OperationStatus.SUCCESS, model)
 
 
 @pytest.mark.update


### PR DESCRIPTION
*Issue #, if available:* #426 

*Description of changes:* This fixes the update fixture used in contract tests to be in line with how the create fixture operates:
https://github.com/aws-cloudformation/cloudformation-cli/blob/dbf6dc34f1ee52b9baf6d0a78b1e62e7f06f83d7/src/rpdk/core/contract/suite/handler_create.py#L23-L31


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
