### PR TITLE
Use seed-isort-config for isort dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 exclude: ^(buildspec.yml|.pre-commit-config.yaml)$
 fail_fast: true
 repos:
+- repo: https://github.com/asottile/seed-isort-config
+  rev: v2.1.1
+  hooks:
+    - id: seed-isort-config
 - repo: https://github.com/pre-commit/mirrors-isort
   rev: v4.3.17
   hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ include_trailing_comma = true
 combine_as_imports = True
 force_grid_wrap = 0
 known_first_party = rpdk
-known_third_party = boto3,botocore,jinja2,jsonschema,werkzeug,yaml,requests
+known_third_party = boto3,botocore,colorama,hypothesis,jinja2,jsonschema,pkg_resources,pytest,pytest_localserver,requests,setuptools,yaml
 
 [tool:pytest]
 # can't do anything about 3rd part modules, so don't spam us


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*. isort is broken, and it also [conflict with blank](https://github.com/psf/black/issues/251).

Also the PR #436  fails on isort without change of those files because of it.

It's recommended to use [seed-isort-config](https://github.com/asottile/seed-isort-config) to populate the known_third_party isort setting. 

After that, my local command `pre-commit run --all-files` works well.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
