### PR TITLE
Assert Handler Request completes in expected time

### DIFF
--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -1,5 +1,6 @@
 # fixture and parameter have the same name
 # pylint: disable=redefined-outer-name,protected-access
+import time
 from io import StringIO
 from unittest.mock import ANY, patch
 
@@ -543,3 +544,11 @@ def test_has_update_handler(resource_client):
     schema = {"handlers": {"update": {"permissions": ["permission"]}}}
     resource_client._update_schema(schema)
     assert resource_client.has_update_handler()
+
+
+def test_call_assert_time_success(resource_client):
+    resource_client.assert_time(time.time() - 30, time.time(), "CREATE")
+
+
+def test_call_assert_time_read(resource_client):
+    resource_client.assert_time(time.time(), time.time(), "READ")


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:* Create, Update, Delete handler request should complete in 60 seconds while Read and List Handler should complete in 30 seconds. In these contract test we are asserting each handler call is completed in expected time.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
