### PR TITLE
Desired state stabilization contract test

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -308,7 +308,6 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         LOG.debug("Received response\n%s", payload)
         return payload
 
-    # pylint: disable=too-many-arguments
     def call_and_assert(
         self, action, assert_status, current_model, previous_model=None, **kwargs
     ):

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -301,8 +301,8 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             primary_identifier_path
         )
         for primary_identifier in primary_identifiers_list:
-            assert traverse(created_model, primary_identifier) == traverse(
-                updated_model, primary_identifier
+            assert created_model.get(primary_identifier) == updated_model.get(
+                primary_identifier
             )
 
     def _make_payload(self, action, request):

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -18,7 +18,7 @@ def test_create_success(resource_client, current_resource_model):
     return response
 
 
-def test_create_fail(resource_client, resource_model):
+def test_create_fail_if_read_only_property_in_input(resource_client, resource_model):
     if len(resource_client.read_only_paths) > 0:
         _status, response, _error_code = resource_client.call_and_assert(
             Action.CREATE,

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -7,10 +7,7 @@ LOG = logging.getLogger(__name__)
 
 def test_create_success(resource_client, current_resource_model):
     _status, response, _error_code = resource_client.call_and_assert(
-        Action.CREATE,
-        OperationStatus.SUCCESS,
-        current_resource_model,
-        resource_client.primary_identifier_paths,
+        Action.CREATE, OperationStatus.SUCCESS, current_resource_model,
     )
     resource_client.assert_primary_identifier(
         resource_client.primary_identifier_paths, current_resource_model
@@ -21,10 +18,7 @@ def test_create_success(resource_client, current_resource_model):
 def test_create_fail_if_read_only_property_in_input(resource_client, resource_model):
     if len(resource_client.read_only_paths) > 0:
         _status, response, _error_code = resource_client.call_and_assert(
-            Action.CREATE,
-            OperationStatus.FAILED,
-            resource_model,
-            resource_client.primary_identifier_paths,
+            Action.CREATE, OperationStatus.FAILED, resource_model,
         )
         assert response["message"]
         assert _error_code == HandlerErrorCode.InvalidRequest
@@ -40,10 +34,7 @@ def test_create_failure_if_repeat_writeable_id(resource_client, current_resource
         # resource model means that the same resource is trying to be
         # created twice.
         _status, _response, error_code = resource_client.call_and_assert(
-            Action.CREATE,
-            OperationStatus.FAILED,
-            current_resource_model,
-            resource_client.primary_identifier_paths,
+            Action.CREATE, OperationStatus.FAILED, current_resource_model,
         )
         assert (
             error_code == HandlerErrorCode.AlreadyExists
@@ -54,10 +45,7 @@ def test_create_failure_if_repeat_writeable_id(resource_client, current_resource
 
 def test_read_success(resource_client, current_resource_model):
     _status, response, _error_code = resource_client.call_and_assert(
-        Action.READ,
-        OperationStatus.SUCCESS,
-        current_resource_model,
-        resource_client.primary_identifier_paths,
+        Action.READ, OperationStatus.SUCCESS, current_resource_model,
     )
     assert response["resourceModel"] == current_resource_model
     resource_client.assert_primary_identifier(
@@ -68,20 +56,14 @@ def test_read_success(resource_client, current_resource_model):
 
 def test_read_failure_not_found(resource_client, current_resource_model):
     _status, _response, error_code = resource_client.call_and_assert(
-        Action.READ,
-        OperationStatus.FAILED,
-        current_resource_model,
-        resource_client.primary_identifier_paths,
+        Action.READ, OperationStatus.FAILED, current_resource_model,
     )
     assert error_code == HandlerErrorCode.NotFound
 
 
 def test_list_success(resource_client, current_resource_model):
     _status, response, _error_code = resource_client.call_and_assert(
-        Action.LIST,
-        OperationStatus.SUCCESS,
-        current_resource_model,
-        resource_client.primary_identifier_paths,
+        Action.LIST, OperationStatus.SUCCESS, current_resource_model,
     )
     next_token = response.get("nextToken")
     resource_models = response["resourceModels"]
@@ -90,7 +72,6 @@ def test_list_success(resource_client, current_resource_model):
             Action.LIST,
             OperationStatus.SUCCESS,
             current_resource_model,
-            resource_client.primary_identifier_paths,
             nextToken=next_token,
         )
         resource_models.extend(next_response["resourceModels"])
@@ -100,11 +81,7 @@ def test_list_success(resource_client, current_resource_model):
 
 def test_update_success(resource_client, update_model, current_model):
     _status, response, _error_code = resource_client.call_and_assert(
-        Action.UPDATE,
-        OperationStatus.SUCCESS,
-        update_model,
-        current_model,
-        resource_client.primary_identifier_paths,
+        Action.UPDATE, OperationStatus.SUCCESS, update_model, current_model,
     )
     # The response model should be the same as the create output model,
     # except the update-able properties should be overridden.
@@ -115,30 +92,20 @@ def test_update_success(resource_client, update_model, current_model):
 def test_update_failure_not_found(resource_client, current_resource_model):
     update_model = resource_client.generate_update_example(current_resource_model)
     _status, _response, error_code = resource_client.call_and_assert(
-        Action.UPDATE,
-        OperationStatus.FAILED,
-        update_model,
-        current_resource_model,
-        resource_client.primary_identifier_paths,
+        Action.UPDATE, OperationStatus.FAILED, update_model, current_resource_model,
     )
     assert error_code == HandlerErrorCode.NotFound
 
 
 def test_delete_success(resource_client, current_resource_model):
     _status, response, _error_code = resource_client.call_and_assert(
-        Action.DELETE,
-        OperationStatus.SUCCESS,
-        current_resource_model,
-        resource_client.primary_identifier_paths,
+        Action.DELETE, OperationStatus.SUCCESS, current_resource_model,
     )
     return response
 
 
 def test_delete_failure_not_found(resource_client, current_resource_model):
     _status, _response, error_code = resource_client.call_and_assert(
-        Action.DELETE,
-        OperationStatus.FAILED,
-        current_resource_model,
-        resource_client.primary_identifier_paths,
+        Action.DELETE, OperationStatus.FAILED, current_resource_model,
     )
     assert error_code == HandlerErrorCode.NotFound

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -7,21 +7,12 @@ LOG = logging.getLogger(__name__)
 
 def test_create_success(resource_client, current_resource_model):
     _status, response, _error_code = resource_client.call_and_assert(
-        Action.CREATE, OperationStatus.SUCCESS, current_resource_model,
+        Action.CREATE, OperationStatus.SUCCESS, current_resource_model
     )
     resource_client.assert_primary_identifier(
         resource_client.primary_identifier_paths, current_resource_model
     )
     return response
-
-
-def test_create_fail_if_read_only_property_in_input(resource_client, resource_model):
-    if len(resource_client.read_only_paths) > 0:
-        _status, response, _error_code = resource_client.call_and_assert(
-            Action.CREATE, OperationStatus.FAILED, resource_model,
-        )
-        assert response["message"]
-        assert _error_code == HandlerErrorCode.InvalidRequest
 
 
 def test_create_failure_if_repeat_writeable_id(resource_client, current_resource_model):
@@ -34,7 +25,7 @@ def test_create_failure_if_repeat_writeable_id(resource_client, current_resource
         # resource model means that the same resource is trying to be
         # created twice.
         _status, _response, error_code = resource_client.call_and_assert(
-            Action.CREATE, OperationStatus.FAILED, current_resource_model,
+            Action.CREATE, OperationStatus.FAILED, current_resource_model
         )
         assert (
             error_code == HandlerErrorCode.AlreadyExists
@@ -45,7 +36,7 @@ def test_create_failure_if_repeat_writeable_id(resource_client, current_resource
 
 def test_read_success(resource_client, current_resource_model):
     _status, response, _error_code = resource_client.call_and_assert(
-        Action.READ, OperationStatus.SUCCESS, current_resource_model,
+        Action.READ, OperationStatus.SUCCESS, current_resource_model
     )
     assert response["resourceModel"] == current_resource_model
     resource_client.assert_primary_identifier(
@@ -56,14 +47,14 @@ def test_read_success(resource_client, current_resource_model):
 
 def test_read_failure_not_found(resource_client, current_resource_model):
     _status, _response, error_code = resource_client.call_and_assert(
-        Action.READ, OperationStatus.FAILED, current_resource_model,
+        Action.READ, OperationStatus.FAILED, current_resource_model
     )
     assert error_code == HandlerErrorCode.NotFound
 
 
 def test_list_success(resource_client, current_resource_model):
     _status, response, _error_code = resource_client.call_and_assert(
-        Action.LIST, OperationStatus.SUCCESS, current_resource_model,
+        Action.LIST, OperationStatus.SUCCESS, current_resource_model
     )
     next_token = response.get("nextToken")
     resource_models = response["resourceModels"]
@@ -81,7 +72,7 @@ def test_list_success(resource_client, current_resource_model):
 
 def test_update_success(resource_client, update_model, current_model):
     _status, response, _error_code = resource_client.call_and_assert(
-        Action.UPDATE, OperationStatus.SUCCESS, update_model, current_model,
+        Action.UPDATE, OperationStatus.SUCCESS, update_model, current_model
     )
     # The response model should be the same as the create output model,
     # except the update-able properties should be overridden.
@@ -92,20 +83,20 @@ def test_update_success(resource_client, update_model, current_model):
 def test_update_failure_not_found(resource_client, current_resource_model):
     update_model = resource_client.generate_update_example(current_resource_model)
     _status, _response, error_code = resource_client.call_and_assert(
-        Action.UPDATE, OperationStatus.FAILED, update_model, current_resource_model,
+        Action.UPDATE, OperationStatus.FAILED, update_model, current_resource_model
     )
     assert error_code == HandlerErrorCode.NotFound
 
 
 def test_delete_success(resource_client, current_resource_model):
     _status, response, _error_code = resource_client.call_and_assert(
-        Action.DELETE, OperationStatus.SUCCESS, current_resource_model,
+        Action.DELETE, OperationStatus.SUCCESS, current_resource_model
     )
     return response
 
 
 def test_delete_failure_not_found(resource_client, current_resource_model):
     _status, _response, error_code = resource_client.call_and_assert(
-        Action.DELETE, OperationStatus.FAILED, current_resource_model,
+        Action.DELETE, OperationStatus.FAILED, current_resource_model
     )
     assert error_code == HandlerErrorCode.NotFound

--- a/src/rpdk/core/contract/suite/handler_create.py
+++ b/src/rpdk/core/contract/suite/handler_create.py
@@ -8,6 +8,7 @@ import pytest
 # when being loaded by pytest
 from rpdk.core.contract.interface import Action, OperationStatus
 from rpdk.core.contract.suite.handler_commons import (
+    test_create_fail,
     test_create_failure_if_repeat_writeable_id,
     test_create_success,
     test_delete_success,
@@ -41,6 +42,12 @@ def contract_create_delete(resource_client):
         delete_model = response["resourceModel"]
     finally:
         test_delete_success(resource_client, delete_model)
+
+
+@pytest.mark.create
+def contract_invalid_create(resource_client):
+    requested_model = resource_client.generate_invalid_create_example()
+    test_create_fail(resource_client, requested_model)
 
 
 @pytest.mark.create

--- a/src/rpdk/core/contract/suite/handler_create.py
+++ b/src/rpdk/core/contract/suite/handler_create.py
@@ -8,7 +8,7 @@ import pytest
 # when being loaded by pytest
 from rpdk.core.contract.interface import Action, OperationStatus
 from rpdk.core.contract.suite.handler_commons import (
-    test_create_fail,
+    test_create_fail_if_read_only_property_in_input,
     test_create_failure_if_repeat_writeable_id,
     test_create_success,
     test_delete_success,
@@ -47,7 +47,7 @@ def contract_create_delete(resource_client):
 @pytest.mark.create
 def contract_invalid_create(resource_client):
     requested_model = resource_client.generate_invalid_create_example()
-    test_create_fail(resource_client, requested_model)
+    test_create_fail_if_read_only_property_in_input(resource_client, requested_model)
 
 
 @pytest.mark.create

--- a/src/rpdk/core/contract/suite/handler_delete.py
+++ b/src/rpdk/core/contract/suite/handler_delete.py
@@ -30,7 +30,10 @@ def deleted_resource(resource_client):
             Action.CREATE, OperationStatus.SUCCESS, request
         )
         model = response["resourceModel"]
-        resource_client.call_and_assert(Action.DELETE, OperationStatus.SUCCESS, model)
+        _status, response, _error = resource_client.call_and_assert(
+            Action.DELETE, OperationStatus.SUCCESS, model
+        )
+        assert "resourceModel" not in response
         yield model, request
     finally:
         request = resource_client.make_request(model, None)

--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -1,12 +1,14 @@
 # fixture and parameter have the same name
 # pylint: disable=redefined-outer-name
+
 import pytest
 
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
-from rpdk.core.contract.interface import Action, OperationStatus
+from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
 from rpdk.core.contract.suite.handler_commons import (
     test_list_success,
+    test_primary_identifier_not_updated,
     test_read_success,
 )
 
@@ -37,6 +39,9 @@ def contract_update_read_success(updated_resource, resource_client):
     # should be able to use the created model
     # to read since physical resource id is immutable
     _create_request, _created_model, _update_request, updated_model = updated_resource
+    test_primary_identifier_not_updated(
+        _created_model, updated_model, resource_client.get_primary_identifier()
+    )
     test_read_success(resource_client, updated_model)
 
 
@@ -46,5 +51,46 @@ def contract_update_list_success(updated_resource, resource_client):
     # should be able to use the created model
     # to read since physical resource id is immutable
     _create_request, _created_model, _update_request, updated_model = updated_resource
+    test_primary_identifier_not_updated(
+        _created_model, updated_model, resource_client.get_primary_identifier()
+    )
     models = test_list_success(resource_client, updated_model)
     assert updated_model in models
+
+
+@pytest.mark.update
+def contract_update_invalid_property(resource_client):
+    if resource_client.has_read_create_property:
+        create_request = resource_client.generate_create_example()
+        try:
+            _status, response, _error = resource_client.call_and_assert(
+                Action.CREATE, OperationStatus.SUCCESS, create_request
+            )
+            created_model = response["resourceModel"]
+            update_request = resource_client.generate_invalid_update_example(
+                created_model
+            )
+            _status, response, _error = resource_client.call_and_assert(
+                Action.UPDATE, OperationStatus.FAILED, update_request, created_model
+            )
+            assert response["message"]
+            assert _error == HandlerErrorCode.NotUpdatable, (
+                "updating readOnly or createOnly properties should" " not possible"
+            )
+        finally:
+            resource_client.call_and_assert(
+                Action.DELETE, OperationStatus.SUCCESS, created_model
+            )
+
+
+@pytest.mark.update
+def contract_update_non_existent_resource(resource_client):
+    create_request = resource_client.generate_create_example()
+    update_request = resource_client.generate_update_example(create_request)
+    _status, response, _error = resource_client.call_and_assert(
+        Action.UPDATE, OperationStatus.FAILED, update_request, create_request
+    )
+    assert response["message"]
+    assert (
+        _error == HandlerErrorCode.NotFound
+    ), "cannot update a resource which does not exist"

--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -58,7 +58,7 @@ def contract_update_list_success(updated_resource, resource_client):
 
 
 @pytest.mark.update
-def contract_update_invalid_property(resource_client):
+def contract_update_create_only_property(resource_client):
 
     if resource_client.create_only_paths:
         create_request = resource_client.generate_create_example()

--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -8,7 +8,6 @@ import pytest
 from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
 from rpdk.core.contract.suite.handler_commons import (
     test_list_success,
-    test_primary_identifier_not_updated,
     test_read_success,
 )
 
@@ -39,8 +38,8 @@ def contract_update_read_success(updated_resource, resource_client):
     # should be able to use the created model
     # to read since physical resource id is immutable
     _create_request, _created_model, _update_request, updated_model = updated_resource
-    test_primary_identifier_not_updated(
-        _created_model, updated_model, resource_client.get_primary_identifier()
+    resource_client.assert_primary_identifier_not_updated(
+        resource_client.primary_identifier_paths, _created_model, updated_model
     )
     test_read_success(resource_client, updated_model)
 
@@ -51,8 +50,8 @@ def contract_update_list_success(updated_resource, resource_client):
     # should be able to use the created model
     # to read since physical resource id is immutable
     _create_request, _created_model, _update_request, updated_model = updated_resource
-    test_primary_identifier_not_updated(
-        _created_model, updated_model, resource_client.get_primary_identifier()
+    resource_client.assert_primary_identifier_not_updated(
+        resource_client.primary_identifier_paths, _created_model, updated_model
     )
     models = test_list_success(resource_client, updated_model)
     assert updated_model in models
@@ -74,9 +73,9 @@ def contract_update_invalid_property(resource_client):
                 Action.UPDATE, OperationStatus.FAILED, update_request, created_model
             )
             assert response["message"]
-            assert _error == HandlerErrorCode.NotUpdatable, (
-                "updating readOnly or createOnly properties should" " not possible"
-            )
+            assert (
+                _error == HandlerErrorCode.NotUpdatable
+            ), "updating readOnly or createOnly properties should not be possible"
         finally:
             resource_client.call_and_assert(
                 Action.DELETE, OperationStatus.SUCCESS, created_model

--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -81,6 +81,8 @@ def contract_update_create_only_property(resource_client):
             resource_client.call_and_assert(
                 Action.DELETE, OperationStatus.SUCCESS, created_model
             )
+    else:
+        pytest.skip("No createOnly Properties. Skipping test.")
 
 
 @pytest.mark.update

--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -59,7 +59,8 @@ def contract_update_list_success(updated_resource, resource_client):
 
 @pytest.mark.update
 def contract_update_invalid_property(resource_client):
-    if resource_client.has_read_create_property:
+
+    if resource_client.create_only_paths:
         create_request = resource_client.generate_create_example()
         try:
             _status, response, _error = resource_client.call_and_assert(

--- a/src/rpdk/core/jsonutils/pointer.py
+++ b/src/rpdk/core/jsonutils/pointer.py
@@ -95,23 +95,3 @@ def fragment_decode(pointer, prefix="#", output=tuple):
     if prefix != actual:
         raise ValueError("Expected prefix '{}', but was '{}'".format(prefix, actual))
     return output(decoded)
-
-
-def fragment_decode_primary_identifier(pointer, output=tuple):
-    """Decode all segments of a JSON pointer from the URI fragment
-    identifier representation.
-
-    >>> fragment_decode_primary_identifier("#")
-    ('#',)
-    >>> fragment_decode_primary_identifier("#/foo/bar")
-    ('bar',)
-    >>> fragment_decode_primary_identifier("#/foo/bar", output=list)
-    ['bar']
-    >>> fragment_decode_primary_identifier("#/0/%20/~0")
-    ('~',)
-    >>> fragment_decode_primary_identifier("/foo")
-    ('foo',)
-    """
-    segments = pointer.split("/")
-    decoded = (part_decode(unquote(segments[-1])),)
-    return output(decoded)

--- a/src/rpdk/core/jsonutils/pointer.py
+++ b/src/rpdk/core/jsonutils/pointer.py
@@ -95,3 +95,27 @@ def fragment_decode(pointer, prefix="#", output=tuple):
     if prefix != actual:
         raise ValueError("Expected prefix '{}', but was '{}'".format(prefix, actual))
     return output(decoded)
+
+
+def fragment_list(segments, prefix="properties", output=list):
+    """Decode all segments of a JSON pointer from the URI fragment
+        identifier representation.
+
+        >>> fragment_list(["properties"])
+        []
+        >>> fragment_list(["properties", "foo", "bar"])
+        ['foo', 'bar']
+        >>> fragment_list(["properties", "foo", "bar"], output=tuple)
+        ('foo', 'bar')
+        >>> fragment_list(["properties", "0", "%20", "~0"])
+        ['0', ' ', '~']
+        >>> fragment_list(["foo"])
+        Traceback (most recent call last):
+        ...
+        ValueError: Expected prefix 'properties', but was 'foo'
+        """
+    decoded = (part_decode(unquote(segment)) for segment in segments)
+    actual = next(decoded)
+    if prefix != actual:
+        raise ValueError("Expected prefix '{}', but was '{}'".format(prefix, actual))
+    return output(decoded)

--- a/src/rpdk/core/jsonutils/pointer.py
+++ b/src/rpdk/core/jsonutils/pointer.py
@@ -95,3 +95,23 @@ def fragment_decode(pointer, prefix="#", output=tuple):
     if prefix != actual:
         raise ValueError("Expected prefix '{}', but was '{}'".format(prefix, actual))
     return output(decoded)
+
+
+def fragment_decode_primary_identifier(pointer, output=tuple):
+    """Decode all segments of a JSON pointer from the URI fragment
+    identifier representation.
+
+    >>> fragment_decode_primary_identifier("#")
+    ('#',)
+    >>> fragment_decode_primary_identifier("#/foo/bar")
+    ('bar',)
+    >>> fragment_decode_primary_identifier("#/foo/bar", output=list)
+    ['bar']
+    >>> fragment_decode_primary_identifier("#/0/%20/~0")
+    ('~',)
+    >>> fragment_decode_primary_identifier("/foo")
+    ('foo',)
+    """
+    segments = pointer.split("/")
+    decoded = (part_decode(unquote(segments[-1])),)
+    return output(decoded)

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -704,7 +704,6 @@ def test_assert_primary_identifier_not_updated_fail(resource_client):
             "createOnlyProperties": ["/properties/c"],
             "primaryIdentifier": ["/properties/c"],
         }
-        print(resource_client.primary_identifier_paths)
         resource_client._update_schema(schema)
         resource_client.assert_primary_identifier_not_updated(
             resource_client.primary_identifier_paths,

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -142,7 +142,7 @@ def test_update_schema(resource_client):
     assert resource_client.primary_identifier_paths == {("properties", "a")}
     assert resource_client.read_only_paths == {("properties", "b")}
     assert resource_client._write_only_paths == {("properties", "c")}
-    assert resource_client._create_only_paths == {("properties", "d")}
+    assert resource_client.create_only_paths == {("properties", "d")}
 
 
 def test_strategy(resource_client):
@@ -428,7 +428,7 @@ def test_call_async(resource_client, action):
 
 @pytest.mark.parametrize("action", [Action.CREATE, Action.UPDATE, Action.DELETE])
 def test_call_async_fail(resource_client, action):
-    with pytest.raises(KeyError):
+    with pytest.raises(AssertionError):
         mock_client = resource_client._client
 
         mock_client.invoke.side_effect = [
@@ -703,7 +703,7 @@ def test_assert_primary_identifier_success(resource_client):
 
 
 def test_assert_primary_identifier_fail(resource_client):
-    with pytest.raises(KeyError):
+    with pytest.raises(AssertionError):
         schema = {
             "properties": {
                 "a": {"type": "number", "const": 1},

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -656,7 +656,7 @@ def test_assert_primary_identifier_success(resource_client):
 
 
 def test_assert_primary_identifier_fail(resource_client):
-    with pytest.raises(AssertionError):
+    with pytest.raises(KeyError):
         schema = {
             "properties": {
                 "a": {"type": "number", "const": 1},

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -420,25 +420,10 @@ def test_call_async(resource_client, action):
         {"Payload": StringIO('{"status": "IN_PROGRESS", "resourceModel": {"c": 3} }')},
         {"Payload": StringIO('{"status": "SUCCESS"}')},
     ]
-    status, response = resource_client.call(action, {}, {("properties", "c")})
+    status, response = resource_client.call(action, {})
 
     assert status == OperationStatus.SUCCESS
     assert response == {"status": OperationStatus.SUCCESS.value}
-
-
-@pytest.mark.parametrize("action", [Action.CREATE, Action.UPDATE, Action.DELETE])
-def test_call_async_fail(resource_client, action):
-    with pytest.raises(AssertionError):
-        mock_client = resource_client._client
-
-        mock_client.invoke.side_effect = [
-            {
-                "Payload": StringIO(
-                    '{"status": "IN_PROGRESS", "resourceModel": {"d": 3} }'
-                )
-            },
-        ]
-        resource_client.call(action, {}, {("properties", "c")})
 
 
 def test_call_and_assert_success(resource_client):
@@ -651,38 +636,6 @@ def test_assert_CUD_time_fail(resource_client, action):
 def test_assert_RL_time_fail(resource_client, action):
     with pytest.raises(AssertionError):
         resource_client.assert_time(time.time() - 31, time.time(), action)
-
-
-def test_has_empty_read_create_property(resource_client):
-    assert resource_client.has_read_create_property() is False
-
-
-def test_has_read_property(resource_client):
-    schema = {
-        "properties": {
-            "a": {"type": "number", "const": 1},
-            "b": {"type": "number", "const": 2},
-            "c": {"type": "number", "const": 3},
-        },
-        "createOnlyProperties": ["/properties/b"],
-    }
-    resource_client._update_schema(schema)
-    assert resource_client.has_read_create_property()
-
-
-def test_has_read_create_property(resource_client):
-    schema = {
-        "properties": {
-            "a": {"type": "number", "const": 1},
-            "b": {"type": "number", "const": 2},
-            "c": {"type": "number", "const": 3},
-        },
-        "readOnlyProperties": ["/properties/b"],
-        "createOnlyProperties": ["/properties/c"],
-        "primaryIdentifier": ["/properties/c"],
-    }
-    resource_client._update_schema(schema)
-    assert resource_client.has_read_create_property()
 
 
 def test_assert_primary_identifier_success(resource_client):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Following are changes made in this PR:

1. Check if Primary Identifier is added after create finishes successfully
~~2. Check  Primary Identifier should not exist after unsuccessful create finishes~~
3. Check Primary Identifier after update has not changed.
4. Assert ResourceModel does not exist  in response after delete.
5. Test case where update fails with NotUpdatable error code when, we try to update an existing resource with readOnly/createOnly property
6. Test case where update fails with NotFound error code when the resource does not exists.
7. Check if Primary Identifier is added after in_progress is returned.

*Test*:
1. **pre-commit run --all-files**  to build the contract test changes
2. **cfn test** to run the contract test for the a resource.
3. The contract test were run for ses-configurationSet and dummy resource.
**SES-ConfigurationSet Test Output**
```
(env) 88e9fe53273b:aws-ses-configurationset anshikg$ cfn test
=========================================================================================== test session starts ============================================================================================
platform darwin -- Python 3.7.2, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- /Volumes/Unix/workspace/rpdk/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Volumes/Unix/workspace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset/.hypothesis/examples')
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /Volumes/Unix/workspace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset, inifile: /private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_usjnl2r1.ini
plugins: hypothesis-5.15.0, cov-2.8.1, localserver-0.5.0, random-order-1.0.4
collected 15 items / 5 deselected / 10 selected

handler_create.py::contract_create_delete PASSED                                                                                                                                                     [ 10%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                    [ 20%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                  [ 30%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                               [ 40%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                               [ 50%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                       [ 60%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                       [ 70%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                     [ 80%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                     [ 90%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                  [100%]

============================================================================================= warnings summary =============================================================================================
/Volumes/Unix/workspace/rpdk/cloudformation-cli/env/lib/python3.7/site-packages/_pytest/logging.py:499
  /Volumes/Unix/workspace/rpdk/cloudformation-cli/env/lib/python3.7/site-packages/_pytest/logging.py:499: PytestDeprecationWarning: --no-print-logs is deprecated and scheduled for removal in pytest 6.0.
  Please use --show-capture instead.
    _issue_warning_captured(NO_PRINT_LOGS, self._config.hook, stacklevel=2)

handler_create.py::contract_create_delete
handler_create.py::contract_invalid_create
handler_create.py::contract_create_duplicate
handler_delete.py::contract_delete_read
  /Volumes/Unix/workspace/rpdk/cloudformation-cli/env/lib/python3.7/site-packages/hypothesis/strategies/_internal/strategies.py:274: NonInteractiveExampleWarning: The `.example()` method is good for exploring strategies, but should only be used interactively.  We recommend using `@given` for tests - it performs better, saves and replays failures to avoid flakiness, and reports minimal examples. (strategy: fixed_dictionaries({'Name': from_regex('^[a-zA-Z0-9_-]{1,64}\\Z')}))
    NonInteractiveExampleWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================= 10 passed, 5 deselected, 5 warnings in 488.21s (0:08:08) =========================================================================
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
