### PR TITLE
Shape Conformance Contract test

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -114,7 +114,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
 
         self.primary_identifier_paths = self._properties_to_paths("primaryIdentifier")
         self.read_only_paths = self._properties_to_paths("readOnlyProperties")
-        self._write_only_paths = self._properties_to_paths("writeOnlyProperties")
+        self.write_only_paths = self._properties_to_paths("writeOnlyProperties")
         self.create_only_paths = self._properties_to_paths("createOnlyProperties")
 
         additional_identifiers = self._schema.get("additionalIdentifiers", [])
@@ -290,6 +290,18 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             for primary_identifier in list(primary_identifier_path)
         )
 
+    @staticmethod
+    def assert_write_only_property_does_not_exist(
+        resource_model, write_only_properties
+    ):
+        if write_only_properties:
+            assert not all(
+                traverse(
+                    resource_model, fragment_list(write_only_property, "properties")
+                )
+                for write_only_property in write_only_properties
+            )
+
     def _make_payload(self, action, request):
         return {
             "credentials": self._creds.copy(),
@@ -337,8 +349,15 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
 
         while status == OperationStatus.IN_PROGRESS:
             callback_delay_seconds = self.assert_in_progress(status, response)
+            _status, read_response, _error = self.call_and_assert(
+                Action.READ, OperationStatus.SUCCESS, response["resourceModel"]
+            )
+            assert read_response["resourceModel"] == response["resourceModel"]
             self.assert_primary_identifier(
                 self.primary_identifier_paths, response.get("resourceModel")
+            )
+            self.assert_write_only_property_does_not_exist(
+                read_response["resourceModel"], self.write_only_paths
             )
             sleep(callback_delay_seconds)
 

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -12,6 +12,9 @@ def test_create_success(resource_client, current_resource_model):
     resource_client.assert_primary_identifier(
         resource_client.primary_identifier_paths, current_resource_model
     )
+    resource_client.assert_write_only_property_does_not_exist(
+        current_resource_model, resource_client.write_only_paths
+    )
     return response
 
 
@@ -41,6 +44,9 @@ def test_read_success(resource_client, current_resource_model):
     assert response["resourceModel"] == current_resource_model
     resource_client.assert_primary_identifier(
         resource_client.primary_identifier_paths, current_resource_model
+    )
+    resource_client.assert_write_only_property_does_not_exist(
+        current_resource_model, resource_client.write_only_paths
     )
     return response
 
@@ -73,6 +79,9 @@ def test_list_success(resource_client, current_resource_model):
 def test_update_success(resource_client, update_model, current_model):
     _status, response, _error_code = resource_client.call_and_assert(
         Action.UPDATE, OperationStatus.SUCCESS, update_model, current_model
+    )
+    resource_client.assert_write_only_property_does_not_exist(
+        update_model, resource_client.write_only_paths
     )
     # The response model should be the same as the create output model,
     # except the update-able properties should be overridden.


### PR DESCRIPTION
*Issue #, if available:*
Tracking this issue here: https://github.com/aws-cloudformation/cloudformation-cli/pull/451
I messed up fixing the merge conflicts in this CR.
*Description of changes:*
1)  verify "In Progress event" is being returned. If so, verify the resource created and the model returned have the same set of values
2) Verify "WriteOnlyProperties" are not being returned.

*Test*
```
(env) 88e9fe53273b:aws-ses-configurationset anshikg$ cfn test
=========================================================================================== test session starts ============================================================================================
platform darwin -- Python 3.7.2, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- /Volumes/Unix/workspace/rpdk/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Volumes/Unix/workspace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset/.hypothesis/examples')
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /Volumes/Unix/workspace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset, inifile: /private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_eje7jekx.ini
plugins: hypothesis-5.15.0, cov-2.8.1, localserver-0.5.0, random-order-1.0.4
collected 15 items / 5 deselected / 10 selected

handler_create.py::contract_create_delete PASSED                                                                                                                                                     [ 10%]
handler_create.py::contract_invalid_create SKIPPED                                                                                                                                                   [ 20%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                  [ 30%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                               [ 40%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                               [ 50%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                       [ 60%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                       [ 70%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                     [ 80%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                     [ 90%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                  [100%]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
