### PR TITLE
Shape Conformance Contract test

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -133,6 +133,15 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
                     return True
         return False
 
+    def assert_write_only_property_does_not_exist(self, resource_model):
+        if self.write_only_paths:
+            assert not any(
+                traverse(
+                    resource_model, fragment_list(write_only_property, "properties")
+                )
+                for write_only_property in self.write_only_paths
+            )
+
     @property
     def strategy(self):
         # an empty strategy (i.e. false-y) is valid
@@ -290,18 +299,6 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             for primary_identifier in primary_identifier_path
         )
 
-    @staticmethod
-    def assert_write_only_property_does_not_exist(
-        resource_model, write_only_properties
-    ):
-        if write_only_properties:
-            assert not all(
-                traverse(
-                    resource_model, fragment_list(write_only_property, "properties")
-                )
-                for write_only_property in write_only_properties
-            )
-
     def _make_payload(self, action, request):
         return {
             "credentials": self._creds.copy(),
@@ -353,9 +350,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             self.assert_primary_identifier(
                 self.primary_identifier_paths, response.get("resourceModel")
             )
-            self.assert_write_only_property_does_not_exist(
-                response["resourceModel"], self.write_only_paths
-            )
+            self.assert_write_only_property_does_not_exist(response["resourceModel"])
             sleep(callback_delay_seconds)
 
             payload["callbackContext"] = response.get("callbackContext")

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -138,7 +138,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             assert not any(
                 traverse(
                     resource_model, fragment_list(write_only_property, "properties")
-                )
+                )[0]
                 for write_only_property in self.write_only_paths
             )
 

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -136,9 +136,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
     def assert_write_only_property_does_not_exist(self, resource_model):
         if self.write_only_paths:
             assert not any(
-                traverse(
-                    resource_model, fragment_list(write_only_property, "properties")
-                )[0]
+                self.key_error_safe_traverse(resource_model, write_only_property)
                 for write_only_property in self.write_only_paths
             )
 
@@ -213,6 +211,15 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         overrides = self._overrides.get("UPDATE", self._overrides.get("CREATE", {}))
         example = override_properties(self.invalid_strategy.example(), overrides)
         return {**create_model, **example}
+
+    @staticmethod
+    def key_error_safe_traverse(resource_model, write_only_property):
+        try:
+            return traverse(
+                resource_model, fragment_list(write_only_property, "properties")
+            )[0]
+        except KeyError:
+            return None
 
     @staticmethod
     def assert_in_progress(status, response):

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -12,9 +12,7 @@ def test_create_success(resource_client, current_resource_model):
     resource_client.assert_primary_identifier(
         resource_client.primary_identifier_paths, current_resource_model
     )
-    resource_client.assert_write_only_property_does_not_exist(
-        current_resource_model, resource_client.write_only_paths
-    )
+    resource_client.assert_write_only_property_does_not_exist(current_resource_model)
     return response
 
 
@@ -45,9 +43,7 @@ def test_read_success(resource_client, current_resource_model):
     resource_client.assert_primary_identifier(
         resource_client.primary_identifier_paths, current_resource_model
     )
-    resource_client.assert_write_only_property_does_not_exist(
-        current_resource_model, resource_client.write_only_paths
-    )
+    resource_client.assert_write_only_property_does_not_exist(current_resource_model)
     return response
 
 
@@ -92,9 +88,7 @@ def test_update_success(resource_client, update_model, current_model):
     _status, response, _error_code = resource_client.call_and_assert(
         Action.UPDATE, OperationStatus.SUCCESS, update_model, current_model
     )
-    resource_client.assert_write_only_property_does_not_exist(
-        update_model, resource_client.write_only_paths
-    )
+    resource_client.assert_write_only_property_does_not_exist(update_model)
     # The response model should be the same as the create output model,
     # except the update-able properties should be overridden.
     assert response["resourceModel"] == {**current_model, **update_model}

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -12,6 +12,9 @@ def test_create_success(resource_client, current_resource_model):
     resource_client.assert_primary_identifier(
         resource_client.primary_identifier_paths, current_resource_model
     )
+    resource_client.assert_write_only_property_does_not_exist(
+        current_resource_model, resource_client.write_only_paths
+    )
     return response
 
 
@@ -41,6 +44,9 @@ def test_read_success(resource_client, current_resource_model):
     assert response["resourceModel"] == current_resource_model
     resource_client.assert_primary_identifier(
         resource_client.primary_identifier_paths, current_resource_model
+    )
+    resource_client.assert_write_only_property_does_not_exist(
+        current_resource_model, resource_client.write_only_paths
     )
     return response
 
@@ -85,6 +91,9 @@ def test_model_in_list(resource_client, current_resource_model):
 def test_update_success(resource_client, update_model, current_model):
     _status, response, _error_code = resource_client.call_and_assert(
         Action.UPDATE, OperationStatus.SUCCESS, update_model, current_model
+    )
+    resource_client.assert_write_only_property_does_not_exist(
+        update_model, resource_client.write_only_paths
     )
     # The response model should be the same as the create output model,
     # except the update-able properties should be overridden.

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -30,10 +30,25 @@ SCHEMA = {
         "a": {"type": "number", "const": 1},
         "b": {"type": "number", "const": 2},
         "c": {"type": "number", "const": 3},
+        "d": {"type": "number", "const": 4},
     },
     "readOnlyProperties": ["/properties/b"],
     "createOnlyProperties": ["/properties/c"],
     "primaryIdentifier": ["/properties/c"],
+    "writeOnlyProperties": ["/properties/d"],
+}
+
+SCHEMA_WITH_MULTIPLE_WRITE_PROPERTIES = {
+    "properties": {
+        "a": {"type": "number", "const": 1},
+        "b": {"type": "number", "const": 2},
+        "c": {"type": "number", "const": 3},
+        "d": {"type": "number", "const": 4},
+    },
+    "readOnlyProperties": ["/properties/b"],
+    "createOnlyProperties": ["/properties/c"],
+    "primaryIdentifier": ["/properties/c"],
+    "writeOnlyProperties": ["/properties/d", "/properties/a"],
 }
 
 
@@ -682,44 +697,16 @@ def test_assert_write_only_property_does_not_exist(resource_client):
     resource_client.assert_write_only_property_does_not_exist(schema)
 
 
-def test_assert_write_only_property_does_not_exist_success(resource_client):
-    with pytest.raises(KeyError):
-        schema = {
-            "properties": {
-                "a": {"type": "number", "const": 1},
-                "b": {"type": "number", "const": 2},
-                "c": {"type": "number", "const": 3},
-                "d": {"type": "number", "const": 4},
-            },
-            "readOnlyProperties": ["/properties/b"],
-            "createOnlyProperties": ["/properties/c"],
-            "primaryIdentifier": ["/properties/c"],
-            "writeOnlyProperties": ["/properties/d"],
-        }
-        created_resource = {"a": 1, "b": 2, "c": 3}
-        resource_client._update_schema(schema)
-        resource_client.assert_write_only_property_does_not_exist(created_resource)
+@pytest.mark.parametrize("schema", [SCHEMA, SCHEMA_WITH_MULTIPLE_WRITE_PROPERTIES])
+def test_assert_write_only_property_does_not_exist_success(resource_client, schema):
+    created_resource = {"a": None, "b": 2, "c": 3, "d": None}
+    resource_client._update_schema(schema)
+    resource_client.assert_write_only_property_does_not_exist(created_resource)
 
 
-def test_assert_write_only_property_does_not_exist_fail(resource_client):
+@pytest.mark.parametrize("schema", [SCHEMA, SCHEMA_WITH_MULTIPLE_WRITE_PROPERTIES])
+def test_assert_write_only_property_does_not_exist_fail(resource_client, schema):
     with pytest.raises(AssertionError):
-        schema = {
-            "properties": {
-                "a": {"type": "number", "const": 1},
-                "b": {"type": "number", "const": 2},
-                "c": {"type": "number", "const": 3},
-                "d": {"type": "number", "const": 4},
-            },
-            "readOnlyProperties": ["/properties/b"],
-            "createOnlyProperties": ["/properties/c"],
-            "primaryIdentifier": ["/properties/c"],
-            "writeOnlyProperties": ["/properties/d", "/properties/a"],
-        }
-        created_resource = {
-            "a": 1,
-            "b": 2,
-            "c": 3,
-            "d": 4,
-        }
+        created_resource = {"a": 1, "b": 2, "c": 3, "d": 4}
         resource_client._update_schema(schema)
         resource_client.assert_write_only_property_does_not_exist(created_resource)

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -699,7 +699,7 @@ def test_assert_write_only_property_does_not_exist(resource_client):
 
 @pytest.mark.parametrize("schema", [SCHEMA, SCHEMA_WITH_MULTIPLE_WRITE_PROPERTIES])
 def test_assert_write_only_property_does_not_exist_success(resource_client, schema):
-    created_resource = {"a": None, "b": 2, "c": 3, "d": None}
+    created_resource = {"a": None, "b": 2, "c": 3}
     resource_client._update_schema(schema)
     resource_client.assert_write_only_property_does_not_exist(created_resource)
 

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -152,7 +152,7 @@ def test_update_schema(resource_client):
     assert resource_client._strategy is None
     assert resource_client.primary_identifier_paths == {("properties", "a")}
     assert resource_client.read_only_paths == {("properties", "b")}
-    assert resource_client._write_only_paths == {("properties", "c")}
+    assert resource_client.write_only_paths == {("properties", "c")}
     assert resource_client.create_only_paths == {("properties", "d")}
 
 
@@ -670,3 +670,62 @@ def test_is_primary_identifier_equal_fail(resource_client):
         {"a": 1, "b": 2, "c": 3},
         {"a": 1, "b": 2, "c": 4},
     )
+
+
+def test_assert_write_only_property_does_not_exist(resource_client):
+    schema = {
+        "a": {"type": "number", "const": 1},
+        "b": {"type": "number", "const": 2},
+        "c": {"type": "number", "const": 3},
+    }
+    resource_client._update_schema(schema)
+    resource_client.assert_write_only_property_does_not_exist(
+        schema, resource_client.write_only_paths
+    )
+
+
+def test_assert_write_only_property_does_not_exist_success(resource_client):
+    with pytest.raises(KeyError):
+        schema = {
+            "properties": {
+                "a": {"type": "number", "const": 1},
+                "b": {"type": "number", "const": 2},
+                "c": {"type": "number", "const": 3},
+                "d": {"type": "number", "const": 4},
+            },
+            "readOnlyProperties": ["/properties/b"],
+            "createOnlyProperties": ["/properties/c"],
+            "primaryIdentifier": ["/properties/c"],
+            "writeOnlyProperties": ["/properties/d"],
+        }
+        created_resource = {"a": 1, "b": 2, "c": 3}
+        resource_client._update_schema(schema)
+        resource_client.assert_write_only_property_does_not_exist(
+            created_resource, resource_client.write_only_paths
+        )
+
+
+def test_assert_write_only_property_does_not_exist_fail(resource_client):
+    with pytest.raises(AssertionError):
+        schema = {
+            "properties": {
+                "a": {"type": "number", "const": 1},
+                "b": {"type": "number", "const": 2},
+                "c": {"type": "number", "const": 3},
+                "d": {"type": "number", "const": 4},
+            },
+            "readOnlyProperties": ["/properties/b"],
+            "createOnlyProperties": ["/properties/c"],
+            "primaryIdentifier": ["/properties/c"],
+            "writeOnlyProperties": ["/properties/d"],
+        }
+        created_resource = {
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "d": 4,
+        }
+        resource_client._update_schema(schema)
+        resource_client.assert_write_only_property_does_not_exist(
+            created_resource, resource_client.write_only_paths
+        )

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -679,9 +679,7 @@ def test_assert_write_only_property_does_not_exist(resource_client):
         "c": {"type": "number", "const": 3},
     }
     resource_client._update_schema(schema)
-    resource_client.assert_write_only_property_does_not_exist(
-        schema, resource_client.write_only_paths
-    )
+    resource_client.assert_write_only_property_does_not_exist(schema)
 
 
 def test_assert_write_only_property_does_not_exist_success(resource_client):
@@ -700,9 +698,7 @@ def test_assert_write_only_property_does_not_exist_success(resource_client):
         }
         created_resource = {"a": 1, "b": 2, "c": 3}
         resource_client._update_schema(schema)
-        resource_client.assert_write_only_property_does_not_exist(
-            created_resource, resource_client.write_only_paths
-        )
+        resource_client.assert_write_only_property_does_not_exist(created_resource)
 
 
 def test_assert_write_only_property_does_not_exist_fail(resource_client):
@@ -717,7 +713,7 @@ def test_assert_write_only_property_does_not_exist_fail(resource_client):
             "readOnlyProperties": ["/properties/b"],
             "createOnlyProperties": ["/properties/c"],
             "primaryIdentifier": ["/properties/c"],
-            "writeOnlyProperties": ["/properties/d"],
+            "writeOnlyProperties": ["/properties/d", "/properties/a"],
         }
         created_resource = {
             "a": 1,
@@ -726,6 +722,4 @@ def test_assert_write_only_property_does_not_exist_fail(resource_client):
             "d": 4,
         }
         resource_client._update_schema(schema)
-        resource_client.assert_write_only_property_does_not_exist(
-            created_resource, resource_client.write_only_paths
-        )
+        resource_client.assert_write_only_property_does_not_exist(created_resource)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/cloudformation-cli/pull/450/

*Description of changes:*
~~1)  verify "In Progress event" is being returned. If so, verify the resource created and the model returned have the same set of values~~
2) Verify "WriteOnlyProperties" are not being returned.

*Test*
```
(env) 88e9fe53273b:aws-ses-configurationset anshikg$ cfn test
=========================================================================================== test session starts ============================================================================================
platform darwin -- Python 3.7.2, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- /Volumes/Unix/workspace/rpdk/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Volumes/Unix/workspace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset/.hypothesis/examples')
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /Volumes/Unix/workspace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset, inifile: /private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_eje7jekx.ini
plugins: hypothesis-5.15.0, cov-2.8.1, localserver-0.5.0, random-order-1.0.4
collected 15 items / 5 deselected / 10 selected

handler_create.py::contract_create_delete PASSED                                                                                                                                                     [ 10%]
handler_create.py::contract_invalid_create SKIPPED                                                                                                                                                   [ 20%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                  [ 30%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                               [ 40%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                               [ 50%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                       [ 60%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                       [ 70%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                     [ 80%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                     [ 90%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                  [100%]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
