### PR TITLE
Allow Customers to add Input to Contract test

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -223,7 +223,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
 
     def generate_invalid_update_example(self, create_model):
         if self._inputs:
-            return {**create_model, **self._inputs["INVALID"]}
+            return self._inputs["INVALID"]
         overrides = self._overrides.get("UPDATE", self._overrides.get("CREATE", {}))
         example = override_properties(self.invalid_strategy.example(), overrides)
         return {**create_model, **example}

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -204,26 +204,26 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
 
     def generate_create_example(self):
         if self._inputs:
-            return self._inputs[0]
+            return self._inputs["CREATE"]
         example = self.strategy.example()
         return override_properties(example, self._overrides.get("CREATE", {}))
 
     def generate_invalid_create_example(self):
         if self._inputs:
-            return self._inputs[2]
+            return self._inputs["INVALID"]
         example = self.invalid_strategy.example()
         return override_properties(example, self._overrides.get("CREATE", {}))
 
     def generate_update_example(self, create_model):
         if self._inputs:
-            return {**create_model, **self._inputs[1]}
+            return {**create_model, **self._inputs["UPDATE"]}
         overrides = self._overrides.get("UPDATE", self._overrides.get("CREATE", {}))
         example = override_properties(self.update_strategy.example(), overrides)
         return {**create_model, **example}
 
     def generate_invalid_update_example(self, create_model):
         if self._inputs:
-            return {**create_model, **self._inputs[2]}
+            return {**create_model, **self._inputs["INVALID"]}
         overrides = self._overrides.get("UPDATE", self._overrides.get("CREATE", {}))
         example = override_properties(self.invalid_strategy.example(), overrides)
         return {**create_model, **example}

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import shutil
 import zipfile
 from pathlib import Path
@@ -29,6 +30,7 @@ LOG = logging.getLogger(__name__)
 SETTINGS_FILENAME = ".rpdk-config"
 SCHEMA_UPLOAD_FILENAME = "schema.json"
 OVERRIDES_FILENAME = "overrides.json"
+INPUTS_FOLDER = "inputs"
 ROLE_TEMPLATE_FILENAME = "resource-role.yaml"
 TYPE_NAME_REGEX = "^[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}$"
 
@@ -137,6 +139,10 @@ class Project:  # pylint: disable=too-many-instance-attributes
     @property
     def overrides_path(self):
         return self.root / OVERRIDES_FILENAME
+
+    @property
+    def inputs_path(self):
+        return self.root / INPUTS_FOLDER
 
     @staticmethod
     def _raise_invalid_project(msg, e):
@@ -333,6 +339,13 @@ class Project:  # pylint: disable=too-many-instance-attributes
                     LOG.debug(
                         "%s not found. Not writing to package.", OVERRIDES_FILENAME
                     )
+                if os.path.isdir(self.inputs_path):
+                    for filename in os.listdir(self.inputs_path):
+                        absolute_path = self.inputs_path / filename
+                        zip_file.write(absolute_path, INPUTS_FOLDER + "/" + filename)
+                        LOG.debug("%s found. Writing to package.", filename)
+                else:
+                    LOG.debug("%s not found. Not writing to package.", INPUTS_FOLDER)
                 self._plugin.package(self, zip_file)
 
             if dry_run:

--- a/src/rpdk/core/test.py
+++ b/src/rpdk/core/test.py
@@ -131,13 +131,12 @@ def get_inputs(root, region_name, endpoint_url, value):
     if not os.path.isdir(path):
         return None
 
-    file_prefix = INPUTS + "_"
-    file_postfix = "_" + str(value) + ".json"
+    file_prefix = INPUTS + "_" + str(value)
 
     directories = os.listdir(path)
     if len(directories) > 0:
         for file in directories:
-            if file.endswith(file_postfix) and file.startswith(file_prefix):
+            if file.startswith(file_prefix) and file.endswith(".json"):
                 input_type = get_type(file)
                 if not input_type:
                     continue

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -746,7 +746,4 @@ def test_generate_update_example_with_inputs(resource_client_inputs):
 
 
 def test_generate_invalid_update_example_with_inputs(resource_client_inputs):
-    assert resource_client_inputs.generate_invalid_update_example({"a": 1}) == {
-        "a": 1,
-        "b": 2,
-    }
+    assert resource_client_inputs.generate_invalid_update_example({"a": 1}) == {"b": 2}

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -101,7 +101,7 @@ def resource_client_inputs():
             DEFAULT_REGION,
             {},
             EMPTY_OVERRIDE,
-            [{"a": 1}, {"a": 2}, {"b": 2}],
+            {"CREATE": {"a": 1}, "UPDATE": {"a": 2}, "INVALID": {"b": 2}},
         )
 
     mock_sesh.client.assert_called_once_with("lambda", endpoint_url=endpoint)

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -1,6 +1,7 @@
 # fixture and parameter have the same name
 # pylint: disable=redefined-outer-name
 import json
+import os
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -15,6 +16,7 @@ from rpdk.core.test import (
     DEFAULT_FUNCTION,
     DEFAULT_REGION,
     empty_override,
+    get_inputs,
     get_marker_options,
     get_overrides,
     temporary_ini_file,
@@ -27,9 +29,31 @@ EMPTY_OVERRIDE = empty_override()
 SCHEMA = {"handlers": {action.lower(): [] for action in Action}}
 
 
+@pytest.fixture
+def base(tmpdir):
+    return Path(tmpdir)
+
+
 @contextmanager
 def mock_temporary_ini_file():
     yield RANDOM_INI
+
+
+def create_input_file(base, create_string, update_string, invalid_string):
+    path = base / "inputs"
+    os.mkdir(path, mode=0o777)
+
+    path_create = path / "inputs1_001.json"
+    with path_create.open("w", encoding="utf-8") as f:
+        f.write(create_string)
+
+    path_update = path / "inputs1_002.json"
+    with path_update.open("w", encoding="utf-8") as f:
+        f.write(update_string)
+
+    path_invalid = path / "inputs1_003.json"
+    with path_invalid.open("w", encoding="utf-8") as f:
+        f.write(invalid_string)
 
 
 @pytest.mark.parametrize(
@@ -51,11 +75,12 @@ def mock_temporary_ini_file():
     ],
 )
 def test_test_command_happy_path(
-    capsys, args_in, pytest_args, plugin_args
+    base, capsys, args_in, pytest_args, plugin_args
 ):  # pylint: disable=too-many-locals
+    create_input_file(base, '{"a": 1}', '{"a": 2}', '{"b": 1}')
     mock_project = Mock(spec=Project)
     mock_project.schema = SCHEMA
-    mock_project.root = None
+    mock_project.root = base
 
     patch_project = patch(
         "rpdk.core.test.Project", autospec=True, return_value=mock_project
@@ -78,7 +103,13 @@ def test_test_command_happy_path(
     mock_project.load.assert_called_once_with()
     function_name, endpoint, region = plugin_args
     mock_client.assert_called_once_with(
-        function_name, endpoint, region, mock_project.schema, EMPTY_OVERRIDE, None
+        function_name,
+        endpoint,
+        region,
+        mock_project.schema,
+        EMPTY_OVERRIDE,
+        [{"a": 1}, {"a": 2}, {"b": 1}],
+        None,
     )
     mock_plugin.assert_called_once_with(mock_client.return_value)
     mock_ini.assert_called_once_with()
@@ -121,11 +152,6 @@ def test_temporary_ini_file():
 
 def test_get_overrides_no_root():
     assert get_overrides(None, DEFAULT_REGION, "") == EMPTY_OVERRIDE
-
-
-@pytest.fixture
-def base(tmpdir):
-    return Path(tmpdir)
 
 
 def test_get_overrides_file_not_found(base):
@@ -235,3 +261,54 @@ def test_get_overrides_with_jinja(
 def test_get_marker_options(schema, expected_marker_keywords):
     marker_options = get_marker_options(schema)
     assert all(keyword in marker_options for keyword in expected_marker_keywords)
+
+
+@pytest.mark.parametrize(
+    "create_string,update_string,invalid_string,"
+    "list_exports_return_value,expected_inputs",
+    [
+        (
+            '{"Name": "TestName"}',
+            '{"Name": "TestNameNew"}',
+            "{}",
+            [{"Exports": [{"Value": "TestValue", "Name": "Test"}]}],
+            [{"Name": "TestName"}, {"Name": "TestNameNew"}, {}],
+        )
+    ],
+)
+# pylint: disable=R0913
+# pylint: disable=R0914
+def test_with_inputs(
+    base,
+    create_string,
+    update_string,
+    invalid_string,
+    list_exports_return_value,
+    expected_inputs,
+):
+    mock_cfn_client = Mock(spec=["get_paginator"])
+    mock_paginator = Mock(spec=["paginate"])
+    mock_cfn_client.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.return_value = list_exports_return_value
+    patch_sdk = patch("rpdk.core.test.create_sdk_session", autospec=True)
+
+    create_input_file(base, create_string, update_string, invalid_string)
+    with patch_sdk as mock_sdk:
+        mock_sdk.return_value.client.side_effect = [mock_cfn_client, Mock()]
+        result = get_inputs(base, DEFAULT_REGION, None, 1)
+
+    assert result == expected_inputs
+
+
+def test_get_input_invalid_root():
+    assert not get_inputs("", DEFAULT_REGION, "", 1)
+
+
+def test_get_input_input_folder_does_not_exist(base):
+    assert not get_inputs(base, DEFAULT_REGION, "", 1)
+
+
+def test_get_input_file_not_found(base):
+    path = base / "inputs"
+    os.mkdir(path, mode=0o777)
+    assert not get_inputs(base, DEFAULT_REGION, "", 1)

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -43,15 +43,15 @@ def create_input_file(base, create_string, update_string, invalid_string):
     path = base / "inputs"
     os.mkdir(path, mode=0o777)
 
-    path_create = path / "inputs_create_1.json"
+    path_create = path / "inputs_1_create.json"
     with path_create.open("w", encoding="utf-8") as f:
         f.write(create_string)
 
-    path_update = path / "inputs_update_1.json"
+    path_update = path / "inputs_1_update.json"
     with path_update.open("w", encoding="utf-8") as f:
         f.write(update_string)
 
-    path_invalid = path / "inputs_invalid_1.json"
+    path_invalid = path / "inputs_1_invalid.json"
     with path_invalid.open("w", encoding="utf-8") as f:
         f.write(invalid_string)
 
@@ -60,7 +60,7 @@ def create_invalid_input_file(base):
     path = base / "inputs"
     os.mkdir(path, mode=0o777)
 
-    path_create = path / "inputs_test_1.json"
+    path_create = path / "inputs_1_test.json"
     with path_create.open("w", encoding="utf-8") as f:
         f.write('{"a": 1}')
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This CR will allow customers to enter their own input to the Contract test suite. This will be advantageous for resources with complex inputs. 
In this case user can add a file under root/inputs/ the expected name format is inputs_1_create.json
User can enter create file with postfix: _create.json
User can enter update file with postfix: _update.json
User can enter invalid file with postfix: _invalid.json

Users can enter multiple input files. inputs_1, inputs_2, inputs_3 these 3 will be treated at 3 separate inputs from the user.

*Testing:* 
- used cfn submit to check if the inputs folder was created in the zip file
- build the cfn package: **pre-commit run --all-files**

- ses configurationset: ** cfn test**
```
(env) 88e9fe53273b:aws-ses-configurationset anshikg$ cfn test
======================================================================================= test session starts anshikg ========================================================================================
platform darwin -- Python 3.7.2, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- /Volumes/Unix/workspace/rpdk/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Volumes/Unix/workspace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset/.hypothesis/examples')
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /Volumes/Unix/workspace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset, inifile: /private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_urrbb5ye.ini
plugins: hypothesis-5.15.0, cov-2.8.1, localserver-0.5.0, random-order-1.0.4
collected 15 items / 5 deselected / 10 selected

handler_create.py::contract_create_delete PASSED                                                                                                                                                     [ 10%]
handler_create.py::contract_invalid_create SKIPPED                                                                                                                                                   [ 20%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                  [ 30%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                               [ 40%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                               [ 50%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                       [ 60%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                       [ 70%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                     [ 80%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                     [ 90%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                  [100%]

============================================================================================= warnings summary =============================================================================================
/Volumes/Unix/workspace/rpdk/cloudformation-cli/env/lib/python3.7/site-packages/_pytest/logging.py:499
  /Volumes/Unix/workspace/rpdk/cloudformation-cli/env/lib/python3.7/site-packages/_pytest/logging.py:499: PytestDeprecationWarning: --no-print-logs is deprecated and scheduled for removal in pytest 6.0.
  Please use --show-capture instead.
    _issue_warning_captured(NO_PRINT_LOGS, self._config.hook, stacklevel=2)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================================================================== 9 passed, 1 skipped, 5 deselected, 1 warning in 700.63s (0:11:40) =====================================================================
(env) 88e9fe53273b:aws-ses-configurationset anshikg$
```
- adding multiple files
```
(env) 88e9fe53273b:aws-ses-configurationset anshikg$ cfn test -- -k contract_create_delete
======================================================================================= test session starts anshikg ========================================================================================
platform darwin -- Python 3.7.2, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- /Volumes/Unix/workspace/rpdk/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Volumes/Unix/workspace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset/.hypothesis/examples')
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /Volumes/Unix/workspace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset, inifile: /private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_ftumqxgf.ini
plugins: hypothesis-5.15.0, cov-2.8.1, localserver-0.5.0, random-order-1.0.4
collected 15 items / 14 deselected / 1 selected

handler_create.py::contract_create_delete PASSED                                                                                                                                                     [100%]

============================================================================================= warnings summary =============================================================================================
/Volumes/Unix/workspace/rpdk/cloudformation-cli/env/lib/python3.7/site-packages/_pytest/logging.py:499
  /Volumes/Unix/workspace/rpdk/cloudformation-cli/env/lib/python3.7/site-packages/_pytest/logging.py:499: PytestDeprecationWarning: --no-print-logs is deprecated and scheduled for removal in pytest 6.0.
  Please use --show-capture instead.
    _issue_warning_captured(NO_PRINT_LOGS, self._config.hook, stacklevel=2)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============================================================================== 1 passed, 14 deselected, 1 warning in 58.89s ===============================================================================
======================================================================================= test session starts anshikg ========================================================================================
platform darwin -- Python 3.7.2, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- /Volumes/Unix/workspace/rpdk/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Volumes/Unix/workspace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset/.hypothesis/examples')
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /Volumes/Unix/workspace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset, inifile: /private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_4z2blhbl.ini
plugins: hypothesis-5.15.0, cov-2.8.1, localserver-0.5.0, random-order-1.0.4
collected 15 items / 14 deselected / 1 selected

handler_create.py::contract_create_delete PASSED                                                                                                                                                     [100%]

============================================================================================= warnings summary =============================================================================================
/Volumes/Unix/workspace/rpdk/cloudformation-cli/env/lib/python3.7/site-packages/_pytest/logging.py:499
  /Volumes/Unix/workspace/rpdk/cloudformation-cli/env/lib/python3.7/site-packages/_pytest/logging.py:499: PytestDeprecationWarning: --no-print-logs is deprecated and scheduled for removal in pytest 6.0.
  Please use --show-capture instead.
    _issue_warning_captured(NO_PRINT_LOGS, self._config.hook, stacklevel=2)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================== 1 passed, 14 deselected, 1 warning in 69.23s (0:01:09) ==========================================================================
(env) 88e9fe53273b:aws-ses-configurationset anshikg$
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
