### PR TITLE
Remove Callback Context assert for handler success and failure

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -242,9 +242,6 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         assert (
             response.get("callbackDelaySeconds", 0) == 0
         ), "SUCCESS events should have no callback delay"
-        assert (
-            response.get("callbackContext") is None
-        ), "SUCCESS events should not return a callback context"
 
     @staticmethod
     def assert_failed(status, response):
@@ -261,9 +258,6 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         assert (
             response.get("resourceModels") is None
         ), "FAILED events should not include any resource models"
-        assert (
-            response.get("callbackContext") is None
-        ), "FAILED events should not return a callback context"
 
         return error_code
 

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -539,11 +539,6 @@ def test_assert_success_callback_delay_seconds_set():
         )
 
 
-def test_assert_success_callback_context_set():
-    with pytest.raises(AssertionError):
-        ResourceClient.assert_success(OperationStatus.SUCCESS, {"callbackContext": []})
-
-
 @pytest.mark.parametrize(
     "status", [OperationStatus.IN_PROGRESS, OperationStatus.SUCCESS]
 )
@@ -589,14 +584,6 @@ def test_assert_failed_resource_models_set():
         ResourceClient.assert_failed(
             OperationStatus.FAILED,
             {"errorCode": HandlerErrorCode.AccessDenied.value, "resourceModels": []},
-        )
-
-
-def test_assert_failed_callback_context_set():
-    with pytest.raises(AssertionError):
-        ResourceClient.assert_failed(
-            OperationStatus.FAILED,
-            {"errorCode": HandlerErrorCode.AccessDenied.value, "callbackContext": []},
         )
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Contract test assert when handler return Callback context on fail/success handlers. This seems unnecessary. Removing this check from the contract test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
