### PR TITLE
added generic  type for multiple type support

### DIFF
--- a/src/rpdk/core/jsonutils/resolver.py
+++ b/src/rpdk/core/jsonutils/resolver.py
@@ -15,6 +15,7 @@ class ContainerType(Enum):
     DICT = auto()
     LIST = auto()
     SET = auto()
+    MULTIPLE = auto()
 
 
 class ResolvedType:
@@ -27,14 +28,6 @@ class ResolvedType:
 
     def __eq__(self, other):
         return self.container == other.container and self.type == other.type
-
-
-def convert_list_to_object(prop_type):
-    if isinstance(
-        prop_type, list
-    ):  # generate a generic type Object which will be casted on the client side
-        return MULTIPLE
-    return prop_type
 
 
 class ModelResolver:
@@ -113,7 +106,11 @@ class ModelResolver:
             return self._get_array_lang_type(property_schema)
         if schema_type == "object":
             return self._get_object_lang_type(property_schema)
-        return self._get_primitive_lang_type(convert_list_to_object(schema_type))
+        if isinstance(
+            schema_type, list
+        ):  # generate a generic type Object which will be casted on the client side
+            return self._get_multiple_lang_type()
+        return self._get_primitive_lang_type(schema_type)
 
     @staticmethod
     def _get_array_container_type(property_schema):
@@ -124,6 +121,10 @@ class ModelResolver:
         if insertion_order or not unique_items:
             return ContainerType.LIST
         return ContainerType.SET
+
+    @staticmethod
+    def _get_multiple_lang_type():
+        return ResolvedType(ContainerType.MULTIPLE, MULTIPLE)
 
     @staticmethod
     def _get_primitive_lang_type(schema_type):

--- a/src/rpdk/core/jsonutils/resolver.py
+++ b/src/rpdk/core/jsonutils/resolver.py
@@ -6,6 +6,7 @@ from .flattener import JsonSchemaFlattener
 from .utils import BASE, fragment_encode
 
 UNDEFINED = "undefined"
+MULTIPLE = "multiple"
 
 
 class ContainerType(Enum):
@@ -26,6 +27,14 @@ class ResolvedType:
 
     def __eq__(self, other):
         return self.container == other.container and self.type == other.type
+
+
+def convert_list_to_object(prop_type):
+    if isinstance(
+        prop_type, list
+    ):  # generate a generic type Object which will be casted on the client side
+        return MULTIPLE
+    return prop_type
 
 
 class ModelResolver:
@@ -104,7 +113,7 @@ class ModelResolver:
             return self._get_array_lang_type(property_schema)
         if schema_type == "object":
             return self._get_object_lang_type(property_schema)
-        return self._get_primitive_lang_type(schema_type)
+        return self._get_primitive_lang_type(convert_list_to_object(schema_type))
 
     @staticmethod
     def _get_array_container_type(property_schema):

--- a/src/rpdk/core/jsonutils/resolver.py
+++ b/src/rpdk/core/jsonutils/resolver.py
@@ -109,7 +109,7 @@ class ModelResolver:
         if isinstance(
             schema_type, list
         ):  # generate a generic type Object which will be casted on the client side
-            return self._get_multiple_lang_type()
+            return self._get_multiple_lang_type(MULTIPLE)
         return self._get_primitive_lang_type(schema_type)
 
     @staticmethod
@@ -123,8 +123,8 @@ class ModelResolver:
         return ContainerType.SET
 
     @staticmethod
-    def _get_multiple_lang_type():
-        return ResolvedType(ContainerType.MULTIPLE, MULTIPLE)
+    def _get_multiple_lang_type(schema_type):
+        return ResolvedType(ContainerType.MULTIPLE, schema_type)
 
     @staticmethod
     def _get_primitive_lang_type(schema_type):

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -20,7 +20,6 @@ from .exceptions import (
     SpecValidationError,
 )
 from .jsonutils.pointer import fragment_decode, fragment_encode
-from .jsonutils.resolver import MULTIPLE
 from .jsonutils.utils import traverse
 from .plugin_registry import load_plugin
 from .upload import Uploader
@@ -76,9 +75,6 @@ BASIC_TYPE_MAPPINGS = {
     "boolean": "Boolean",
 }
 
-MULTIPLE_TYPE_MAPPINGS = {
-    MULTIPLE: "Object",
-}
 
 MARKDOWN_RESERVED_CHARACTERS = frozenset({"^", "*", "+", ".", "(", "[", "{", "#"})
 
@@ -439,8 +435,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
         prop_type = prop.get("type", "object")
 
         if isinstance(prop_type, list):
-            mapped = MULTIPLE_TYPE_MAPPINGS[MULTIPLE]
-            prop["jsontype"] = prop["yamltype"] = prop["longformtype"] = mapped
+            prop["jsontype"] = prop["yamltype"] = prop["longformtype"] = "Object"
         elif prop_type in BASIC_TYPE_MAPPINGS:
             mapped = BASIC_TYPE_MAPPINGS[prop_type]
             prop["jsontype"] = prop["yamltype"] = prop["longformtype"] = mapped

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -20,6 +20,7 @@ from .exceptions import (
     SpecValidationError,
 )
 from .jsonutils.pointer import fragment_decode, fragment_encode
+from .jsonutils.resolver import MULTIPLE, convert_list_to_object
 from .jsonutils.utils import traverse
 from .plugin_registry import load_plugin
 from .upload import Uploader
@@ -73,6 +74,7 @@ BASIC_TYPE_MAPPINGS = {
     "number": "Double",
     "integer": "Double",
     "boolean": "Boolean",
+    MULTIPLE: "Object",
 }
 
 
@@ -432,7 +434,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
         ):
             prop["readonly"] = True
 
-        prop_type = prop.get("type", "object")
+        prop_type = convert_list_to_object(prop.get("type", "object"))
 
         if prop_type in BASIC_TYPE_MAPPINGS:
             mapped = BASIC_TYPE_MAPPINGS[prop_type]

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -20,7 +20,7 @@ from .exceptions import (
     SpecValidationError,
 )
 from .jsonutils.pointer import fragment_decode, fragment_encode
-from .jsonutils.resolver import MULTIPLE, convert_list_to_object
+from .jsonutils.resolver import MULTIPLE
 from .jsonutils.utils import traverse
 from .plugin_registry import load_plugin
 from .upload import Uploader
@@ -74,9 +74,11 @@ BASIC_TYPE_MAPPINGS = {
     "number": "Double",
     "integer": "Double",
     "boolean": "Boolean",
-    MULTIPLE: "Object",
 }
 
+MULTIPLE_TYPE_MAPPINGS = {
+    MULTIPLE: "Object",
+}
 
 MARKDOWN_RESERVED_CHARACTERS = frozenset({"^", "*", "+", ".", "(", "[", "{", "#"})
 
@@ -434,9 +436,12 @@ class Project:  # pylint: disable=too-many-instance-attributes
         ):
             prop["readonly"] = True
 
-        prop_type = convert_list_to_object(prop.get("type", "object"))
+        prop_type = prop.get("type", "object")
 
-        if prop_type in BASIC_TYPE_MAPPINGS:
+        if isinstance(prop_type, list):
+            mapped = MULTIPLE_TYPE_MAPPINGS[MULTIPLE]
+            prop["jsontype"] = prop["yamltype"] = prop["longformtype"] = mapped
+        elif prop_type in BASIC_TYPE_MAPPINGS:
             mapped = BASIC_TYPE_MAPPINGS[prop_type]
             prop["jsontype"] = prop["yamltype"] = prop["longformtype"] = mapped
         elif prop_type == "array":

--- a/tests/data/schema/valid/valid_pattern_properties.json
+++ b/tests/data/schema/valid/valid_pattern_properties.json
@@ -54,6 +54,12 @@
             "items": {
                 "$ref": "#/definitions/obj2def"
             }
+        },
+        "obj3": {
+            "type": [
+                "object"
+            ],
+            "description": ""
         }
     },
     "primaryIdentifier": [

--- a/tests/jsonutils/test_resolver.py
+++ b/tests/jsonutils/test_resolver.py
@@ -196,3 +196,10 @@ def test_modelresolver__schema_to_lang_type_primitive():
     resolved_type = resolver._schema_to_lang_type({"type": "string"})
     assert resolved_type.container == ContainerType.PRIMITIVE
     assert resolved_type.type == "string"
+
+
+def test_modelresolver__schema_to_lang_type_primitive_object():
+    resolver = ModelResolver({})
+    resolved_type = resolver._schema_to_lang_type({"type": ["string"]})
+    assert resolved_type.container == ContainerType.PRIMITIVE
+    assert resolved_type.type == "multiple"

--- a/tests/jsonutils/test_resolver.py
+++ b/tests/jsonutils/test_resolver.py
@@ -198,8 +198,8 @@ def test_modelresolver__schema_to_lang_type_primitive():
     assert resolved_type.type == "string"
 
 
-def test_modelresolver__schema_to_lang_type_primitive_object():
+def test_modelresolver__schema_to_lang_type_multiple():
     resolver = ModelResolver({})
     resolved_type = resolver._schema_to_lang_type({"type": ["string"]})
-    assert resolved_type.container == ContainerType.PRIMITIVE
+    assert resolved_type.container == ContainerType.MULTIPLE
     assert resolved_type.type == "multiple"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

added a generic type for multi type support. 

Example:

```json
"properties": {
    "property1": {
        "type": ["string", "object"]
    }
}
```
generated `ResourceModel.java`:
```java
@JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
public class ResourceModel {
    @JsonProperty("property1")
    private Object property1;
    ...
```

test cases:
* 1  [CREATE] with escaped string `property1` -> [UPDATE] with modified escaped string `property1`
* 2 [CREATE] with escaped string `property1` -> [UPDATE] with json object `property1` 
* 3 [CREATE] with json object `property1` -> [UPDATE] with modified json `property1`
* 4 [CREATE] with list input for `property1` -> Failed with error `Model validation failed (#/property1: #: no subschema matched out of the total 2 subschemas) #/property1: expected type: JSONObject, found: JSONArray (#/property1) #/property1: expected type: String, found: JSONArray (#/property1)` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
