### PR TITLE
Assert CRUDL timeout for all Progress Events

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -341,9 +341,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             raise ValueError("Assert status {} not supported.".format(assert_status))
         request = self.make_request(current_model, previous_model, **kwargs)
 
-        start_time = time.time()
         status, response = self.call(action, request)
-        self.assert_time(start_time, time.time(), action)
         if assert_status == OperationStatus.SUCCESS:
             self.assert_success(status, response)
             error_code = None
@@ -353,7 +351,9 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
 
     def call(self, action, request):
         payload = self._make_payload(action, request)
+        start_time = time.time()
         response = self._call(payload)
+        self.assert_time(start_time, time.time(), action)
 
         # this throws a KeyError if status isn't present, or if it isn't a valid status
         status = OperationStatus[response["status"]]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* It seems contract test expect Create, Update and Delete handlers to complete in 60 seconds. This is not possible for most resources. Therefore, changing the handler assert to assert when a Progress Event is returned. This includes Success, Failure and InProgress. This also in aligned with the handler contracts: 
```
A create handler MUST always return a ProgressEvent object within 60 seconds. For more information, see ProgressEvent Object Schema.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
