### PR TITLE
Assert on created/updated model

### DIFF
--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -10,9 +10,9 @@ def test_create_success(resource_client, current_resource_model):
         Action.CREATE, OperationStatus.SUCCESS, current_resource_model
     )
     resource_client.assert_primary_identifier(
-        resource_client.primary_identifier_paths, current_resource_model
+        resource_client.primary_identifier_paths, response["resourceModel"]
     )
-    resource_client.assert_write_only_property_does_not_exist(current_resource_model)
+    resource_client.assert_write_only_property_does_not_exist(response["resourceModel"])
     return response
 
 
@@ -41,9 +41,9 @@ def test_read_success(resource_client, current_resource_model):
     )
     assert response["resourceModel"] == current_resource_model
     resource_client.assert_primary_identifier(
-        resource_client.primary_identifier_paths, current_resource_model
+        resource_client.primary_identifier_paths, response["resourceModel"]
     )
-    resource_client.assert_write_only_property_does_not_exist(current_resource_model)
+    resource_client.assert_write_only_property_does_not_exist(response["resourceModel"])
     return response
 
 
@@ -88,7 +88,7 @@ def test_update_success(resource_client, update_model, current_model):
     _status, response, _error_code = resource_client.call_and_assert(
         Action.UPDATE, OperationStatus.SUCCESS, update_model, current_model
     )
-    resource_client.assert_write_only_property_does_not_exist(update_model)
+    resource_client.assert_write_only_property_does_not_exist(response["resourceModel"])
     # The response model should be the same as the create output model,
     # except the update-able properties should be overridden.
     assert response["resourceModel"] == {**current_model, **update_model}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/cloudformation-cli/issues/462

*Description of changes:* This change ensures the assert for primary identifier and writeOnly property is made on returned resourceModel

*Test:*

1. pre-commit run --all-files

2. cfn test for ses-configurationset

```
======================================================================================= test session starts anshikg ========================================================================================
platform darwin -- Python 3.7.2, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- /Volumes/Unix/workspace/rpdk/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Volumes/Unix/workspace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset/.hypothesis/examples')
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /Volumes/Unix/workspace/aws-cloudformation-resource-providers-ses/aws-ses-configurationset, inifile: /private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_d4n0qyxw.ini
plugins: hypothesis-5.15.0, cov-2.8.1, localserver-0.5.0, random-order-1.0.4
collected 15 items / 5 deselected / 10 selected

handler_create.py::contract_create_delete PASSED                                                                                                                                                     [ 10%]
handler_create.py::contract_invalid_create SKIPPED                                                                                                                                                   [ 20%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                  [ 30%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                               [ 40%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                               [ 50%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                       [ 60%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                       [ 70%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                     [ 80%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                     [ 90%]
handler_misc.py::contract_check_asserts_work PASSED
``` 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
