### PR TITLE
Switch Update Test Execution Order [Workaround]

### DIFF
--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -33,30 +33,6 @@ def updated_resource(resource_client):
 
 
 @pytest.mark.update
-@pytest.mark.read
-def contract_update_read_success(updated_resource, resource_client):
-    # should be able to use the created model
-    # to read since physical resource id is immutable
-    _create_request, _created_model, _update_request, updated_model = updated_resource
-    assert resource_client.is_primary_identifier_equal(
-        resource_client.primary_identifier_paths, _created_model, updated_model
-    )
-    test_read_success(resource_client, updated_model)
-
-
-@pytest.mark.update
-@pytest.mark.list
-def contract_update_list_success(updated_resource, resource_client):
-    # should be able to use the created model
-    # to read since physical resource id is immutable
-    _create_request, _created_model, _update_request, updated_model = updated_resource
-    assert resource_client.is_primary_identifier_equal(
-        resource_client.primary_identifier_paths, _created_model, updated_model
-    )
-    assert test_model_in_list(resource_client, updated_model)
-
-
-@pytest.mark.update
 def contract_update_create_only_property(resource_client):
 
     if resource_client.create_only_paths:
@@ -95,3 +71,27 @@ def contract_update_non_existent_resource(resource_client):
     assert (
         _error == HandlerErrorCode.NotFound
     ), "cannot update a resource which does not exist"
+
+
+@pytest.mark.update
+@pytest.mark.read
+def contract_update_read_success(updated_resource, resource_client):
+    # should be able to use the created model
+    # to read since physical resource id is immutable
+    _create_request, _created_model, _update_request, updated_model = updated_resource
+    assert resource_client.is_primary_identifier_equal(
+        resource_client.primary_identifier_paths, _created_model, updated_model
+    )
+    test_read_success(resource_client, updated_model)
+
+
+@pytest.mark.update
+@pytest.mark.list
+def contract_update_list_success(updated_resource, resource_client):
+    # should be able to use the created model
+    # to read since physical resource id is immutable
+    _create_request, _created_model, _update_request, updated_model = updated_resource
+    assert resource_client.is_primary_identifier_equal(
+        resource_client.primary_identifier_paths, _created_model, updated_model
+    )
+    assert test_model_in_list(resource_client, updated_model)


### PR DESCRIPTION
*Issue #, if available:*
It seems that`contract_update_create_only_property` performs poorly when you have an overrides file that is overriding an `additionalIdentifiers` property due to https://github.com/aws-cloudformation/cloudformation-cli/blame/0cceffd8d308d6a6c6b3b419191b3ec972f2dfe2/src/rpdk/core/contract/suite/handler_update.py#L63-L67

Here is what I am experiencing:
1. `updated_resource` fixture calls create handler with `coProp/addIdProp=A` (from overrides file) and **passes** with `roProp/priIdProp=1`.
2. `updated_resource` fixture calls update handler with `roProp/priIdProp=1` and **passes**.
3. other update tests run against `roProp/priIdProp=1` and **pass**.
3. contract_update_create_only_property test calls create handler with `coProp/addIdProp=A` (from overrides file) and **fails** with `error=AlreadyExists`.

I am not sure if this is a failure of the contact test, lacking a custom fixture for this contract test, or a failure of the overrides systems we currently have. I would like to get some feedback of how we should handle this case better.

*Description of changes:*
Unfortunately this PR is more of a workaround and not really a great solution to the root cause, but effectively if we just change the test execution order such that we run contract tests that **do not** use the update test fixture, then we can ensure that we will not have a pre-created resource in the way of our test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
