### PR TITLE
added docgen for multi typed properties

### DIFF
--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -462,7 +462,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
                 return item2
             return "{}, {}".format(item1, item2)
 
-        def __set_property_type(prop_type):
+        def __set_property_type(prop_type, single_type=True):
             nonlocal prop
             type_json = type_yaml = type_longform = "Unknown"
             if prop_type in BASIC_TYPE_MAPPINGS:
@@ -472,7 +472,11 @@ class Project:  # pylint: disable=too-many-instance-attributes
                     propname, prop["items"], proppath
                 )
                 type_json = f'[ {arrayitems["jsontype"]}, ... ]'
-                type_yaml = f'\n      - {arrayitems["yamltype"]}'
+                type_yaml = (
+                    f'\n      - {arrayitems["yamltype"]}'
+                    if single_type
+                    else f'[ {arrayitems["yamltype"]}, ... ]'
+                )
                 type_longform = f'List of {arrayitems["longformtype"]}'
             elif prop_type == "object":
                 template = self.env.get_template("docs-subproperty.md")
@@ -518,11 +522,13 @@ class Project:  # pylint: disable=too-many-instance-attributes
 
         prop_type = prop.get("type", "object")
 
+        single_item = False
         if not isinstance(prop_type, list):
             prop_type = [prop_type]
+            single_item = True
 
         for prop_item in prop_type:
-            __set_property_type(prop_item)
+            __set_property_type(prop_item, single_type=single_item)
 
         return prop
 

--- a/tests/data/schema/target_output/multityped.md
+++ b/tests/data/schema/target_output/multityped.md
@@ -1,0 +1,74 @@
+# AWS::Color::Red
+
+a test schema
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "Type" : "AWS::Color::Red",
+    "Properties" : {
+        "<a href="#property1" title="property1">property1</a>" : <i>String, Double, Map, [ <a href="obj2def.md">obj2def</a>, ... ]</i>,
+        "<a href="#obj1" title="obj1">obj1</a>" : <i><a href="obj2def.md">obj2def</a></i>,
+        "<a href="#arr1" title="arr1">arr1</a>" : <i>[ <a href="obj2def.md">obj2def</a>, ... ]</i>
+    }
+}
+</pre>
+
+### YAML
+
+<pre>
+Type: AWS::Color::Red
+Properties:
+    <a href="#property1" title="property1">property1</a>: <i>String, Double, Map,
+      - <a href="obj2def.md">obj2def</a></i>
+    <a href="#obj1" title="obj1">obj1</a>: <i><a href="obj2def.md">obj2def</a></i>
+    <a href="#arr1" title="arr1">arr1</a>: <i>
+      - <a href="obj2def.md">obj2def</a></i>
+</pre>
+
+## Properties
+
+#### property1
+
+some description
+
+_Required_: No
+
+_Type_: String, Double, Map, List of <a href="obj2def.md">obj2def</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### obj1
+
+_Required_: No
+
+_Type_: <a href="obj2def.md">obj2def</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### arr1
+
+_Required_: No
+
+_Type_: List of <a href="obj2def.md">obj2def</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+## Return Values
+
+### Ref
+
+When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the enum1.
+
+### Fn::GetAtt
+
+The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type. The following are the available attributes and sample return values.
+
+For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
+
+#### str3

--- a/tests/data/schema/target_output/multityped.md
+++ b/tests/data/schema/target_output/multityped.md
@@ -24,8 +24,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 Type: AWS::Color::Red
 Properties:
-    <a href="#property1" title="property1">property1</a>: <i>String, Double, Map,
-      - <a href="obj2def.md">obj2def</a></i>
+    <a href="#property1" title="property1">property1</a>: <i>String, Double, Map, [ <a href="obj2def.md">obj2def</a>, ... ]</i>
     <a href="#obj1" title="obj1">obj1</a>: <i><a href="obj2def.md">obj2def</a></i>
     <a href="#arr1" title="arr1">arr1</a>: <i>
       - <a href="obj2def.md">obj2def</a></i>

--- a/tests/data/schema/valid/valid_multityped_property.json
+++ b/tests/data/schema/valid/valid_multityped_property.json
@@ -1,0 +1,76 @@
+{
+    "typeName": "AWS::Valid::TypeName",
+    "description": "a test schema",
+    "definitions": {
+        "obj2def": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "str1": {
+                    "type": "string",
+                    "minLength": 2
+                }
+            }
+        }
+    },
+    "properties": {
+        "property1": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "object"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/obj2def"
+                    }
+                }
+            ],
+            "description": "some description"
+        },
+        "obj1": {
+            "type": "object",
+            "description": "",
+            "$ref": "#/definitions/obj2def"
+        },
+        "str3": {
+            "type": "string",
+            "description": ""
+        },
+        "arr1": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "$ref": "#/definitions/obj2def"
+            }
+        }
+    },
+    "primaryIdentifier": [
+        "/properties/enum1"
+    ],
+    "readOnlyProperties": [
+        "/properties/str3"
+    ],
+    "additionalIdentifiers": [
+        [
+            "/properties/enum1",
+            "/properties/str2"
+        ],
+        [
+            "/properties/obj1/obj2/str1"
+        ],
+        [
+            "/properties/str2"
+        ]
+    ],
+    "createOnlyProperties": [
+        "/properties/str2"
+    ],
+    "additionalProperties": false
+}

--- a/tests/data/schema/valid/valid_type_complex.json
+++ b/tests/data/schema/valid/valid_type_complex.json
@@ -22,7 +22,14 @@
             ]
         },
         "str2": {
-            "type": "string",
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ],
             "description": "some description"
         },
         "obj1": {

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -187,7 +187,7 @@ def test_safewrite_exists(project, tmpdir, caplog):
         project.safewrite(path, CONTENTS_UTF8)
 
     last_record = caplog.records[-1]
-    assert last_record.levelname == "WARNING"
+    assert last_record.levelname == "INFO"
     assert str(path) in last_record.message
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -14,7 +14,7 @@ import pytest
 import yaml
 from botocore.exceptions import ClientError, WaiterError
 
-from rpdk.core.data_loaders import resource_json
+from rpdk.core.data_loaders import resource_json, resource_stream
 from rpdk.core.exceptions import (
     DownstreamError,
     InternalError,
@@ -247,6 +247,40 @@ def test_generate_with_docs(project, tmp_path_factory, schema_path, path):
         project.generate_docs()
     readme_contents = readme_file.read_text(encoding="utf-8")
     assert project.type_name in readme_contents
+
+
+def test_generate_docs_with_multityped_property(project, tmp_path_factory):
+    project.schema = resource_json(
+        __name__, "data/schema/valid/valid_multityped_property.json"
+    )
+
+    project.type_name = "AWS::Color::Red"
+    # tmpdir conflicts with other tests, make a unique one
+    project.root = tmp_path_factory.mktemp("generate_with_docs_type_complex")
+    mock_plugin = MagicMock(spec=["generate"])
+    with patch.object(project, "_plugin", mock_plugin):
+        project.generate()
+        project.generate_docs()
+    mock_plugin.generate.assert_called_once_with(project)
+
+    docs_dir = project.root / "docs"
+    readme_file = project.root / "docs" / "README.md"
+
+    assert docs_dir.is_dir()
+    assert readme_file.is_file()
+    with patch.object(project, "_plugin", mock_plugin):
+        project.generate()
+        project.generate_docs()
+    readme_contents = readme_file.read_text(encoding="utf-8")
+    readme_contents_target = resource_stream(
+        __name__, "data/schema/target_output/multityped.md"
+    )
+
+    read_me_stripped = readme_contents.strip().replace(" ", "")
+    read_me_target_stripped = readme_contents_target.read().strip().replace(" ", "")
+
+    assert project.type_name in readme_contents
+    assert read_me_stripped == read_me_target_stripped
 
 
 def test_generate_with_docs_invalid_property_type(project, tmp_path_factory):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

enhanced docgen for multityped properties:
### additions:
* using flattened schema to generalize [`allOf`, `anyOf`, `oneOf`]

e.g
following structure:
```
{
    ...
    "properties": {
        "Property1": {
            "oneOf": [
                 {
                     "type": "string"
                 },
                 {
                     "type": "object"
                 },
                 {
                     "type": "boolean"
                 },
                 {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/CustomObject"
                     }
                }
            ]
        }
    }
}
```
will result in:
```md
{
    "Type" : "AMZN::SAMPLE::RESOURCE",
    "Properties" : {
        ...
        "Property1" : String, Map, Boolean, [ CustomObject, ... ],
    }
}
```

------------------------
### changes:
* `propname` and `proppath` are tied to the `$ref` type, which helps now use the correct name

e.g.
following structure:
```json
{
    ...
    "definitions": {
        "Tag": { ... }
    },
    ...
    "properties": {
        "Tags": {
            "type": "array",
            "items": {
                "$ref": "#/definitions/Tag"
            }
        }
    }
}
```
would result in:
```
Tags: [ Tags, ... ]
```
with the change it will result in:
```
Tags: [ Tag, ... ]
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
