### PR TITLE
Fixed contract test check on writeOnlyProperties redaction

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -367,7 +367,6 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             self.assert_primary_identifier(
                 self.primary_identifier_paths, response.get("resourceModel")
             )
-            self.assert_write_only_property_does_not_exist(response["resourceModel"])
             sleep(callback_delay_seconds)
 
             request["desiredResourceState"] = response.get("resourceModel")
@@ -376,6 +375,10 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
 
             response = self._call(payload)
             status = OperationStatus[response["status"]]
+
+        # ensure writeOnlyProperties are not returned on final responses
+        if "resourceModel" in response.keys():
+            self.assert_write_only_property_does_not_exist(response["resourceModel"])
 
         return status, response
 

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -476,6 +476,23 @@ def test_call_async(resource_client, action):
     assert response == {"status": OperationStatus.SUCCESS.value}
 
 
+@pytest.mark.parametrize("action", [Action.CREATE, Action.UPDATE, Action.DELETE])
+def test_call_async_write_only_properties_are_removed(resource_client, action):
+    mock_client = resource_client._client
+
+    mock_client.invoke.side_effect = [
+        {
+            "Payload": StringIO(
+                '{"status": "SUCCESS", "resourceModel": {"c": 3, "d": 4} }'
+            )
+        }
+    ]
+
+    resource_client._update_schema(SCHEMA)
+    with pytest.raises(AssertionError):
+        resource_client.call(action, {})
+
+
 def test_call_and_assert_success(resource_client):
     mock_client = resource_client._client
     mock_client.invoke.return_value = {"Payload": StringIO('{"status": "SUCCESS"}')}

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -493,6 +493,25 @@ def test_call_async_write_only_properties_are_removed(resource_client, action):
         resource_client.call(action, {})
 
 
+@pytest.mark.parametrize("action", [Action.CREATE, Action.UPDATE, Action.DELETE])
+def test_call_async_write_only_properties_are_not_removed_for_in_progress(
+    resource_client, action
+):
+    mock_client = resource_client._client
+
+    mock_client.invoke.side_effect = [
+        {
+            "Payload": StringIO(
+                '{"status": "IN_PROGRESS", "resourceModel": {"c": 3, "d": 4} }'
+            )
+        },
+        {"Payload": StringIO('{"status": "SUCCESS"}')},
+    ]
+
+    resource_client._update_schema(SCHEMA)
+    resource_client.call(action, {})
+
+
 def test_call_and_assert_success(resource_client):
     mock_client = resource_client._client
     mock_client.invoke.return_value = {"Payload": StringIO('{"status": "SUCCESS"}')}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Contract test was asserting that writeOnlyProperties are not returned on an IN_PROGRESS result which is problematic, as many resources need writeOnlyProperties to exist on the resource through re-invocation or stabilization checks. The redaction assert is only needed on the final result from a SUCCESS or FAILED response.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
