### PR TITLE
Add Enforce timeout tag to increase timeout for handler for local tes…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To run the contract tests, use the `test` command.
 ```bash
 cfn test
 cfn test -- -k contract_delete_update #to run a single test
+cfn test --enforce-timeout 60 #set the RL handler timeout to 60 seconds and CUD handler timeout to 120 seconds.
 ```
 
 

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -78,6 +78,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         overrides,
         inputs=None,
         role_arn=None,
+        timeout_in_seconds=None,
     ):  # pylint: disable=too-many-arguments
         self._schema = schema
         self._session = create_sdk_session(region)
@@ -109,6 +110,9 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         self._overrides = overrides
         self._update_schema(schema)
         self._inputs = inputs
+        self._timeout_in_seconds = (
+            30 if timeout_in_seconds is None else int(timeout_in_seconds)
+        )
 
     def _properties_to_paths(self, key):
         return {fragment_decode(prop, prefix="") for prop in self._schema.get(key, [])}
@@ -290,9 +294,12 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
     def generate_token():
         return str(uuid4())
 
-    @staticmethod
-    def assert_time(start_time, end_time, action):
-        timeout_in_seconds = 30 if action in (Action.READ, Action.LIST) else 60
+    def assert_time(self, start_time, end_time, action):
+        timeout_in_seconds = (
+            self._timeout_in_seconds
+            if action in (Action.READ, Action.LIST)
+            else self._timeout_in_seconds * 2
+        )
         assert end_time - start_time <= timeout_in_seconds, (
             "Handler %r timed out." % action
         )

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -78,7 +78,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         overrides,
         inputs=None,
         role_arn=None,
-        timeout_in_seconds=None,
+        timeout_in_seconds="30",
     ):  # pylint: disable=too-many-arguments
         self._schema = schema
         self._session = create_sdk_session(region)
@@ -110,9 +110,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         self._overrides = overrides
         self._update_schema(schema)
         self._inputs = inputs
-        self._timeout_in_seconds = (
-            30 if timeout_in_seconds is None else int(timeout_in_seconds)
-        )
+        self._timeout_in_seconds = int(timeout_in_seconds)
 
     def _properties_to_paths(self, key):
         return {fragment_decode(prop, prefix="") for prop in self._schema.get(key, [])}

--- a/src/rpdk/core/test.py
+++ b/src/rpdk/core/test.py
@@ -30,6 +30,7 @@ LOG = logging.getLogger(__name__)
 DEFAULT_ENDPOINT = "http://127.0.0.1:3001"
 DEFAULT_FUNCTION = "TestEntrypoint"
 DEFAULT_REGION = "us-east-1"
+DEFAULT_TIMEOUT = "30"
 INPUTS = "inputs"
 
 OVERRIDES_VALIDATOR = Draft6Validator(
@@ -234,7 +235,9 @@ def setup_subparser(subparsers, parents):
     )
 
     parser.add_argument(
-        "--enforce-timeout", help="Enforce a different timeout for handlers"
+        "--enforce-timeout",
+        default=DEFAULT_TIMEOUT,
+        help="Enforce a different timeout for handlers",
     )
 
     parser.add_argument("passed_to_pytest", nargs="*", help=SUPPRESS)

--- a/src/rpdk/core/test.py
+++ b/src/rpdk/core/test.py
@@ -201,6 +201,7 @@ def invoke_test(args, project, overrides, inputs):
             overrides,
             inputs,
             args.role_arn,
+            args.enforce_timeout,
         )
     )
 
@@ -230,6 +231,10 @@ def setup_subparser(subparsers, parents):
 
     parser.add_argument(
         "--cloudformation-endpoint-url", help="CloudFormation endpoint to use."
+    )
+
+    parser.add_argument(
+        "--enforce-timeout", help="Enforce a different timeout for handlers"
     )
 
     parser.add_argument("passed_to_pytest", nargs="*", help=SUPPRESS)

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -68,18 +68,22 @@ def create_invalid_input_file(base):
 @pytest.mark.parametrize(
     "args_in,pytest_args,plugin_args",
     [
-        ([], [], [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, DEFAULT_REGION]),
-        (["--endpoint", "foo"], [], [DEFAULT_FUNCTION, "foo", DEFAULT_REGION]),
-        (["--function-name", "bar"], [], ["bar", DEFAULT_ENDPOINT, DEFAULT_REGION]),
+        ([], [], [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, DEFAULT_REGION, None]),
+        (["--endpoint", "foo"], [], [DEFAULT_FUNCTION, "foo", DEFAULT_REGION, None]),
+        (
+            ["--function-name", "bar", "--enforce-timeout", "60"],
+            [],
+            ["bar", DEFAULT_ENDPOINT, DEFAULT_REGION, "60"],
+        ),
         (
             ["--", "-k", "create"],
             ["-k", "create"],
-            [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, DEFAULT_REGION],
+            [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, DEFAULT_REGION, None],
         ),
         (
             ["--region", "us-west-2", "--", "--collect-only"],
             ["--collect-only"],
-            [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, "us-west-2"],
+            [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, "us-west-2", None],
         ),
     ],
 )
@@ -110,7 +114,7 @@ def test_test_command_happy_path(
     # fmt: on
 
     mock_project.load.assert_called_once_with()
-    function_name, endpoint, region = plugin_args
+    function_name, endpoint, region, enforce_timeout = plugin_args
     mock_client.assert_called_once_with(
         function_name,
         endpoint,
@@ -119,6 +123,7 @@ def test_test_command_happy_path(
         EMPTY_OVERRIDE,
         {"CREATE": {"a": 1}, "UPDATE": {"a": 2}, "INVALID": {"b": 1}},
         None,
+        enforce_timeout,
     )
     mock_plugin.assert_called_once_with(mock_client.return_value)
     mock_ini.assert_called_once_with()

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -68,8 +68,8 @@ def create_invalid_input_file(base):
 @pytest.mark.parametrize(
     "args_in,pytest_args,plugin_args",
     [
-        ([], [], [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, DEFAULT_REGION, None]),
-        (["--endpoint", "foo"], [], [DEFAULT_FUNCTION, "foo", DEFAULT_REGION, None]),
+        ([], [], [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, DEFAULT_REGION, "30"]),
+        (["--endpoint", "foo"], [], [DEFAULT_FUNCTION, "foo", DEFAULT_REGION, "30"]),
         (
             ["--function-name", "bar", "--enforce-timeout", "60"],
             [],
@@ -78,12 +78,12 @@ def create_invalid_input_file(base):
         (
             ["--", "-k", "create"],
             ["-k", "create"],
-            [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, DEFAULT_REGION, None],
+            [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, DEFAULT_REGION, "30"],
         ),
         (
             ["--region", "us-west-2", "--", "--collect-only"],
             ["--collect-only"],
-            [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, "us-west-2", None],
+            [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, "us-west-2", "30"],
         ),
     ],
 )


### PR DESCRIPTION
…ting

*Issue #, if available:*https://github.com/aws-cloudformation/cloudformation-cli/issues/481

*Description of changes:* Adding an additional tag to allow customers to add timeout in order to increase the timeout asserts for handlers when running contract test locally. By default the timeout for CDU handlers is 60 seconds and for RL handler is 30 seconds. 

for the following command: cfn test --enforce-timeout 120 -- -k contract_create_delete
the timeout for RL handler is 120 seconds and CDU handler is 240 seconds.

*Test:*
* built the code locally: pre-commit run --all-files
* ran contract test for : aws-ses-configurationset resource 
```
 cfn test --enforce-timeout 120 -- -k contract_create_delete 
```

```
(env) 88e9fe53273b:aws-ses-configurationset anshikg$ cfn test --enforce-timeout 120 -- -k contract_create_delete
============================================================================================================================= test session starts ==============================================================================================================================
platform darwin -- Python 3.7.2, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /Volumes/Unix/workspace/rpdk/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Volumes/Unix/workspace/rpdk/aws-cloudformation-resource-providers-ses/aws-ses-configurationset/.hypothesis/examples')
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
rootdir: /Volumes/Unix/workspace/rpdk/aws-cloudformation-resource-providers-ses/aws-ses-configurationset, inifile: /private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_quccp96l.ini
plugins: hypothesis-5.19.0, cov-2.10.0, localserver-0.5.0, random-order-1.0.4
collected 15 items / 14 deselected / 1 selected

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                                         [100%]

=========================================================================================================== 1 passed, 14 deselected, 2 warnings in 90.56s (0:01:30) ============================================================================================================
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
