### PR TITLE
Removed empty model assert in contract tests

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -269,9 +269,6 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             response.get("callbackDelaySeconds", 0) == 0
         ), "FAILED events should have no callback delay"
         assert (
-            response.get("resourceModel") is None
-        ), "FAILED events should not include a resource model"
-        assert (
             response.get("resourceModels") is None
         ), "FAILED events should not include any resource models"
 

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -638,17 +638,6 @@ def test_assert_failed_callback_delay_seconds_set():
         )
 
 
-def test_assert_failed_resource_model_set():
-    with pytest.raises(AssertionError):
-        ResourceClient.assert_failed(
-            OperationStatus.FAILED,
-            {
-                "errorCode": HandlerErrorCode.AccessDenied.value,
-                "resourceModel": {"a": 1},
-            },
-        )
-
-
 def test_assert_failed_resource_models_set():
     with pytest.raises(AssertionError):
         ResourceClient.assert_failed(


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* 

Removed an assert requiring that ProgressEvent results with a status of FAILED should not include a ResourceModel.

This requirement is not actually part of the handler contract: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test-contract.html and was likely added to ensure consistency on this result as the model is strictly ignored in this case.

However, given this is not a documented part of the contract and there are no adverse outcomes from including a model in FAILED events, the test is an impediment and not a protection.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
