### PR TITLE
Update pytest log printing option

### DIFF
--- a/src/rpdk/core/data/pytest-contract.ini
+++ b/src/rpdk/core/data/pytest-contract.ini
@@ -2,7 +2,7 @@
 addopts =
     --pyargs "rpdk.core.contract.suite"
     --verbose
-    --no-print-logs
+    --show-capture no
 python_files = handler_*.py
 python_functions = contract_*
 markers =


### PR DESCRIPTION
*Issue #, if available:*
The following warning is generated when running `cfn test`:
```
================================================================= warnings summary ==================================================================
.venv/lib/python3.7/site-packages/_pytest/logging.py:499
  .venv/lib/python3.7/site-packages/_pytest/logging.py:499: PytestDeprecationWarning: --no-print-logs is deprecated and scheduled for removal in pytest 6.0.
  Please use --show-capture instead.
    _issue_warning_captured(NO_PRINT_LOGS, self._config.hook, stacklevel=2)
```

*Description of changes:*
Migrate to new pytest option to resolve warning.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
