### PR TITLE
Add read without create test, add error code to update handler

### DIFF
--- a/src/rpdk/core/contract/suite/handler_read.py
+++ b/src/rpdk/core/contract/suite/handler_read.py
@@ -1,0 +1,14 @@
+# fixture and parameter have the same name
+# pylint: disable=redefined-outer-name
+
+import pytest
+
+# WARNING: contract tests should use fully qualified imports to avoid issues
+# when being loaded by pytest
+from rpdk.core.contract.suite.handler_commons import test_read_failure_not_found
+
+
+@pytest.mark.read
+def contract_read_without_create(resource_client):
+    model = resource_client.generate_create_example()
+    test_read_failure_not_found(resource_client, model)

--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -71,8 +71,9 @@ def contract_update_create_only_property(resource_client):
                 Action.UPDATE, OperationStatus.FAILED, update_request, created_model
             )
             assert response["message"]
-            assert (
-                _error == HandlerErrorCode.NotUpdatable
+            assert _error in (
+                HandlerErrorCode.NotUpdatable,
+                HandlerErrorCode.NotFound,
             ), "updating readOnly or createOnly properties should not be possible"
         finally:
             resource_client.call_and_assert(


### PR DESCRIPTION
*Issue #, if available:*https://github.com/aws-cloudformation/cloudformation-cli/issues/494

*Description of changes:* 
* Adding a test case to check if read fails when no resource was created.
* **contract_update_create_only_property**  fails with Not_Found error code in resources where createOnly property is also the primary Identifier. Therefore asserting for either error codes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
