### PR TITLE
Fix the fixture scope for update handler

### DIFF
--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -5,14 +5,14 @@ import pytest
 
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
-from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
+from rpdk.core.contract.interface import Action, OperationStatus
 from rpdk.core.contract.suite.handler_commons import (
     test_model_in_list,
     test_read_success,
 )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="module")
 def updated_resource(resource_client):
     create_request = model = resource_client.generate_create_example()
     try:
@@ -52,45 +52,3 @@ def contract_update_list_success(updated_resource, resource_client):
         resource_client.primary_identifier_paths, _created_model, updated_model
     )
     assert test_model_in_list(resource_client, updated_model)
-
-
-@pytest.mark.update
-def contract_update_create_only_property(resource_client):
-
-    if resource_client.create_only_paths:
-        create_request = resource_client.generate_create_example()
-        try:
-            _status, response, _error = resource_client.call_and_assert(
-                Action.CREATE, OperationStatus.SUCCESS, create_request
-            )
-            created_model = response["resourceModel"]
-            update_request = resource_client.generate_invalid_update_example(
-                created_model
-            )
-            _status, response, _error = resource_client.call_and_assert(
-                Action.UPDATE, OperationStatus.FAILED, update_request, created_model
-            )
-            assert response["message"]
-            assert _error in (
-                HandlerErrorCode.NotUpdatable,
-                HandlerErrorCode.NotFound,
-            ), "updating readOnly or createOnly properties should not be possible"
-        finally:
-            resource_client.call_and_assert(
-                Action.DELETE, OperationStatus.SUCCESS, created_model
-            )
-    else:
-        pytest.skip("No createOnly Properties. Skipping test.")
-
-
-@pytest.mark.update
-def contract_update_non_existent_resource(resource_client):
-    create_request = resource_client.generate_create_example()
-    update_request = resource_client.generate_update_example(create_request)
-    _status, response, _error = resource_client.call_and_assert(
-        Action.UPDATE, OperationStatus.FAILED, update_request, create_request
-    )
-    assert response["message"]
-    assert (
-        _error == HandlerErrorCode.NotFound
-    ), "cannot update a resource which does not exist"

--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -12,7 +12,7 @@ from rpdk.core.contract.suite.handler_commons import (
 )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def updated_resource(resource_client):
     create_request = model = resource_client.generate_create_example()
     try:

--- a/src/rpdk/core/contract/suite/handler_update_invalid.py
+++ b/src/rpdk/core/contract/suite/handler_update_invalid.py
@@ -1,0 +1,49 @@
+# fixture and parameter have the same name
+# pylint: disable=redefined-outer-name
+
+import pytest
+
+# WARNING: contract tests should use fully qualified imports to avoid issues
+# when being loaded by pytest
+from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
+
+
+@pytest.mark.update
+def contract_update_create_only_property(resource_client):
+
+    if resource_client.create_only_paths:
+        create_request = resource_client.generate_create_example()
+        try:
+            _status, response, _error = resource_client.call_and_assert(
+                Action.CREATE, OperationStatus.SUCCESS, create_request
+            )
+            created_model = response["resourceModel"]
+            update_request = resource_client.generate_invalid_update_example(
+                created_model
+            )
+            _status, response, _error = resource_client.call_and_assert(
+                Action.UPDATE, OperationStatus.FAILED, update_request, created_model
+            )
+            assert response["message"]
+            assert (
+                _error == HandlerErrorCode.NotUpdatable
+            ), "updating readOnly or createOnly properties should not be possible"
+        finally:
+            resource_client.call_and_assert(
+                Action.DELETE, OperationStatus.SUCCESS, created_model
+            )
+    else:
+        pytest.skip("No createOnly Properties. Skipping test.")
+
+
+@pytest.mark.update
+def contract_update_non_existent_resource(resource_client):
+    create_request = resource_client.generate_create_example()
+    update_request = resource_client.generate_update_example(create_request)
+    _status, response, _error = resource_client.call_and_assert(
+        Action.UPDATE, OperationStatus.FAILED, update_request, create_request
+    )
+    assert response["message"]
+    assert (
+        _error == HandlerErrorCode.NotFound
+    ), "cannot update a resource which does not exist"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/cloudformation-cli/issues/488

*Description of changes:*
fixtures for update handler test need to run for functions which need the create and update common model/request

* Test:*
* Ran test for elasticloadbalancing::loadbalancer
```
==================================================================================================================== test session starts =====================================================================================================================
platform darwin -- Python 3.8.4, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/rpdk/aws-cloudformation-resource-providers-elasticloadbalancing/aws-elasticloadbalancing-loadbalancer/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/rpdk/aws-cloudformation-resource-providers-elasticloadbalancing/aws-elasticloadbalancing-loadbalancer, inifile: /private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_ugnqj5e2.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3
collected 16 items                                                                                                                                                                                                                                           

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                       [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                                      [ 12%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                                                    [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                                 [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                                 [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                         [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                                         [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                                       [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                       [ 56%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                                                       [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                    [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                   [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                                 [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                                 [ 87%]
handler_update.py::contract_update_create_only_property PASSED                                                                                                                                                                                         [ 93%]
handler_update.py::contract_update_non_existent_resource PASSED                                                                                                                                                                                        [100%]


```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
