### PR TITLE
added asserts into a library

### DIFF
--- a/src/rpdk/core/contract/suite/contract_asserts.py
+++ b/src/rpdk/core/contract/suite/contract_asserts.py
@@ -1,16 +1,17 @@
 from functools import wraps
 from inspect import Parameter, signature
 
+
 def _rebind(decorator, func, *args, **kwargs):
     """Helper function to construct decorated arguments
 
     This works only with positional and likely positional arguments
-    strongly keyword arguments are in **kwargs. It constructs kwargs' 
+    strongly keyword arguments are in **kwargs. It constructs kwargs'
     from positional values
     """
     parameters = signature(func).parameters.values()
     decorated_parameters = set(signature(decorator).parameters.keys())
-    
+
     positional_kwargs = dict(
         zip(
             [
@@ -25,50 +26,61 @@ def _rebind(decorator, func, *args, **kwargs):
     )
     return {k: kwargs.get(k) or positional_kwargs[k] for k in decorated_parameters}
 
+
 def decorate(decorator: object):
     """Helper function to construct decorator from a simple function
-    
+
     This is a 'decorate' meta function that wraps new decorator around
     target function and merges decorated arguments with target arguments
     convention: each new decorator should have a 'response' argument,
     which is an output of a target function
     """
+
     def new_decorator(func: object):
         @wraps(func)
         def function(*args, **kwargs):
-            response = func(*args, **kwargs) # calling target function
-            kvargs = _rebind(decorator, func, *args, **{**kwargs, **{"response": response}})
-            
+            response = func(*args, **kwargs)  # calling target function
+            kvargs = _rebind(
+                decorator, func, *args, **{**kwargs, **{"response": response}}
+            )
             decorated_sig = signature(decorator)
             bound_arguments = decorated_sig.bind(**kvargs)
-
-            decorator(*bound_arguments.args, **bound_arguments.kwargs) # calling a decorated funciont to execute check
+            decorator(
+                *bound_arguments.args, **bound_arguments.kwargs
+            )  # calling a decorated funciont to execute check
             return response
+
         return function
+
     return new_decorator
+
 
 @decorate
 def write_only_properties(resource_client, response):
-    resource_client.assert_write_only_property_does_not_exist(
-        response["resourceModel"]
-    )
+    resource_client.assert_write_only_property_does_not_exist(response["resourceModel"])
+
 
 @decorate
 def resource_model_equal_created(response, current_resource_model):
     assert response["resourceModel"] == current_resource_model
 
+
 @decorate
-def resource_model_equal_updated(response, current_resource_model, update_resource_model):
+def resource_model_equal_updated(
+    response, current_resource_model, update_resource_model
+):
     assert response["resourceModel"] == {
-            **current_resource_model,
-            **update_resource_model,
-        }
+        **current_resource_model,
+        **update_resource_model,
+    }
+
 
 @decorate
 def primary_identifier(resource_client, response):
     resource_client.assert_primary_identifier(
         resource_client.primary_identifier_paths, response["resourceModel"]
     )
+
 
 @decorate
 def primary_identifier_not_changed(resource_client, response, current_resource_model):
@@ -78,6 +90,7 @@ def primary_identifier_not_changed(resource_client, response, current_resource_m
         response["resourceModel"],
     )
 
+
 def failed_event(error_code, msg=""):
     def decorator_wrapper(func: object):
         @wraps(func)
@@ -86,5 +99,7 @@ def failed_event(error_code, msg=""):
             if response is not None:
                 assert response == error_code, msg
             return response
+
         return wrapper
+
     return decorator_wrapper

--- a/src/rpdk/core/contract/suite/contract_asserts.py
+++ b/src/rpdk/core/contract/suite/contract_asserts.py
@@ -1,0 +1,90 @@
+from functools import wraps
+from inspect import Parameter, signature
+
+def _rebind(decorator, func, *args, **kwargs):
+    """Helper function to construct decorated arguments
+
+    This works only with positional and likely positional arguments
+    strongly keyword arguments are in **kwargs. It constructs kwargs' 
+    from positional values
+    """
+    parameters = signature(func).parameters.values()
+    decorated_parameters = set(signature(decorator).parameters.keys())
+    
+    positional_kwargs = dict(
+        zip(
+            [
+                parameter.name
+                for parameter in parameters
+                if parameter.kind
+                in (Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD)
+                and parameter.name not in kwargs
+            ],
+            args,
+        )
+    )
+    return {k: kwargs.get(k) or positional_kwargs[k] for k in decorated_parameters}
+
+def decorate(decorator: object):
+    """Helper function to construct decorator from a simple function
+    
+    This is a 'decorate' meta function that wraps new decorator around
+    target function and merges decorated arguments with target arguments
+    convention: each new decorator should have a 'response' argument,
+    which is an output of a target function
+    """
+    def new_decorator(func: object):
+        @wraps(func)
+        def function(*args, **kwargs):
+            response = func(*args, **kwargs) # calling target function
+            kvargs = _rebind(decorator, func, *args, **{**kwargs, **{"response": response}})
+            
+            decorated_sig = signature(decorator)
+            bound_arguments = decorated_sig.bind(**kvargs)
+
+            decorator(*bound_arguments.args, **bound_arguments.kwargs) # calling a decorated funciont to execute check
+            return response
+        return function
+    return new_decorator
+
+@decorate
+def write_only_properties(resource_client, response):
+    resource_client.assert_write_only_property_does_not_exist(
+        response["resourceModel"]
+    )
+
+@decorate
+def resource_model_equal_created(response, current_resource_model):
+    assert response["resourceModel"] == current_resource_model
+
+@decorate
+def resource_model_equal_updated(response, current_resource_model, update_resource_model):
+    assert response["resourceModel"] == {
+            **current_resource_model,
+            **update_resource_model,
+        }
+
+@decorate
+def primary_identifier(resource_client, response):
+    resource_client.assert_primary_identifier(
+        resource_client.primary_identifier_paths, response["resourceModel"]
+    )
+
+@decorate
+def primary_identifier_not_changed(resource_client, response, current_resource_model):
+    resource_client.is_primary_identifier_equal(
+        resource_client.primary_identifier_paths,
+        current_resource_model,
+        response["resourceModel"],
+    )
+
+def failed_event(error_code, msg=""):
+    def decorator_wrapper(func: object):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            response = func(*args, **kwargs)
+            if response is not None:
+                assert response == error_code, msg
+            return response
+        return wrapper
+    return decorator_wrapper

--- a/src/rpdk/core/contract/suite/contract_asserts.py
+++ b/src/rpdk/core/contract/suite/contract_asserts.py
@@ -56,17 +56,19 @@ def decorate(decorator: object):
 
 
 @decorate
-def write_only_properties(resource_client, response):
+def response_does_not_contain_write_only_properties(resource_client, response):
     resource_client.assert_write_only_property_does_not_exist(response["resourceModel"])
 
 
 @decorate
-def resource_model_equal_created(response, current_resource_model):
+def response_contains_resource_model_equal_current_model(
+    response, current_resource_model
+):
     assert response["resourceModel"] == current_resource_model
 
 
 @decorate
-def resource_model_equal_updated(
+def response_contains_resource_model_equal_updated_model(
     response, current_resource_model, update_resource_model
 ):
     assert response["resourceModel"] == {
@@ -76,14 +78,16 @@ def resource_model_equal_updated(
 
 
 @decorate
-def primary_identifier(resource_client, response):
+def response_contains_primary_identifier(resource_client, response):
     resource_client.assert_primary_identifier(
         resource_client.primary_identifier_paths, response["resourceModel"]
     )
 
 
 @decorate
-def primary_identifier_not_changed(resource_client, response, current_resource_model):
+def response_contains_unchanged_primary_identifier(
+    resource_client, response, current_resource_model
+):
     resource_client.is_primary_identifier_equal(
         resource_client.primary_identifier_paths,
         current_resource_model,

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -22,26 +22,29 @@ def test_create_success(resource_client, current_resource_model):
     return response
 
 
+def test_create_failure_if_repeat_writeable_id(resource_client, current_resource_model):
+    if resource_client.has_writable_identifier():
+        _create_failure_with_writable_id(resource_client, current_resource_model)
+    else:
+        LOG.debug("no identifiers are writeable; skipping duplicate-CREATE-failed test")
+
+
 @failed_event(
     error_code=HandlerErrorCode.AlreadyExists,
     msg="creating the same resource should not be possible",
 )
-def test_create_failure_if_repeat_writeable_id(resource_client, current_resource_model):
-    if resource_client.has_writable_identifier():
-        LOG.debug(
-            "at least one identifier is writeable; "
-            "performing duplicate-CREATE-failed test"
-        )
-        # Should fail, because different clientRequestToken for the same
-        # resource model means that the same resource is trying to be
-        # created twice.
-        _status, _response, error_code = resource_client.call_and_assert(
-            Action.CREATE, OperationStatus.FAILED, current_resource_model
-        )
-        return error_code
-    else:
-        LOG.debug("no identifiers are writeable; skipping duplicate-CREATE-failed test")
-        return
+def _create_failure_with_writable_id(resource_client, current_resource_model):
+    LOG.debug(
+        "at least one identifier is writeable; "
+        "performing duplicate-CREATE-failed test"
+    )
+    # Should fail, because different clientRequestToken for the same
+    # resource model means that the same resource is trying to be
+    # created twice.
+    _status, _response, error_code = resource_client.call_and_assert(
+        Action.CREATE, OperationStatus.FAILED, current_resource_model
+    )
+    return error_code
 
 
 @primary_identifier

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -3,18 +3,18 @@ import logging
 from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
 from rpdk.core.contract.suite.contract_asserts import (
     failed_event,
-    primary_identifier,
-    primary_identifier_not_changed,
-    resource_model_equal_created,
-    resource_model_equal_updated,
-    write_only_properties,
+    response_contains_primary_identifier,
+    response_contains_resource_model_equal_current_model,
+    response_contains_resource_model_equal_updated_model,
+    response_contains_unchanged_primary_identifier,
+    response_does_not_contain_write_only_properties,
 )
 
 LOG = logging.getLogger(__name__)
 
 
-@primary_identifier
-@write_only_properties
+@response_contains_primary_identifier
+@response_does_not_contain_write_only_properties
 def test_create_success(resource_client, current_resource_model):
     _status, response, _error_code = resource_client.call_and_assert(
         Action.CREATE, OperationStatus.SUCCESS, current_resource_model
@@ -47,9 +47,9 @@ def _create_failure_with_writable_id(resource_client, current_resource_model):
     return error_code
 
 
-@primary_identifier
-@write_only_properties
-@resource_model_equal_created
+@response_contains_primary_identifier
+@response_does_not_contain_write_only_properties
+@response_contains_resource_model_equal_current_model
 def test_read_success(resource_client, current_resource_model):
     _status, response, _error_code = resource_client.call_and_assert(
         Action.READ, OperationStatus.SUCCESS, current_resource_model
@@ -95,10 +95,10 @@ def test_model_in_list(resource_client, current_resource_model):
     )
 
 
-@primary_identifier
-@primary_identifier_not_changed
-@resource_model_equal_updated
-@write_only_properties
+@response_contains_primary_identifier
+@response_contains_unchanged_primary_identifier
+@response_contains_resource_model_equal_updated_model
+@response_does_not_contain_write_only_properties
 def test_update_success(resource_client, update_resource_model, current_resource_model):
     _status, response, _error_code = resource_client.call_and_assert(
         Action.UPDATE,

--- a/src/rpdk/core/contract/suite/handler_create.py
+++ b/src/rpdk/core/contract/suite/handler_create.py
@@ -7,6 +7,7 @@ import pytest
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
 from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
+from rpdk.core.contract.suite.contract_asserts import failed_event
 from rpdk.core.contract.suite.handler_commons import (
     test_create_failure_if_repeat_writeable_id,
     test_create_success,
@@ -44,14 +45,16 @@ def contract_create_delete(resource_client):
 
 
 @pytest.mark.create
+@failed_event(error_code=HandlerErrorCode.InvalidRequest)
 def contract_invalid_create(resource_client):
     if resource_client.read_only_paths:
         requested_model = resource_client.generate_invalid_create_example()
+        print("resource MODEL:", requested_model)
         _status, response, _error_code = resource_client.call_and_assert(
             Action.CREATE, OperationStatus.FAILED, requested_model
         )
         assert response["message"]
-        assert _error_code == HandlerErrorCode.InvalidRequest
+        return _error_code
     else:
         pytest.skip("No readOnly Properties. Skipping test.")
 

--- a/src/rpdk/core/contract/suite/handler_create.py
+++ b/src/rpdk/core/contract/suite/handler_create.py
@@ -45,18 +45,21 @@ def contract_create_delete(resource_client):
 
 
 @pytest.mark.create
-@failed_event(error_code=HandlerErrorCode.InvalidRequest)
 def contract_invalid_create(resource_client):
     if resource_client.read_only_paths:
-        requested_model = resource_client.generate_invalid_create_example()
-        print("resource MODEL:", requested_model)
-        _status, response, _error_code = resource_client.call_and_assert(
-            Action.CREATE, OperationStatus.FAILED, requested_model
-        )
-        assert response["message"]
-        return _error_code
+        _create_with_invalid_model(resource_client)
     else:
         pytest.skip("No readOnly Properties. Skipping test.")
+
+
+@failed_event(error_code=HandlerErrorCode.InvalidRequest)
+def _create_with_invalid_model(resource_client):
+    requested_model = resource_client.generate_invalid_create_example()
+    _status, response, _error_code = resource_client.call_and_assert(
+        Action.CREATE, OperationStatus.FAILED, requested_model
+    )
+    assert response["message"]
+    return _error_code
 
 
 @pytest.mark.create

--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -5,8 +5,7 @@ import pytest
 
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
-from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
-from rpdk.core.contract.suite.contract_asserts import failed_event
+from rpdk.core.contract.interface import Action, OperationStatus
 from rpdk.core.contract.suite.handler_commons import (
     test_model_in_list,
     test_read_success,
@@ -53,52 +52,3 @@ def contract_update_list_success(updated_resource, resource_client):
         resource_client.primary_identifier_paths, _created_model, updated_model
     )
     assert test_model_in_list(resource_client, updated_model)
-
-
-@pytest.mark.update
-def contract_update_create_only_property(resource_client):
-
-    if resource_client.create_only_paths:
-        try:
-            create_request = resource_client.generate_create_example()
-            _status, response, _error = resource_client.call_and_assert(
-                Action.CREATE, OperationStatus.SUCCESS, create_request
-            )
-            created_model = response["resourceModel"]
-            update_request = resource_client.generate_invalid_update_example(
-                created_model
-            )
-            _update_invalid_model(resource_client, created_model, update_request)
-        finally:
-            resource_client.call_and_assert(
-                Action.DELETE, OperationStatus.SUCCESS, created_model
-            )
-    else:
-        pytest.skip("No createOnly Properties. Skipping test.")
-
-
-@failed_event(
-    error_code=HandlerErrorCode.NotUpdatable,
-    msg="updating readOnly or createOnly properties should not be possible",
-)
-def _update_invalid_model(resource_client, created_model, update_request):
-    _status, response, _error = resource_client.call_and_assert(
-        Action.UPDATE, OperationStatus.FAILED, update_request, created_model
-    )
-    assert response["message"]
-    return _error
-
-
-@pytest.mark.update
-@failed_event(
-    error_code=HandlerErrorCode.NotFound,
-    msg="cannot update a resource which does not exist",
-)
-def contract_update_non_existent_resource(resource_client):
-    create_request = resource_client.generate_create_example()
-    update_request = resource_client.generate_update_example(create_request)
-    _status, response, _error = resource_client.call_and_assert(
-        Action.UPDATE, OperationStatus.FAILED, update_request, create_request
-    )
-    assert response["message"]
-    return _error

--- a/src/rpdk/core/contract/suite/handler_update_invalid.py
+++ b/src/rpdk/core/contract/suite/handler_update_invalid.py
@@ -6,6 +6,7 @@ import pytest
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
 from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
+from rpdk.core.contract.suite.contract_asserts import failed_event
 
 
 @pytest.mark.update
@@ -37,6 +38,10 @@ def contract_update_create_only_property(resource_client):
 
 
 @pytest.mark.update
+@failed_event(
+    error_code=HandlerErrorCode.NotFound,
+    msg="cannot update a resource which does not exist",
+)
 def contract_update_non_existent_resource(resource_client):
     create_request = resource_client.generate_create_example()
     update_request = resource_client.generate_update_example(create_request)
@@ -44,6 +49,4 @@ def contract_update_non_existent_resource(resource_client):
         Action.UPDATE, OperationStatus.FAILED, update_request, create_request
     )
     assert response["message"]
-    assert (
-        _error == HandlerErrorCode.NotFound
-    ), "cannot update a resource which does not exist"
+    return _error


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
adding a module where we could concentrate all the checks or asserts necessary for tests cases and decorate them.

It has a parent method `decorate` which makes decorator out of any simple function. The convention is to have variables that could be either returned by the target function (which is `response` if not returned then `None`) or accepted by the target function (e.g. `resource_client`). `decorate` rebinds `positional` or `keyword_or_positional` args from the target function and rebinds it to the assumed decorator. 

Then it could be used to decorate any method, which response needs to be checked upon `write_only_properties` or something else

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
