### PR TITLE
Add region, partition and accountId to contract test request to handler

### DIFF
--- a/src/rpdk/core/boto_helpers.py
+++ b/src/rpdk/core/boto_helpers.py
@@ -76,3 +76,9 @@ def get_service_endpoint(service, region):
     resolver = botocore.regions.EndpointResolver(data)
     endpoint_data = resolver.construct_endpoint(service, region)
     return "https://" + endpoint_data["hostname"]
+
+
+def get_account(session):
+    sts_client = session.client("sts")
+    response = sts_client.get_caller_identity()
+    return response.get("Account")

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -14,6 +14,7 @@ from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStat
 from ..boto_helpers import (
     LOWER_CAMEL_CRED_KEYS,
     create_sdk_session,
+    get_account,
     get_temporary_credentials,
 )
 from ..jsonutils.pointer import fragment_decode, fragment_list
@@ -85,6 +86,9 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         self._creds = get_temporary_credentials(
             self._session, LOWER_CAMEL_CRED_KEYS, role_arn
         )
+        self.region = region
+        self.account = get_account(self._session)
+        self.partition = self._get_partition()
         self._function_name = function_name
         if endpoint.startswith("http://"):
             self._client = self._session.client(
@@ -111,6 +115,13 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         self._update_schema(schema)
         self._inputs = inputs
         self._timeout_in_seconds = int(timeout_in_seconds)
+
+    def _get_partition(self):
+        if self.region.startswith("cn"):
+            return "aws-cn"
+        if self.region.startswith("us-gov"):
+            return "aws-gov"
+        return "aws"
 
     def _properties_to_paths(self, key):
         return {fragment_decode(prop, prefix="") for prop in self._schema.get(key, [])}
@@ -277,12 +288,22 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         return error_code
 
     @staticmethod
-    def make_request(desired_resource_state, previous_resource_state, **kwargs):
+    def make_request(
+        desired_resource_state,
+        previous_resource_state,
+        region,
+        account,
+        partition,
+        **kwargs
+    ):
         return {
             "desiredResourceState": desired_resource_state,
             "previousResourceState": previous_resource_state,
             "logicalResourceIdentifier": None,
             **kwargs,
+            "region": region,
+            "awsPartition": partition,
+            "awsAccountId": account,
         }
 
     @staticmethod
@@ -341,7 +362,14 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
     ):
         if assert_status not in [OperationStatus.SUCCESS, OperationStatus.FAILED]:
             raise ValueError("Assert status {} not supported.".format(assert_status))
-        request = self.make_request(current_model, previous_model, **kwargs)
+        request = self.make_request(
+            current_model,
+            previous_model,
+            self.region,
+            self.account,
+            self.partition,
+            **kwargs
+        )
 
         status, response = self.call(action, request)
         if assert_status == OperationStatus.SUCCESS:

--- a/src/rpdk/core/contract/suite/handler_delete.py
+++ b/src/rpdk/core/contract/suite/handler_delete.py
@@ -36,7 +36,13 @@ def deleted_resource(resource_client):
         assert "resourceModel" not in response
         yield model, request
     finally:
-        request = resource_client.make_request(model, None)
+        request = resource_client.make_request(
+            model,
+            None,
+            resource_client.region,
+            resource_client.account,
+            resource_client.partition,
+        )
         status, response = resource_client.call(Action.DELETE, request)
 
         # a failed status is allowed if the error code is NotFound

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -23,6 +23,7 @@ from rpdk.core.test import (
 )
 
 EMPTY_OVERRIDE = empty_override()
+ACCOUNT = "11111111"
 LOG = logging.getLogger(__name__)
 
 SCHEMA = {
@@ -66,7 +67,7 @@ def resource_client():
     patch_account = patch(
         "rpdk.core.contract.resource_client.get_account",
         autospec=True,
-        return_value={},
+        return_value=ACCOUNT,
     )
     with patch_sesh as mock_create_sesh, patch_creds as mock_creds:
         with patch_account as mock_account:
@@ -83,6 +84,7 @@ def resource_client():
     assert client._function_name == DEFAULT_FUNCTION
     assert client._schema == {}
     assert client._overrides == EMPTY_OVERRIDE
+    assert client.account == ACCOUNT
 
     return client
 
@@ -101,7 +103,7 @@ def resource_client_inputs():
     patch_account = patch(
         "rpdk.core.contract.resource_client.get_account",
         autospec=True,
-        return_value={},
+        return_value=ACCOUNT,
     )
     with patch_sesh as mock_create_sesh, patch_creds as mock_creds:
         with patch_account as mock_account:
@@ -124,6 +126,7 @@ def resource_client_inputs():
     assert client._function_name == DEFAULT_FUNCTION
     assert client._schema == {}
     assert client._overrides == EMPTY_OVERRIDE
+    assert client.account == ACCOUNT
 
     return client
 
@@ -168,13 +171,13 @@ def test_init_sam_cli_client():
     patch_account = patch(
         "rpdk.core.contract.resource_client.get_account",
         autospec=True,
-        return_value={},
+        return_value=ACCOUNT,
     )
     with patch_sesh as mock_create_sesh, patch_creds as mock_creds:
         with patch_account as mock_account:
             mock_sesh = mock_create_sesh.return_value
             mock_sesh.region_name = DEFAULT_REGION
-            ResourceClient(
+            client = ResourceClient(
                 DEFAULT_FUNCTION, DEFAULT_ENDPOINT, DEFAULT_REGION, {}, EMPTY_OVERRIDE
             )
 
@@ -183,6 +186,7 @@ def test_init_sam_cli_client():
     )
     mock_creds.assert_called_once_with(mock_sesh, LOWER_CAMEL_CRED_KEYS, None)
     mock_account.assert_called_once_with(mock_sesh)
+    assert client.account == ACCOUNT
 
 
 def test_generate_token():

--- a/tests/test_boto_helpers.py
+++ b/tests/test_boto_helpers.py
@@ -8,6 +8,7 @@ from rpdk.core.boto_helpers import (
     BOTO_CRED_KEYS,
     LOWER_CAMEL_CRED_KEYS,
     create_sdk_session,
+    get_account,
     get_temporary_credentials,
 )
 from rpdk.core.exceptions import CLIMisconfiguredError, DownstreamError
@@ -197,3 +198,12 @@ def test_get_temporary_credentials_assume_role():
     assert len(creds) == 3
     assert tuple(creds.keys()) == LOWER_CAMEL_CRED_KEYS
     assert tuple(creds.values()) == (access_key, secret_key, token)
+
+
+def test_get_account():
+    session = create_autospec(spec=Session, spec_set=True)
+    client = session.client.return_value
+    get_account(session)
+
+    session.client.assert_called_once_with("sts")
+    client.get_caller_identity.assert_called_once()


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/cloudformation-cli/issues/501

*Description of changes:* Contract test does not provide a mechanism to add Region/Partition/AccountId to the contract test request. This change will allow users to add the above mentioned values as parameters.

*Test:* Ran the following command successfully:
```
(env) anshikg@3c22fbb25c23 aws-elasticloadbalancing-loadbalancer % cfn test --region "us-west-2" --partition "aws" --account-id "12345678" -- -k contract_create_delete
==================================================================================================================== test session starts =====================================================================================================================
platform darwin -- Python 3.8.4, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/rpdk/aws-cloudformation-resource-providers-elasticloadbalancing/aws-elasticloadbalancing-loadbalancer/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/rpdk/aws-cloudformation-resource-providers-elasticloadbalancing/aws-elasticloadbalancing-loadbalancer, inifile: /private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_rnt4wt90.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3
collected 16 items / 15 deselected / 1 selected                                                                                                                                                                                                              

handler_create.py::contract_create_delete PASSED          
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
