### PR TITLE
removed potential duplicate types within array

### DIFF
--- a/src/rpdk/core/jsonutils/resolver.py
+++ b/src/rpdk/core/jsonutils/resolver.py
@@ -102,14 +102,18 @@ class ModelResolver:
             return ResolvedType(ContainerType.MODEL, self._models[ref_path])
 
         schema_type = property_schema.get("type", "object")
+
+        if isinstance(
+            schema_type, list
+        ):  # generate a generic type Object which will be casted on the client side
+            if len(set(schema_type)) > 1:
+                return self._get_multiple_lang_type(MULTIPLE)
+            schema_type = schema_type[0]
+
         if schema_type == "array":
             return self._get_array_lang_type(property_schema)
         if schema_type == "object":
             return self._get_object_lang_type(property_schema)
-        if isinstance(
-            schema_type, list
-        ):  # generate a generic type Object which will be casted on the client side
-            return self._get_multiple_lang_type(MULTIPLE)
         return self._get_primitive_lang_type(schema_type)
 
     @staticmethod

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -527,8 +527,11 @@ class Project:  # pylint: disable=too-many-instance-attributes
             prop_type = [prop_type]
             single_item = True
 
+        visited = set()
         for prop_item in prop_type:
-            __set_property_type(prop_item, single_type=single_item)
+            if prop_item not in visited:
+                visited.add(prop_item)
+                __set_property_type(prop_item, single_type=single_item)
 
         return prop
 

--- a/tests/data/schema/valid/valid_multityped_property.json
+++ b/tests/data/schema/valid/valid_multityped_property.json
@@ -23,6 +23,9 @@
                     "type": "integer"
                 },
                 {
+                    "type": "integer"
+                },
+                {
                     "type": "object"
                 },
                 {

--- a/tests/jsonutils/test_resolver.py
+++ b/tests/jsonutils/test_resolver.py
@@ -200,6 +200,13 @@ def test_modelresolver__schema_to_lang_type_primitive():
 
 def test_modelresolver__schema_to_lang_type_multiple():
     resolver = ModelResolver({})
-    resolved_type = resolver._schema_to_lang_type({"type": ["string"]})
+    resolved_type = resolver._schema_to_lang_type({"type": ["string", "object"]})
     assert resolved_type.container == ContainerType.MULTIPLE
     assert resolved_type.type == "multiple"
+
+
+def test_modelresolver__schema_to_lang_duplicatetype():
+    resolver = ModelResolver({})
+    resolved_type = resolver._schema_to_lang_type({"type": ["string", "string"]})
+    assert resolved_type.container == ContainerType.PRIMITIVE
+    assert resolved_type.type == "string"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,7 @@
 # fixture and parameter have the same name
 # pylint: disable=redefined-outer-name,useless-super-delegation,protected-access
 import json
+import logging
 import os
 import random
 import string
@@ -174,6 +175,7 @@ def test_safewrite_doesnt_exist(project, tmpdir):
 
 
 def test_safewrite_exists(project, tmpdir, caplog):
+    caplog.set_level(logging.INFO)
     path = Path(tmpdir.join("test")).resolve()
 
     with path.open("w", encoding="utf-8") as f:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

added a check to avoid setting property to `Object` if it has conditional subschema with the same type as flattened type would be `type: [string, string]`;
Example:
```json
{
    "SampleObject": {
        "type": "object",
        "oneOf": [
            {
                "properties": { "Type": { "type": "string" } }
            },
            {
                "properties": { "Type": { "type": "string" } }
            }
        ]
    }
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
