### PR TITLE
added a writable id skip for read without create

### DIFF
--- a/src/rpdk/core/contract/suite/contract_asserts.py
+++ b/src/rpdk/core/contract/suite/contract_asserts.py
@@ -46,7 +46,7 @@ def decorate(after=True):
             @wraps(func)
             def function(*args, **kwargs):
                 response_arg = {}
-                if after:  # running function before so the decorated check
+                if after:  # running function before the decorated check
                     response = func(*args, **kwargs)  # calling target function
                     response_arg = {"response": response}
 
@@ -57,6 +57,8 @@ def decorate(after=True):
                     *bound_arguments.args, **bound_arguments.kwargs
                 )  # calling a decorated function to execute check
 
+                # this allows to make a pre-execution check
+                # e.g. if skip function
                 if not after:  # running function after the decorated check
                     response = func(*args, **kwargs)  # calling target function
                 return response
@@ -68,19 +70,19 @@ def decorate(after=True):
     return inner_decorator
 
 
-@decorate
+@decorate()
 def response_does_not_contain_write_only_properties(resource_client, response):
     resource_client.assert_write_only_property_does_not_exist(response["resourceModel"])
 
 
-@decorate
+@decorate()
 def response_contains_resource_model_equal_current_model(
     response, current_resource_model
 ):
     assert response["resourceModel"] == current_resource_model
 
 
-@decorate
+@decorate()
 def response_contains_resource_model_equal_updated_model(
     response, current_resource_model, update_resource_model
 ):
@@ -90,14 +92,14 @@ def response_contains_resource_model_equal_updated_model(
     }
 
 
-@decorate
+@decorate()
 def response_contains_primary_identifier(resource_client, response):
     resource_client.assert_primary_identifier(
         resource_client.primary_identifier_paths, response["resourceModel"]
     )
 
 
-@decorate
+@decorate()
 def response_contains_unchanged_primary_identifier(
     resource_client, response, current_resource_model
 ):

--- a/src/rpdk/core/contract/suite/contract_asserts.py
+++ b/src/rpdk/core/contract/suite/contract_asserts.py
@@ -1,6 +1,8 @@
 from functools import wraps
 from inspect import Parameter, signature
 
+import pytest
+
 
 def _rebind(decorator, func, *args, **kwargs):
     """Helper function to construct decorated arguments
@@ -27,8 +29,11 @@ def _rebind(decorator, func, *args, **kwargs):
     return {k: kwargs.get(k) or positional_kwargs[k] for k in decorated_parameters}
 
 
-def decorate(decorator: object):
+def decorate(after=True):
     """Helper function to construct decorator from a simple function
+
+    arg: after means that decorated check should be run after the
+    target function
 
     This is a 'decorate' meta function that wraps new decorator around
     target function and merges decorated arguments with target arguments
@@ -36,23 +41,31 @@ def decorate(decorator: object):
     which is an output of a target function
     """
 
-    def new_decorator(func: object):
-        @wraps(func)
-        def function(*args, **kwargs):
-            response = func(*args, **kwargs)  # calling target function
-            kvargs = _rebind(
-                decorator, func, *args, **{**kwargs, **{"response": response}}
-            )
-            decorated_sig = signature(decorator)
-            bound_arguments = decorated_sig.bind(**kvargs)
-            decorator(
-                *bound_arguments.args, **bound_arguments.kwargs
-            )  # calling a decorated funciont to execute check
-            return response
+    def inner_decorator(decorator: object):
+        def new_decorator(func: object):
+            @wraps(func)
+            def function(*args, **kwargs):
+                response_arg = {}
+                if after:  # running function before so the decorated check
+                    response = func(*args, **kwargs)  # calling target function
+                    response_arg = {"response": response}
 
-        return function
+                kvargs = _rebind(decorator, func, *args, **{**kwargs, **response_arg})
+                decorated_sig = signature(decorator)
+                bound_arguments = decorated_sig.bind(**kvargs)
+                decorator(
+                    *bound_arguments.args, **bound_arguments.kwargs
+                )  # calling a decorated function to execute check
 
-    return new_decorator
+                if not after:  # running function after the decorated check
+                    response = func(*args, **kwargs)  # calling target function
+                return response
+
+            return function
+
+        return new_decorator
+
+    return inner_decorator
 
 
 @decorate
@@ -93,6 +106,12 @@ def response_contains_unchanged_primary_identifier(
         current_resource_model,
         response["resourceModel"],
     )
+
+
+@decorate(after=False)
+def skip_not_writable_identifier(resource_client):
+    if not resource_client.has_writable_identifier():
+        pytest.skip("No writable identifiers. Skipping test.")
 
 
 def failed_event(error_code, msg=""):

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -22,18 +22,11 @@ def test_create_success(resource_client, current_resource_model):
     return response
 
 
-def test_create_failure_if_repeat_writeable_id(resource_client, current_resource_model):
-    if resource_client.has_writable_identifier():
-        _create_failure_with_writable_id(resource_client, current_resource_model)
-    else:
-        LOG.debug("no identifiers are writeable; skipping duplicate-CREATE-failed test")
-
-
 @failed_event(
     error_code=HandlerErrorCode.AlreadyExists,
     msg="creating the same resource should not be possible",
 )
-def _create_failure_with_writable_id(resource_client, current_resource_model):
+def test_create_failure_if_repeat_writeable_id(resource_client, current_resource_model):
     LOG.debug(
         "at least one identifier is writeable; "
         "performing duplicate-CREATE-failed test"

--- a/src/rpdk/core/contract/suite/handler_create.py
+++ b/src/rpdk/core/contract/suite/handler_create.py
@@ -7,7 +7,10 @@ import pytest
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
 from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
-from rpdk.core.contract.suite.contract_asserts import failed_event
+from rpdk.core.contract.suite.contract_asserts import (
+    failed_event,
+    skip_not_writable_identifier,
+)
 from rpdk.core.contract.suite.handler_commons import (
     test_create_failure_if_repeat_writeable_id,
     test_create_success,
@@ -63,6 +66,7 @@ def _create_with_invalid_model(resource_client):
 
 
 @pytest.mark.create
+@skip_not_writable_identifier
 def contract_create_duplicate(created_resource, resource_client):
     _created_model, request = created_resource
     test_create_failure_if_repeat_writeable_id(resource_client, request)

--- a/src/rpdk/core/contract/suite/handler_read.py
+++ b/src/rpdk/core/contract/suite/handler_read.py
@@ -5,10 +5,12 @@ import pytest
 
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
+from rpdk.core.contract.suite.contract_asserts import skip_not_writable_identifier
 from rpdk.core.contract.suite.handler_commons import test_read_failure_not_found
 
 
 @pytest.mark.read
+@skip_not_writable_identifier
 def contract_read_without_create(resource_client):
     model = resource_client.generate_create_example()
     test_read_failure_not_found(resource_client, model)

--- a/src/rpdk/core/contract/suite/handler_read.py
+++ b/src/rpdk/core/contract/suite/handler_read.py
@@ -5,12 +5,12 @@ import pytest
 
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
-from rpdk.core.contract.suite.contract_asserts import skip_not_writable_identifier
 from rpdk.core.contract.suite.handler_commons import test_read_failure_not_found
 
 
 @pytest.mark.read
-@skip_not_writable_identifier
 def contract_read_without_create(resource_client):
-    model = resource_client.generate_create_example()
+    model = (
+        resource_client.generate_invalid_create_example()
+    )  # to allow invalid (correctly formatted primary id)
     test_read_failure_not_found(resource_client, model)

--- a/src/rpdk/core/contract/suite/handler_update_invalid.py
+++ b/src/rpdk/core/contract/suite/handler_update_invalid.py
@@ -43,7 +43,7 @@ def contract_update_create_only_property(resource_client):
     msg="cannot update a resource which does not exist",
 )
 def contract_update_non_existent_resource(resource_client):
-    create_request = resource_client.generate_create_example()
+    create_request = resource_client.generate_invalid_create_example()
     update_request = resource_client.generate_update_example(create_request)
     _status, response, _error = resource_client.call_and_assert(
         Action.UPDATE, OperationStatus.FAILED, update_request, create_request


### PR DESCRIPTION
*Issue #, if available:* #507 

*Description of changes:*

**contract_read_without_create**

Test anticipates `NotFound` error as it invokes `ReadHandler` without prior creation of the resource. This test starts with `resource_client.generate_create_example` but it's pretty hard to provide a good generation strategy for primary identifier to mock a good value, as primary identifier pattern is not always good enough to generate a good substitute (e.g. `arn` - partition or region constraints). This test might be very inconsistent if we rely on generation strategy, as different api might throw different error - `NotFound`, `InvalidRequest`, `CfnGeneralException`, etc. 

Eventually, this test checks if `ReadHandler` throws `NotFound` exception in case the resource has already been deleted. This could be achieved by `contract_delete_read` test, which in fact operates with a good identifier. 

~~This change skips the test for service generated identifiers~~


**UPDATE**

Changed generation strategy for `contract_read_without_create` to allow invalid input. Requirement: inputs_*n*_invalid.json should contain *invalid* primary identifier but correctly formatted so that target api will accept it and produces `NotFound` error

additional changes: made `decorate` meta function to accept argument {after} this allows to decorate checks that should be run before the target function is executed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
