### PR TITLE
increasing default lambda memory size

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ ipdb>=0.12
 # testing tools
 pylint>=2.3.1
 coverage>=4.5.4
-pytest>=5.3.5
+pytest>=6.0.0
 pytest-cov>=2.7.1
 pytest-random-order>=1.0.4
 hypothesis>=4.32.3

--- a/src/rpdk/core/templates/template.yml
+++ b/src/rpdk/core/templates/template.yml
@@ -13,6 +13,7 @@ Description: AWS SAM template for the {{ resource_type }} resource type
 Globals:
   Function:
     Timeout: 180  # docker start-up times can be long for SAM CLI
+    MemorySize: 256
 
 Resources:
 {% if functions %}


### PR DESCRIPTION
*Issue #, if available:* #510 

*Description of changes:*

increasing the default memory size

bumping pytest to 6.x as annotations were not recognized as callable  https://github.com/pytest-dev/pytest/issues/7473

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
