### PR TITLE
Fix Contract test for resources with one createOnly Property

### DIFF
--- a/src/rpdk/core/contract/suite/contract_asserts.py
+++ b/src/rpdk/core/contract/suite/contract_asserts.py
@@ -2,9 +2,9 @@ from functools import wraps
 from inspect import Parameter, signature
 from unittest.test.testmock.support import is_instance
 
-from rpdk.core.contract.interface import HandlerErrorCode
-
 import pytest
+
+from rpdk.core.contract.interface import HandlerErrorCode
 
 
 def _rebind(decorator, func, *args, **kwargs):
@@ -126,9 +126,8 @@ def failed_event(error_code, msg=""):
             response_error = func(*args, **kwargs)
             if response_error is not None:
                 if is_instance(error_code, HandlerErrorCode):
-                    assert response_error == error_code, msg
-                else:
-                    assert response_error in error_code
+                    error_code_tuple = (error_code,)
+                assert response_error in error_code_tuple, msg
             return response_error
 
         return wrapper

--- a/src/rpdk/core/contract/suite/contract_asserts.py
+++ b/src/rpdk/core/contract/suite/contract_asserts.py
@@ -1,5 +1,8 @@
 from functools import wraps
 from inspect import Parameter, signature
+from unittest.test.testmock.support import is_instance
+
+from rpdk.core.contract.interface import HandlerErrorCode
 
 import pytest
 
@@ -120,10 +123,13 @@ def failed_event(error_code, msg=""):
     def decorator_wrapper(func: object):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            response = func(*args, **kwargs)
-            if response is not None:
-                assert response == error_code, msg
-            return response
+            response_error = func(*args, **kwargs)
+            if response_error is not None:
+                if is_instance(error_code, HandlerErrorCode):
+                    assert response_error == error_code, msg
+                else:
+                    assert response_error in error_code
+            return response_error
 
         return wrapper
 

--- a/src/rpdk/core/contract/suite/handler_update_invalid.py
+++ b/src/rpdk/core/contract/suite/handler_update_invalid.py
@@ -26,8 +26,9 @@ def contract_update_create_only_property(resource_client):
                 Action.UPDATE, OperationStatus.FAILED, update_request, created_model
             )
             assert response["message"]
-            assert (
-                _error == HandlerErrorCode.NotUpdatable
+            assert _error in (
+                HandlerErrorCode.NotUpdatable,
+                HandlerErrorCode.NotFound,
             ), "updating readOnly or createOnly properties should not be possible"
         finally:
             resource_client.call_and_assert(

--- a/src/rpdk/core/contract/suite/handler_update_invalid.py
+++ b/src/rpdk/core/contract/suite/handler_update_invalid.py
@@ -10,6 +10,7 @@ from rpdk.core.contract.suite.contract_asserts import failed_event
 
 
 @pytest.mark.update
+@failed_event(error_code=(HandlerErrorCode.NotUpdatable, HandlerErrorCode.NotFound))
 def contract_update_create_only_property(resource_client):
 
     if resource_client.create_only_paths:
@@ -22,14 +23,10 @@ def contract_update_create_only_property(resource_client):
             update_request = resource_client.generate_invalid_update_example(
                 created_model
             )
-            _status, response, _error = resource_client.call_and_assert(
+            _status, response, _error_code = resource_client.call_and_assert(
                 Action.UPDATE, OperationStatus.FAILED, update_request, created_model
             )
             assert response["message"]
-            assert _error in (
-                HandlerErrorCode.NotUpdatable,
-                HandlerErrorCode.NotFound,
-            ), "updating readOnly or createOnly properties should not be possible"
         finally:
             resource_client.call_and_assert(
                 Action.DELETE, OperationStatus.SUCCESS, created_model


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Contract test which have just one create only property as identifier fail with NotFound error code instead of NotUpdatable

*Test*
* Ran the test against cloudwatch alarm resource


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
