### PR TITLE
added inputs generation on [cfn init]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
     - flake8-pep3101>=1.2.1
     # language_version: python3.6
   - id: pretty-format-json
+    exclude: inputs.json
     args:
     - --autofix
     - --indent=4

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -189,6 +189,26 @@ class Project:  # pylint: disable=too-many-instance-attributes
 
         self.safewrite(self.schema_path, _write)
 
+    def _write_example_inputs(self):
+
+        shutil.rmtree(self.inputs_path, ignore_errors=True)
+        self.inputs_path.mkdir(exist_ok=True)
+
+        template = self.env.get_template("inputs.json")
+        properties = list(self.schema["properties"].keys())
+
+        for inputs_file in (
+            "inputs_1_create.json",
+            "inputs_1_update.json",
+            "inputs_1_invalid.json",
+        ):
+            self.safewrite(
+                self.inputs_path / inputs_file,
+                template.render(
+                    properties=properties[:-1], last_property=properties[-1]
+                ),
+            )
+
     def write_settings(self):
         if self.runtime not in LAMBDA_RUNTIMES:
             LOG.critical(
@@ -220,6 +240,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
         self.settings = settings or {}
 
         self._write_example_schema()
+        self._write_example_inputs()
         self._plugin.init(self)
         self.write_settings()
 

--- a/src/rpdk/core/templates/inputs.json
+++ b/src/rpdk/core/templates/inputs.json
@@ -1,0 +1,6 @@
+{
+    {% for property in properties %}
+    "{{ property }}": "...",
+    {% endfor %}
+    "{{ last_property }}": "..."
+}

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -470,6 +470,15 @@ def test_init(project):
     with project.schema_path.open("r", encoding="utf-8") as f:
         assert json.load(f)
 
+    for file_inputs in (
+        "inputs_1_create.json",
+        "inputs_1_update.json",
+        "inputs_1_invalid.json",
+    ):
+        path_file = project.inputs_path / file_inputs
+        with path_file.open("r", encoding="utf-8") as f:
+            assert json.load(f)
+
     # ends with newline
     with project.schema_path.open("rb") as f:
         f.seek(-1, os.SEEK_END)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

added `inputs`/{`inputs_1_create.json`, `inputs_1_update.json`, `inputs_1_invalid.json`} on `cfn init`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
