### PR TITLE
Enable Soft delete for resources

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -80,6 +80,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         inputs=None,
         role_arn=None,
         timeout_in_seconds="30",
+        soft_delete="false",
     ):  # pylint: disable=too-many-arguments
         self._schema = schema
         self._session = create_sdk_session(region)
@@ -115,6 +116,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         self._update_schema(schema)
         self._inputs = inputs
         self._timeout_in_seconds = int(timeout_in_seconds)
+        self.soft_delete = bool(soft_delete == "true")
 
     def _get_partition(self):
         if self.region.startswith("cn"):

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -116,7 +116,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         self._update_schema(schema)
         self._inputs = inputs
         self._timeout_in_seconds = int(timeout_in_seconds)
-        self.soft_delete = bool(soft_delete == "true")
+        self.soft_delete = soft_delete == "true"
 
     def _get_partition(self):
         if self.region.startswith("cn"):

--- a/src/rpdk/core/contract/suite/handler_delete.py
+++ b/src/rpdk/core/contract/suite/handler_delete.py
@@ -56,8 +56,11 @@ def deleted_resource(resource_client):
 @pytest.mark.delete
 @pytest.mark.read
 def contract_delete_read(resource_client, deleted_resource):
-    deleted_model, _request = deleted_resource
-    test_read_failure_not_found(resource_client, deleted_model)
+    if resource_client.soft_delete:
+        deleted_model, _request = deleted_resource
+        test_read_failure_not_found(resource_client, deleted_model)
+    else:
+        pytest.skip("This resource supports soft delete")
 
 
 @pytest.mark.delete
@@ -66,22 +69,30 @@ def contract_delete_list(resource_client, deleted_resource):
     # LIST: Should not fail after deletion, since it is a list of all
     #       current resources of the resource type. Deletion should
     #       remove the model from the list, however.
-
-    deleted_model, _request = deleted_resource
-    assert not test_model_in_list(resource_client, deleted_model)
+    if resource_client.soft_delete:
+        deleted_model, _request = deleted_resource
+        assert not test_model_in_list(resource_client, deleted_model)
+    else:
+        pytest.skip("This resource supports soft delete")
 
 
 @pytest.mark.delete
 @pytest.mark.update
 def contract_delete_update(resource_client, deleted_resource):
-    deleted_model, _request = deleted_resource
-    test_update_failure_not_found(resource_client, deleted_model)
+    if resource_client.soft_delete:
+        deleted_model, _request = deleted_resource
+        test_update_failure_not_found(resource_client, deleted_model)
+    else:
+        pytest.skip("This resource supports soft delete")
 
 
 @pytest.mark.delete
 def contract_delete_delete(resource_client, deleted_resource):
-    deleted_model, _request = deleted_resource
-    test_delete_failure_not_found(resource_client, deleted_model)
+    if resource_client.soft_delete:
+        deleted_model, _request = deleted_resource
+        test_delete_failure_not_found(resource_client, deleted_model)
+    else:
+        pytest.skip("This resource supports soft delete")
 
 
 @pytest.mark.create

--- a/src/rpdk/core/test.py
+++ b/src/rpdk/core/test.py
@@ -203,6 +203,7 @@ def invoke_test(args, project, overrides, inputs):
             inputs,
             args.role_arn,
             args.enforce_timeout,
+            args.soft_delete,
         )
     )
 
@@ -266,4 +267,9 @@ def _sam_arguments(parser):
         help=(
             "The region used for temporary credentials " f"(Default: {DEFAULT_REGION})"
         ),
+    )
+    parser.add_argument(
+        "--soft-delete",
+        default="false",
+        help=("Resource supports soft delete (Default: false)"),
     )

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -68,22 +68,33 @@ def create_invalid_input_file(base):
 @pytest.mark.parametrize(
     "args_in,pytest_args,plugin_args",
     [
-        ([], [], [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, DEFAULT_REGION, "30"]),
-        (["--endpoint", "foo"], [], [DEFAULT_FUNCTION, "foo", DEFAULT_REGION, "30"]),
+        ([], [], [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, DEFAULT_REGION, "30", "false"]),
         (
-            ["--function-name", "bar", "--enforce-timeout", "60"],
+            ["--endpoint", "foo"],
             [],
-            ["bar", DEFAULT_ENDPOINT, DEFAULT_REGION, "60"],
+            [DEFAULT_FUNCTION, "foo", DEFAULT_REGION, "30", "false"],
+        ),
+        (
+            [
+                "--function-name",
+                "bar",
+                "--enforce-timeout",
+                "60",
+                "--soft-delete",
+                "true",
+            ],
+            [],
+            ["bar", DEFAULT_ENDPOINT, DEFAULT_REGION, "60", "true"],
         ),
         (
             ["--", "-k", "create"],
             ["-k", "create"],
-            [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, DEFAULT_REGION, "30"],
+            [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, DEFAULT_REGION, "30", "false"],
         ),
         (
             ["--region", "us-west-2", "--", "--collect-only"],
             ["--collect-only"],
-            [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, "us-west-2", "30"],
+            [DEFAULT_FUNCTION, DEFAULT_ENDPOINT, "us-west-2", "30", "false"],
         ),
     ],
 )
@@ -114,7 +125,7 @@ def test_test_command_happy_path(
     # fmt: on
 
     mock_project.load.assert_called_once_with()
-    function_name, endpoint, region, enforce_timeout = plugin_args
+    function_name, endpoint, region, enforce_timeout, soft_delete = plugin_args
     mock_client.assert_called_once_with(
         function_name,
         endpoint,
@@ -124,6 +135,7 @@ def test_test_command_happy_path(
         {"CREATE": {"a": 1}, "UPDATE": {"a": 2}, "INVALID": {"b": 1}},
         None,
         enforce_timeout,
+        soft_delete,
     )
     mock_plugin.assert_called_once_with(mock_client.return_value)
     mock_ini.assert_called_once_with()


### PR DESCRIPTION
*Issue #, if available:*https://github.com/aws-cloudformation/cloudformation-cli/issues/503

*Description of changes:* Some resources are not deleted right away when delete is called on the resource. This CR allows users to ensure their contract test pass if their resource supports soft delete.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
