### PR TITLE
mapping integer to Integer instead of Double in generated documentation

### DIFF
--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -75,7 +75,7 @@ SETTINGS_VALIDATOR = Draft7Validator(
 BASIC_TYPE_MAPPINGS = {
     "string": "String",
     "number": "Double",
-    "integer": "Double",
+    "integer": "Integer",
     "boolean": "Boolean",
 }
 

--- a/tests/data/schema/target_output/multityped.md
+++ b/tests/data/schema/target_output/multityped.md
@@ -12,7 +12,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 {
     "Type" : "AWS::Color::Red",
     "Properties" : {
-        "<a href="#property1" title="property1">property1</a>" : <i>String, Double, Map, [ <a href="obj2def.md">obj2def</a>, ... ]</i>,
+        "<a href="#property1" title="property1">property1</a>" : <i>String, Integer, Map, [ <a href="obj2def.md">obj2def</a>, ... ]</i>,
         "<a href="#obj1" title="obj1">obj1</a>" : <i><a href="obj2def.md">obj2def</a></i>,
         "<a href="#arr1" title="arr1">arr1</a>" : <i>[ <a href="obj2def.md">obj2def</a>, ... ]</i>
     }
@@ -24,7 +24,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 Type: AWS::Color::Red
 Properties:
-    <a href="#property1" title="property1">property1</a>: <i>String, Double, Map, [ <a href="obj2def.md">obj2def</a>, ... ]</i>
+    <a href="#property1" title="property1">property1</a>: <i>String, Integer, Map, [ <a href="obj2def.md">obj2def</a>, ... ]</i>
     <a href="#obj1" title="obj1">obj1</a>: <i><a href="obj2def.md">obj2def</a></i>
     <a href="#arr1" title="arr1">arr1</a>: <i>
       - <a href="obj2def.md">obj2def</a></i>
@@ -38,7 +38,7 @@ some description
 
 _Required_: No
 
-_Type_: String, Double, Map, List of <a href="obj2def.md">obj2def</a>
+_Type_: String, Integer, Map, List of <a href="obj2def.md">obj2def</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
@iann0036 https://github.com/aws-cloudformation/cloudformation-cli/pull/367/files#r465968007

["In my JSON schema I clearly define one of my properties to be a “type”: “integer”, yet no matter what when run mvn package, it will always generate docs/README.md with incorrect JSON/YAML type specifying the property to Double instead of Integer. I have no idea why it is changing my desiredInferenceUnits property expect a Double and would appreciate anyone who knows how to fix the way the docs/README.md is generated. I have attached a picture of the incorrectly generated doc below."](https://list-archive.amazon.com/lists/1110/messages/10489862)

---

Most common `PrimitiveType` values in the [Resource Specification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) include `Integer`:

```bash
$ curl -s -N --compressed https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json | pcregrep -o1 '("PrimitiveType": .*?),' | sort | uniq -c | sort -nr
3643 "PrimitiveType": "String"
 475 "PrimitiveType": "Integer"
 440 "PrimitiveType": "Boolean"
 149 "PrimitiveType": "Json"
  75 "PrimitiveType": "Double"
```

---

[also updated expected documentation generation test results for this `integer` type property:](https://travis-ci.com/github/aws-cloudformation/cloudformation-cli/jobs/368806002#L963)

https://github.com/aws-cloudformation/cloudformation-cli/blob/a4d25da92b548ff4eaf73b7b588532294bb7d8b2/tests/data/schema/valid/valid_multityped_property.json#L22-L27

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
