### PR TITLE
Remove contract test which is implemented by Lambda Wrapper

### DIFF
--- a/src/rpdk/core/contract/suite/handler_create.py
+++ b/src/rpdk/core/contract/suite/handler_create.py
@@ -6,11 +6,8 @@ import pytest
 
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
-from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
-from rpdk.core.contract.suite.contract_asserts import (
-    failed_event,
-    skip_not_writable_identifier,
-)
+from rpdk.core.contract.interface import Action, OperationStatus
+from rpdk.core.contract.suite.contract_asserts import skip_not_writable_identifier
 from rpdk.core.contract.suite.handler_commons import (
     test_create_failure_if_repeat_writeable_id,
     test_create_success,
@@ -45,27 +42,6 @@ def contract_create_delete(resource_client):
         delete_model = response["resourceModel"]
     finally:
         test_delete_success(resource_client, delete_model)
-
-
-@pytest.mark.create
-def contract_invalid_create(resource_client):
-    if resource_client.read_only_paths:
-        _create_with_invalid_model(resource_client)
-    else:
-        pytest.skip("No readOnly Properties. Skipping test.")
-
-
-@failed_event(error_code=HandlerErrorCode.InvalidRequest)
-def _create_with_invalid_model(resource_client):
-    try:
-        requested_model = resource_client.generate_invalid_create_example()
-        _status, response, _error_code = resource_client.call_and_assert(
-            Action.CREATE, OperationStatus.FAILED, requested_model
-        )
-        assert response["message"]
-        return _error_code
-    finally:
-        resource_client.call(Action.DELETE, requested_model)
 
 
 @pytest.mark.create


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Removing contract test which is asserted by Lambda Wrapper.
Lambda Wrapper by default checks for readOnly properties in the input for the handlers. This functionality does need to be implemented in the contract test.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
