### PR TITLE
adding S3 and KMS IAM actions to LogAndMetricsDeliveryRole to see contract test results after cfn submit

### DIFF
--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -117,6 +117,11 @@ Resources:
           Statement:
           - Effect: Allow
             Action:
+            - kms:Encrypt
+            - kms:Decrypt
+            - kms:ReEncrypt*
+            - kms:GenerateDataKey*
+            - kms:DescribeKey
             - logs:CreateLogGroup
             - logs:CreateLogStream
             - logs:DescribeLogGroups
@@ -124,7 +129,10 @@ Resources:
             - logs:PutLogEvents
             - cloudwatch:ListMetrics
             - cloudwatch:PutMetricData
-            Resource: "*"
+            - s3:PutObject
+            Resource:
+            - !GetAtt EncryptionKey.Arn
+            - !GetAtt ArtifactBucket.Arn
 
 Outputs:
   CloudFormationManagedUploadBucketName:


### PR DESCRIPTION
[KMS IAM actions](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awskeymanagementservice.html#awskeymanagementservice-actions-as-permissions)
[S3 IAM actions](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazons3.html#amazons3-actions-as-permissions)

["In order to see how the contract tests will run during registration, you can use cfn submit. You will need to add S3 and KMS permissions to your log and metrics delivery role. You can add the following policy as an inline policy to your logging role"](https://w.amazon.com/bin/view/AWS21/Design/Uluru/ContractTests/#HTestingcontracttestswithcfnsubmit)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
