### PR TITLE
added assert only on successful event

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -407,7 +407,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             status = OperationStatus[response["status"]]
 
         # ensure writeOnlyProperties are not returned on final responses
-        if "resourceModel" in response.keys():
+        if "resourceModel" in response.keys() and status == OperationStatus.SUCCESS:
             self.assert_write_only_property_does_not_exist(response["resourceModel"])
 
         return status, response


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I dont think we need to assert for write only properties on anything but successful event. especially with call chain it becomes hard to maintain as resource model is carried over to each method and is not considered to be changed as it will change the hashcode for the call graph

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
