### PR TITLE
reducing logging output

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -348,8 +348,14 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         }
 
     def _call(self, payload):
+        payload_to_log = {
+            key: payload[key] for key in ["callbackContext", "action", "request"]
+        }
+        LOG.debug(
+            "Sending request\n%s",
+            json.dumps(payload_to_log, ensure_ascii=False, indent=2),
+        )
         payload = json.dumps(payload, ensure_ascii=False, indent=2)
-        LOG.debug("Sending request\n%s", payload)
         result = self._client.invoke(
             FunctionName=self._function_name, Payload=payload.encode("utf-8")
         )


### PR DESCRIPTION
`rpdk.log` output snippet from testing locally with `pip install -e .`:

```
[2020-08-11T02:28:40Z] DEBUG    - Sending request
{
  "callbackContext": null,
  "action": "CREATE",
  "request": {
    "clientRequestToken": "e22a98c1-3dd6-4d47-840d-b3fedd7811f2",
    "desiredResourceState": {
      "Name": "񺈈",
      "OperatingSystem": "AMAZON_LINUX",
      "StorageLocation": {
        "Bucket": "cf-templates-1nku2armaeosd-us-east-1",
        "Key": "gamelift.zip",
        "RoleArn": "arn:aws:iam::591441109405:role/GameLiftBuildRole-Role-ULTQ2VWEFA2B"
      },
      "Version": "+ "
    },
    "previousResourceState": null,
    "logicalResourceIdentifier": null,
    "region": "us-east-1",
    "awsPartition": "aws",
    "awsAccountId": "591441109405"
  }
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
