### PR TITLE
Delete the resource in contract_delete_create test

### DIFF
--- a/src/rpdk/core/contract/suite/handler_delete.py
+++ b/src/rpdk/core/contract/suite/handler_delete.py
@@ -89,7 +89,7 @@ def contract_delete_delete(resource_client, deleted_resource):
 def contract_delete_create(resource_client, deleted_resource):
     if resource_client.has_writable_identifier():
         deleted_model, request = deleted_resource
-        response = test_create_success(resource_client, request)
+        created_response = response = test_create_success(resource_client, request)
 
         # read-only properties should be excluded from the comparison
         prune_properties_from_model(deleted_model, resource_client.read_only_paths)
@@ -98,5 +98,8 @@ def contract_delete_create(resource_client, deleted_resource):
         )
 
         assert deleted_model == response["resourceModel"]
+        resource_client.call_and_assert(
+            Action.DELETE, OperationStatus.SUCCESS, created_response["resourceModel"]
+        )
     else:
         pytest.skip("No writable identifiers. Skipping test.")

--- a/src/rpdk/core/contract/suite/handler_delete.py
+++ b/src/rpdk/core/contract/suite/handler_delete.py
@@ -89,8 +89,8 @@ def contract_delete_delete(resource_client, deleted_resource):
 def contract_delete_create(resource_client, deleted_resource):
     if resource_client.has_writable_identifier():
         deleted_model, request = deleted_resource
-        created_response = response = test_create_success(resource_client, request)
-
+        response = test_create_success(resource_client, request)
+        created_response = response.copy()
         # read-only properties should be excluded from the comparison
         prune_properties_from_model(deleted_model, resource_client.read_only_paths)
         prune_properties_from_model(


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/cloudformation-cli/issues/524

*Description of changes:* Resources which have readonly identifiers are unable to be deleted because the read only identifier is not present in the fixture.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
