### PR TITLE
Increase timeoutInMinute to 2160

### DIFF
--- a/src/rpdk/core/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.v1.json
@@ -24,7 +24,7 @@
                     "description": "Defines the timeout for the entire operation to be interpreted by the invoker of the handler.  The default is 120 (2 hours).",
                     "type": "integer",
                     "minimum": 2,
-                    "maximum": 720,
+                    "maximum": 2160,
                     "default": 120
                 }
             },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

the timeout limit has increased from 12 hrs to 36 hrs. Hence, we also need to increase timeoutInMinutes from 720 to 2160 (36 x 60)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
