### PR TITLE
Support embeded list properties

### DIFF
--- a/src/rpdk/core/jsonutils/utils.py
+++ b/src/rpdk/core/jsonutils/utils.py
@@ -103,17 +103,9 @@ def traverse(document, path_parts):
     return document, tuple(path), parent
 
 
-# pylint: disable=R0913,C0301
-# flake8: noqa=C901,B950
-def traverse_list_safe(
-    document,
-    path_parts,
-    parent=None,
-    path=None,
-    paths=None,
-    documents=None,
-    parents=None,
-):
+# pylint: disable=C0301
+# flake8: noqa=B950
+def traverse_list_safe(document, path_parts):
     """Traverse the document according to the reference.
     This method traverses all the elements of the lists
     and returns their corresponding document, path, parent
@@ -124,7 +116,7 @@ def traverse_list_safe(
     :raises ValueError, LookupError: the reference is invalid for this document
 
     >>> traverse_list_safe({"foo": {"bar": [42]}}, tuple())
-    ([{'foo': {'bar': [42]}}], [None], [None])
+    ([{'foo': {'bar': [42]}}], [[]], [None])
     >>> traverse_list_safe({"foo": {"bar": [42]}}, ["foo"])
     ([{'bar': [42]}], [['foo']], [{'foo': {'bar': [42]}}])
     >>> traverse_list_safe({"foo": {"bar": [42]}}, ("foo", "bar"))
@@ -132,7 +124,7 @@ def traverse_list_safe(
     >>> traverse_list_safe({"foo": {"bar": [42]}}, ("foo", "bar", "0"))
     ([42], [['foo', 'bar', 0]], [[42]])
     >>> traverse_list_safe({"foo": {"bar": [42, 21, 32]}}, ("foo", "bar", "*"))
-    ([42, 21, 32], [['foo', 'bar', 0], ['foo', 'bar', 1], ['foo', 'bar', 2]], [[42, 21, 32], [42, 21, 32], [42, 21, 32]])
+    ([[42], [21], [32]], [['foo', 'bar', 0], ['foo', 'bar', 1], ['foo', 'bar', 2]], [[42], [21], [32]])
     >>> traverse_list_safe({}, ["foo"])
     Traceback (most recent call last):
     ...
@@ -146,52 +138,47 @@ def traverse_list_safe(
     ...
     IndexError: list index out of range
     """
-    if not path_parts:
-        if not paths:
-            paths = []
-        paths.append(path)
+    parent = None
+    path = []
+    documents = []
+    parents = []
+    paths = []
+    for part in path_parts:
+        if isinstance(document, Sequence):
+            if part == "*":
+                return interate_over_list(document, path, path_parts)
+            part = int(part)
+        parent = document
+        try:
+            document = document[part]
+            path.append(part)
+        except TypeError:
+            pass
+    documents.append(document)
+    paths.append(path)
+    parents.append(parent)
+    return documents, paths, parents
 
-        if not documents:
-            documents = []
-        documents.append(document)
 
-        if not parents:
-            parents = []
-        parents.append(parent)
-
-        return documents, paths, parents
-
-    temp_path = path_parts[0]
-    if isinstance(document, Sequence):
-        if temp_path == "*":
-            index = 0
-            path_copy = path.copy()
-            while True:
-                temp_path = index
-                path = path_copy.copy()
-                try:
-                    path.append(temp_path)
-                    documents, paths, parents = traverse_list_safe(
-                        document[temp_path],
-                        path_parts[1:],
-                        document,
-                        path,
-                        paths,
-                        documents,
-                        parents,
-                    )
-                    index += 1
-                except LookupError:
-                    break
-            return documents, paths, parents
-        temp_path = int(temp_path)
-
-    if not path:
-        path = []
-    path.append(temp_path)
-    return traverse_list_safe(
-        document[temp_path], path_parts[1:], document, path, paths, documents, parents
-    )
+def interate_over_list(document, path, path_parts):
+    documents = []
+    parents = []
+    paths = []
+    index = 0
+    while True:
+        path_copy = path.copy()
+        path_copy.append(index)
+        try:
+            _document, _path, _parent = traverse_list_safe(
+                document[index], path_parts[1:]
+            )
+        except IndexError:
+            break
+        documents.append(_document)
+        paths.append(path_copy)
+        parents.append(_parent)
+        index += 1
+    return documents, paths, parents
 
 
 def schema_merge(target, src, path):  # noqa: C901

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -46,11 +46,12 @@ SCHEMA_WITH_MULTIPLE_WRITE_PROPERTIES = {
         "b": {"type": "number", "const": 2},
         "c": {"type": "number", "const": 3},
         "d": {"type": "number", "const": 4},
+        "e": {"type": "array", "const": [1, 3, 5]},
     },
     "readOnlyProperties": ["/properties/b"],
     "createOnlyProperties": ["/properties/c"],
     "primaryIdentifier": ["/properties/c"],
-    "writeOnlyProperties": ["/properties/d", "/properties/a"],
+    "writeOnlyProperties": ["/properties/d", "/properties/a", "/properties/e"],
 }
 
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/cloudformation-cli/issues/478

*Description of changes:*
Currently, if any property type like writeOnly/readOnly/createOnly/readOnly property have an embedded list we will get a KeyError in traverse method. For example, lets say this is a writeOnlyProperty: ```/properties/DefaultActions/AuthenticateOidcConfig/ClientSecret``` where ```DefaultActions``` is a list of objects. In contract test we want to ensure no writeOnly properties are being leaked to make sure, we traverse all writeOnly properties in the schema and check if the object does not exist. Right now, if a list exists in the schema we can look at a specific index of the list.Using the above example, contract test can support this property as an index is mentioned ```/properties/DefaultActions/0/AuthenticateOidcConfig/ClientSecret``` but, what happens when we want all the values under the list ```/properties/DefaultActions/*/AuthenticateOidcConfig/ClientSecret``` we will get a keyError. So, in order to get all the values under a list I added the following change which will recurse through the path provided as a parameter and if a list exists it will recurse through all the required indices (single index is asked and if * is present all the indices)

*Test*
* unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
