### PR TITLE
adding json decoding runtime error handling

### DIFF
--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -619,6 +619,16 @@ def test_call_and_assert_success(resource_client):
     assert error_code is None
 
 
+def test_call_and_assert_failed_invalid_payload(resource_client):
+    mock_client = resource_client._client
+    mock_client.invoke.return_value = {"Payload": StringIO("invalid json document")}
+
+    with pytest.raises(ValueError):
+        status, response, error_code = resource_client.call_and_assert(
+            Action.CREATE, OperationStatus.SUCCESS, {}, None
+        )
+
+
 def test_call_and_assert_failed(resource_client):
     mock_client = resource_client._client
     mock_client.invoke.return_value = {


### PR DESCRIPTION
*Issue #, if available:* #506 

*Description of changes:*

adding `try-catch/except` handling on json decoder runtime issues; 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
