### PR TITLE
Restructure request to match handlers

### DIFF
--- a/src/rpdk/core/__init__.py
+++ b/src/rpdk/core/__init__.py
@@ -1,5 +1,5 @@
 import logging
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -347,7 +347,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             "region": region,
             "awsAccountId": account,
             "action": action,
-            "requestContext": {"callbackContext": callback_context},
+            "callbackContext": callback_context,
             "bearerToken": token,
             **kwargs,
         }
@@ -416,7 +416,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         payload_to_log = {
             key: payload[key]
             for key in [
-                "requestContext",
+                "callbackContext",
                 "action",
                 "requestData",
                 "region",

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -133,7 +133,6 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         )
         self.region = region
         self.account = get_account(self._session, self._creds)
-        self.partition = self._get_partition()
         self._function_name = function_name
         if endpoint.startswith("http://"):
             self._client = self._session.client(
@@ -160,13 +159,6 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         self._update_schema(schema)
         self._inputs = inputs
         self._timeout_in_seconds = int(timeout_in_seconds)
-
-    def _get_partition(self):
-        if self.region.startswith("cn"):
-            return "aws-cn"
-        if self.region.startswith("us-gov"):
-            return "aws-gov"
-        return "aws"
 
     def _properties_to_paths(self, key):
         return {fragment_decode(prop, prefix="") for prop in self._schema.get(key, [])}
@@ -340,7 +332,6 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         previous_resource_state,
         region,
         account,
-        partition,
         action,
         creds,
         token,
@@ -354,10 +345,9 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
                 "previousResourceProperties": previous_resource_state,
             },
             "region": region,
-            "awsPartition": partition,
             "awsAccountId": account,
             "action": action,
-            "callbackContext": callback_context,
+            "requestContext": {"callbackContext": callback_context},
             "bearerToken": token,
             **kwargs,
         }
@@ -416,7 +406,6 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             previous_model,
             self.region,
             self.account,
-            self.partition,
             action,
             self._creds.copy(),
             self.generate_token(),
@@ -427,11 +416,10 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         payload_to_log = {
             key: payload[key]
             for key in [
-                "callbackContext",
+                "requestContext",
                 "action",
                 "requestData",
                 "region",
-                "awsPartition",
                 "awsAccountId",
                 "bearerToken",
             ]

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -267,7 +267,7 @@ def test_make_request():
         "awsAccountId": ACCOUNT,
         "action": "CREATE",
         "bearerToken": token,
-        "requestContext": {"callbackContext": None},
+        "callbackContext": None,
     }
 
 
@@ -539,7 +539,7 @@ def test_make_payload(resource_client):
         "awsAccountId": ACCOUNT,
         "action": "CREATE",
         "bearerToken": token,
-        "requestContext": {"callbackContext": None},
+        "callbackContext": None,
     }
 
 

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -253,7 +253,6 @@ def test_make_request():
         previous_resource_state,
         "us-east-1",
         ACCOUNT,
-        "aws",
         "CREATE",
         {},
         token,
@@ -265,11 +264,10 @@ def test_make_request():
             "previousResourceProperties": previous_resource_state,
         },
         "region": DEFAULT_REGION,
-        "awsPartition": "aws",
         "awsAccountId": ACCOUNT,
         "action": "CREATE",
         "bearerToken": token,
-        "callbackContext": None,
+        "requestContext": {"callbackContext": None},
     }
 
 
@@ -538,11 +536,10 @@ def test_make_payload(resource_client):
             "previousResourceProperties": None,
         },
         "region": DEFAULT_REGION,
-        "awsPartition": "aws",
         "awsAccountId": ACCOUNT,
         "action": "CREATE",
         "bearerToken": token,
-        "callbackContext": None,
+        "requestContext": {"callbackContext": None},
     }
 
 
@@ -876,17 +873,3 @@ def test_generate_update_example_with_inputs(resource_client_inputs):
 
 def test_generate_invalid_update_example_with_inputs(resource_client_inputs):
     assert resource_client_inputs.generate_invalid_update_example({"a": 1}) == {"b": 2}
-
-
-def test_get_partition_aws(resource_client):
-    assert resource_client._get_partition() == "aws"
-
-
-def test_get_partition_aws_cn(resource_client):
-    resource_client.region = "cn-north-1"
-    assert resource_client._get_partition() == "aws-cn"
-
-
-def test_get_partition_aws_gov(resource_client):
-    resource_client.region = "us-gov-west-1"
-    assert resource_client._get_partition() == "aws-gov"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/cloudformation-cli-python-plugin/issues/112 https://github.com/aws-cloudformation/cloudformation-cli-python-plugin/issues/109

*Description of changes:* The request to the resource handlers for contract tests is slightly wrong in structure, causing hard failures while testing via the python plugin (partition isn't a field in the [request](https://github.com/aws-cloudformation/cloudformation-cli-python-plugin/blob/master/src/cloudformation_cli_python_lib/utils.py#L83-L95)).

This should fix the request. Tested with the python plugin and tests ran succesfully with some other changes to the lib that will go out after this. Also bumping the version to expedite a release.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
