### PR TITLE
Revert Delete & Read Handler should be invoked using identifiers (#537)

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -98,22 +98,6 @@ def override_properties(document, overrides):
     return document
 
 
-def create_model_with_properties_in_path(src_model, paths):
-    """Creates a model with values preset in the paths.
-
-    This assumes properties will always have an object (dict) as a parent.
-    The function returns the created model.
-    """
-    model = {}
-    try:
-        for path in paths:
-            pruned_path = path[-1]
-            model[pruned_path] = src_model[pruned_path]
-    except LookupError:
-        pass
-    return model
-
-
 class ResourceClient:  # pylint: disable=too-many-instance-attributes
     def __init__(
         self,

--- a/src/rpdk/core/contract/suite/contract_asserts.py
+++ b/src/rpdk/core/contract/suite/contract_asserts.py
@@ -1,12 +1,9 @@
-import logging
 from functools import wraps
 from inspect import Parameter, signature
 
 import pytest
 
 from rpdk.core.contract.interface import HandlerErrorCode
-
-LOG = logging.getLogger(__name__)
 
 
 def _rebind(decorator, func, *args, **kwargs):

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -2,7 +2,6 @@ import logging
 
 from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
 from rpdk.core.contract.resource_client import (
-    create_model_with_properties_in_path,
     prune_properties_from_model,
     prune_properties_if_not_exist_in_path,
 )
@@ -50,12 +49,8 @@ def test_create_failure_if_repeat_writeable_id(resource_client, current_resource
 @response_does_not_contain_write_only_properties
 @response_contains_resource_model_equal_current_model
 def test_read_success(resource_client, current_resource_model):
-    primay_identifier_only_model = create_model_with_properties_in_path(
-        current_resource_model.copy(),
-        resource_client.primary_identifier_paths,
-    )
     _status, response, _error_code = resource_client.call_and_assert(
-        Action.READ, OperationStatus.SUCCESS, primay_identifier_only_model
+        Action.READ, OperationStatus.SUCCESS, current_resource_model
     )
     return response
 
@@ -69,12 +64,8 @@ def test_read_failure_not_found(
     resource_client,
     current_resource_model,
 ):
-    primay_identifier_only_model = create_model_with_properties_in_path(
-        current_resource_model,
-        resource_client.primary_identifier_paths,
-    )
     _status, _response, error_code = resource_client.call_and_assert(
-        Action.READ, OperationStatus.FAILED, primay_identifier_only_model
+        Action.READ, OperationStatus.FAILED, current_resource_model
     )
     return error_code
 
@@ -137,12 +128,8 @@ def test_update_failure_not_found(resource_client, current_resource_model):
 
 
 def test_delete_success(resource_client, current_resource_model):
-    primay_identifier_only_model = create_model_with_properties_in_path(
-        current_resource_model,
-        resource_client.primary_identifier_paths,
-    )
     _status, response, _error_code = resource_client.call_and_assert(
-        Action.DELETE, OperationStatus.SUCCESS, primay_identifier_only_model
+        Action.DELETE, OperationStatus.SUCCESS, current_resource_model
     )
     return response
 
@@ -153,12 +140,8 @@ def test_delete_success(resource_client, current_resource_model):
          if the resource did not exist prior to the delete request",
 )
 def test_delete_failure_not_found(resource_client, current_resource_model):
-    primay_identifier_only_model = create_model_with_properties_in_path(
-        current_resource_model,
-        resource_client.primary_identifier_paths,
-    )
     _status, _response, error_code = resource_client.call_and_assert(
-        Action.DELETE, OperationStatus.FAILED, primay_identifier_only_model
+        Action.DELETE, OperationStatus.FAILED, current_resource_model
     )
     return error_code
 

--- a/src/rpdk/core/contract/suite/handler_create.py
+++ b/src/rpdk/core/contract/suite/handler_create.py
@@ -7,7 +7,6 @@ import pytest
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
 from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
-from rpdk.core.contract.resource_client import create_model_with_properties_in_path
 from rpdk.core.contract.suite.contract_asserts import (
     failed_event,
     skip_not_writable_identifier,
@@ -35,12 +34,7 @@ def created_resource(resource_client):
         test_input_equals_output(resource_client, input_model, model)
         yield model, request
     finally:
-        primay_identifier_only_model = create_model_with_properties_in_path(
-            model, resource_client.primary_identifier_paths
-        )
-        resource_client.call_and_assert(
-            Action.DELETE, OperationStatus.SUCCESS, primay_identifier_only_model
-        )
+        resource_client.call_and_assert(Action.DELETE, OperationStatus.SUCCESS, model)
 
 
 @pytest.mark.create

--- a/src/rpdk/core/contract/suite/handler_delete.py
+++ b/src/rpdk/core/contract/suite/handler_delete.py
@@ -7,10 +7,7 @@ import pytest
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
 from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
-from rpdk.core.contract.resource_client import (
-    create_model_with_properties_in_path,
-    prune_properties_from_model,
-)
+from rpdk.core.contract.resource_client import prune_properties_from_model
 from rpdk.core.contract.suite.handler_commons import (
     test_create_success,
     test_delete_failure_not_found,
@@ -28,26 +25,22 @@ LOG = logging.getLogger(__name__)
 
 @pytest.fixture(scope="module")
 def deleted_resource(resource_client):
-    request = input_model = pruned_model = resource_client.generate_create_example()
+    request = input_model = model = resource_client.generate_create_example()
     try:
         _status, response, _error = resource_client.call_and_assert(
             Action.CREATE, OperationStatus.SUCCESS, request
         )
         model = response["resourceModel"]
         test_input_equals_output(resource_client, input_model, model)
-        primay_identifier_only_model = create_model_with_properties_in_path(
-            model,
-            resource_client.primary_identifier_paths,
-        )
         _status, response, _error = resource_client.call_and_assert(
-            Action.DELETE, OperationStatus.SUCCESS, primay_identifier_only_model
+            Action.DELETE, OperationStatus.SUCCESS, model
         )
         assert (
             "resourceModel" not in response
         ), "The deletion handler's response object MUST NOT contain a model"
         yield model, request
     finally:
-        status, response = resource_client.call(Action.DELETE, pruned_model)
+        status, response = resource_client.call(Action.DELETE, model)
 
         # a failed status is allowed if the error code is NotFound
         if status == OperationStatus.FAILED:

--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -6,7 +6,6 @@ import pytest
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
 from rpdk.core.contract.interface import Action, OperationStatus
-from rpdk.core.contract.resource_client import create_model_with_properties_in_path
 from rpdk.core.contract.suite.handler_commons import (
     test_input_equals_output,
     test_model_in_list,
@@ -35,12 +34,7 @@ def updated_resource(resource_client):
 
         yield create_request, created_model, update_request, updated_model
     finally:
-        primay_identifier_only_model = create_model_with_properties_in_path(
-            model, resource_client.primary_identifier_paths
-        )
-        resource_client.call_and_assert(
-            Action.DELETE, OperationStatus.SUCCESS, primay_identifier_only_model
-        )
+        resource_client.call_and_assert(Action.DELETE, OperationStatus.SUCCESS, model)
 
 
 @pytest.mark.update

--- a/src/rpdk/core/contract/suite/handler_update_invalid.py
+++ b/src/rpdk/core/contract/suite/handler_update_invalid.py
@@ -6,7 +6,6 @@ import pytest
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
 from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
-from rpdk.core.contract.resource_client import create_model_with_properties_in_path
 from rpdk.core.contract.suite.contract_asserts import failed_event
 
 
@@ -38,12 +37,8 @@ def contract_update_create_only_property(resource_client):
             ], "The progress event MUST return an error message\
                  when the status is failed"
         finally:
-            primay_identifier_only_model = create_model_with_properties_in_path(
-                created_model,
-                resource_client.primary_identifier_paths,
-            )
             resource_client.call_and_assert(
-                Action.DELETE, OperationStatus.SUCCESS, primay_identifier_only_model
+                Action.DELETE, OperationStatus.SUCCESS, created_model
             )
     else:
         pytest.skip("No createOnly Properties. Skipping test.")

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -7,7 +7,6 @@ from unittest.mock import ANY, patch
 
 import pytest
 
-import rpdk.core.contract.resource_client as client
 from rpdk.core.boto_helpers import LOWER_CAMEL_CRED_KEYS
 from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
 from rpdk.core.contract.resource_client import (
@@ -15,6 +14,7 @@ from rpdk.core.contract.resource_client import (
     override_properties,
     prune_properties,
     prune_properties_from_model,
+    prune_properties_if_not_exist_in_path,
 )
 from rpdk.core.test import (
     DEFAULT_ENDPOINT,
@@ -174,7 +174,7 @@ def test_prune_properties_if_not_exist_in_path():
         "one": "two",
         "array": ["first", "second"],
     }
-    model = client.prune_properties_if_not_exist_in_path(
+    model = prune_properties_if_not_exist_in_path(
         model,
         previous_model,
         [
@@ -185,27 +185,6 @@ def test_prune_properties_if_not_exist_in_path():
         ],
     )
     assert model == previous_model
-
-
-def test_create_model_with_properties_in_path_empty_path():
-    model = {
-        "foo": "bar",
-        "spam": "eggs",
-        "array": ["second"],
-        "map": {"map1": {"test": "1", "not_test": "2"}},
-    }
-    model = client.create_model_with_properties_in_path(model, [])
-    assert model == {}
-
-
-def test_create_model_with_properties_in_path():
-    model = {"foo": "bar", "spam": "eggs", "one": "two"}
-
-    model = client.create_model_with_properties_in_path(
-        model,
-        [("properties", "foo"), ("properties", "spam"), ("properties", "invaild")],
-    )
-    assert model == {"foo": "bar", "spam": "eggs"}
 
 
 def test_init_sam_cli_client():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The current master branch is broken due to this change. This is because delete/read handlers are invoked using the primary identifier this causes the language specific validation to fail because we assert on this for Delete and read handler. For now this change needs to be reverted to reduce customer pain point. 

*Test*
```
========================================================= test session starts =========================================================
platform darwin -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/rpdk/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/rpdk/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm, configfile: ../../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_lbd_rsfe.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3, black-0.3.10
collected 16 items                                                                                                                    

handler_create.py::contract_create_delete PASSED                                                                                [  6%]
handler_create.py::contract_invalid_create PASSED                                                                               [ 12%]
handler_create.py::contract_create_duplicate PASSED                                                                             [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                          [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                          [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                  [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                  [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                [ 56%]
handler_delete.py::contract_delete_create PASSED                                                                                [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                             [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                            [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                          [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                          [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                          [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                         [100%]

=================================================== 16 passed in 764.20s (0:12:44) ====================================================
========================================================= test session starts =========================================================
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
