### PR TITLE
Initial support using a docker image directly instead of using sam cli

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ include_trailing_comma = true
 combine_as_imports = True
 force_grid_wrap = 0
 known_first_party = rpdk
-known_third_party = boto3,botocore,colorama,hypothesis,jinja2,jsonschema,pkg_resources,pytest,pytest_localserver,setuptools,yaml
+known_third_party = boto3,botocore,colorama,docker,hypothesis,jinja2,jsonschema,pkg_resources,pytest,pytest_localserver,setuptools,yaml
 
 [tool:pytest]
 # can't do anything about 3rd part modules, so don't spam us

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "requests>=2.22",
         "hypothesis>=4.32",
         "colorama>=0.4.1",
+        "docker>=4.3.1",
     ],
     entry_points={
         "console_scripts": ["cfn-cli = rpdk.core.cli:main", "cfn = rpdk.core.cli:main"]

--- a/src/rpdk/core/boto_helpers.py
+++ b/src/rpdk/core/boto_helpers.py
@@ -46,14 +46,16 @@ def get_temporary_credentials(session, key_names=BOTO_CRED_KEYS, role_arn=None):
             response = sts_client.assume_role(
                 RoleArn=role_arn, RoleSessionName=session_name
             )
-        except ClientError as e:
+        except ClientError:
             # pylint: disable=W1201
             LOG.debug(
                 "Getting session token resulted in unknown ClientError. "
                 + "Could not assume specified role '%s'",
                 role_arn,
             )
-            raise DownstreamError("Could not assume specified role") from e
+            raise DownstreamError() from Exception(
+                "Could not assume specified role '{}'".format(role_arn)
+            )
         temp = response["Credentials"]
         creds = (temp["AccessKeyId"], temp["SecretAccessKey"], temp["SessionToken"])
     else:

--- a/src/rpdk/core/boto_helpers.py
+++ b/src/rpdk/core/boto_helpers.py
@@ -50,7 +50,7 @@ def get_temporary_credentials(session, key_names=BOTO_CRED_KEYS, role_arn=None):
             # pylint: disable=W1201
             LOG.debug(
                 "Getting session token resulted in unknown ClientError. "
-                + "Could not assume specified role '%s'",
+                + "Could not assume specified role '%s'.",
                 role_arn,
             )
             raise DownstreamError() from Exception(

--- a/src/rpdk/core/boto_helpers.py
+++ b/src/rpdk/core/boto_helpers.py
@@ -83,21 +83,14 @@ def get_service_endpoint(service, region):
     return "https://" + endpoint_data["hostname"]
 
 
-def get_account(session, temporary_credentials=None):
-    if temporary_credentials:
-        sts_client = session.client(
-            "sts",
-            endpoint_url=get_service_endpoint("sts", session.region_name),
-            region_name=session.region_name,
-            aws_access_key_id=temporary_credentials["accessKeyId"],
-            aws_secret_access_key=temporary_credentials["secretAccessKey"],
-            aws_session_token=temporary_credentials["sessionToken"],
-        )
-    else:
-        sts_client = session.client(
-            "sts",
-            endpoint_url=get_service_endpoint("sts", session.region_name),
-            region_name=session.region_name,
-        )
+def get_account(session, temporary_credentials):
+    sts_client = session.client(
+        "sts",
+        endpoint_url=get_service_endpoint("sts", session.region_name),
+        region_name=session.region_name,
+        aws_access_key_id=temporary_credentials["accessKeyId"],
+        aws_secret_access_key=temporary_credentials["secretAccessKey"],
+        aws_session_token=temporary_credentials["sessionToken"],
+    )
     response = sts_client.get_caller_identity()
     return response.get("Account")

--- a/src/rpdk/core/build_image.py
+++ b/src/rpdk/core/build_image.py
@@ -1,0 +1,64 @@
+"""This sub command will build an image for the executable
+
+Projects can be created via the 'init' sub command.
+"""
+import logging
+import os
+
+import docker
+
+from .project import Project
+
+LOG = logging.getLogger(__name__)
+VALID_IMAGE_RUNTIMES = [
+    "java8",
+    "java11",
+]
+
+
+def _get_executable_name(runtime, type_info):
+    name = None
+    if "java" in runtime:
+        name = "-".join(type_info).lower() + "-handler-1.0-SNAPSHOT"
+    return name
+
+
+def build_image(_args):
+    project = Project()
+    project.load()
+
+    if project.runtime not in VALID_IMAGE_RUNTIMES:
+        raise ValueError(
+            "Runtime '{}' is not supported for building an image".format(
+                project.runtime
+            )
+        )
+
+    executable_name = _get_executable_name(project.runtime, project.type_info)
+    dockerfile_path = (
+        os.path.dirname(os.path.realpath(__file__))
+        + "/data/build-image-src/Dockerfile-"
+        + project.runtime
+    )
+    project_path = os.path.dirname(os.path.realpath(__name__))
+    image_name = (
+        _args.image_name if _args.image_name else "-".join(project.type_info).lower()
+    )
+
+    docker_client = docker.from_env()
+    LOG.warning("Creating image")
+    docker_client.images.build(
+        path=project_path,
+        dockerfile=dockerfile_path,
+        tag=image_name,
+        buildargs={"executable_name": executable_name},
+    )
+    LOG.warning("Image '%s' created", image_name)
+
+
+def setup_subparser(subparsers, parents):
+    # see docstring of this file
+    parser = subparsers.add_parser("build-image", description=__doc__, parents=parents)
+    parser.set_defaults(command=build_image)
+
+    parser.add_argument("--image-name", help="Image name")

--- a/src/rpdk/core/cli.py
+++ b/src/rpdk/core/cli.py
@@ -9,6 +9,7 @@ from logging.config import dictConfig
 from colorama import colorama_text
 
 from .__init__ import __version__
+from .build_image import setup_subparser as build_image_setup_subparser
 from .data_loaders import resource_yaml
 from .exceptions import DownstreamError, SysExitRecommendedError
 from .generate import setup_subparser as generate_setup_subparser
@@ -86,6 +87,7 @@ def main(args_in=None):  # pylint: disable=too-many-statements
         test_setup_subparser(subparsers, parents)
         invoke_setup_subparser(subparsers, parents)
         unittest_patch_setup_subparser(subparsers, parents)
+        build_image_setup_subparser(subparsers, parents)
         args = parser.parse_args(args=args_in)
 
         setup_logging(args.verbose)

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -132,7 +132,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             self._session, LOWER_CAMEL_CRED_KEYS, role_arn
         )
         self.region = region
-        self.account = get_account(self._session)
+        self.account = get_account(self._session, self._creds)
         self.partition = self._get_partition()
         self._function_name = function_name
         if endpoint.startswith("http://"):

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -50,7 +50,8 @@ def test_create_failure_if_repeat_writeable_id(resource_client, current_resource
 @response_contains_resource_model_equal_current_model
 def test_read_success(resource_client, current_resource_model):
     primay_identifier_only_model = create_model_with_properties_in_path(
-        current_resource_model.copy(), resource_client.primary_identifier_paths,
+        current_resource_model.copy(),
+        resource_client.primary_identifier_paths,
     )
     _status, response, _error_code = resource_client.call_and_assert(
         Action.READ, OperationStatus.SUCCESS, primay_identifier_only_model
@@ -61,7 +62,8 @@ def test_read_success(resource_client, current_resource_model):
 @failed_event(error_code=HandlerErrorCode.NotFound)
 def test_read_failure_not_found(resource_client, current_resource_model):
     primay_identifier_only_model = create_model_with_properties_in_path(
-        current_resource_model, resource_client.primary_identifier_paths,
+        current_resource_model,
+        resource_client.primary_identifier_paths,
     )
     _status, _response, error_code = resource_client.call_and_assert(
         Action.READ, OperationStatus.FAILED, primay_identifier_only_model
@@ -124,7 +126,8 @@ def test_update_failure_not_found(resource_client, current_resource_model):
 
 def test_delete_success(resource_client, current_resource_model):
     primay_identifier_only_model = create_model_with_properties_in_path(
-        current_resource_model, resource_client.primary_identifier_paths,
+        current_resource_model,
+        resource_client.primary_identifier_paths,
     )
     _status, response, _error_code = resource_client.call_and_assert(
         Action.DELETE, OperationStatus.SUCCESS, primay_identifier_only_model
@@ -135,7 +138,8 @@ def test_delete_success(resource_client, current_resource_model):
 @failed_event(error_code=HandlerErrorCode.NotFound)
 def test_delete_failure_not_found(resource_client, current_resource_model):
     primay_identifier_only_model = create_model_with_properties_in_path(
-        current_resource_model, resource_client.primary_identifier_paths,
+        current_resource_model,
+        resource_client.primary_identifier_paths,
     )
     _status, _response, error_code = resource_client.call_and_assert(
         Action.DELETE, OperationStatus.FAILED, primay_identifier_only_model

--- a/src/rpdk/core/contract/suite/handler_delete.py
+++ b/src/rpdk/core/contract/suite/handler_delete.py
@@ -36,7 +36,8 @@ def deleted_resource(resource_client):
         model = response["resourceModel"]
         test_input_equals_output(resource_client, input_model, model)
         primay_identifier_only_model = create_model_with_properties_in_path(
-            model, resource_client.primary_identifier_paths,
+            model,
+            resource_client.primary_identifier_paths,
         )
         _status, response, _error = resource_client.call_and_assert(
             Action.DELETE, OperationStatus.SUCCESS, primay_identifier_only_model

--- a/src/rpdk/core/contract/suite/handler_update_invalid.py
+++ b/src/rpdk/core/contract/suite/handler_update_invalid.py
@@ -30,7 +30,8 @@ def contract_update_create_only_property(resource_client):
             assert response["message"]
         finally:
             primay_identifier_only_model = create_model_with_properties_in_path(
-                created_model, resource_client.primary_identifier_paths,
+                created_model,
+                resource_client.primary_identifier_paths,
             )
             resource_client.call_and_assert(
                 Action.DELETE, OperationStatus.SUCCESS, primay_identifier_only_model

--- a/src/rpdk/core/data/build-image-src/Dockerfile-java11
+++ b/src/rpdk/core/data/build-image-src/Dockerfile-java11
@@ -1,0 +1,4 @@
+FROM openjdk:11-alpine
+ARG executable_name
+ADD target/${executable_name}.jar handler.jar
+ENTRYPOINT ["java", "-Xmx256M", "-cp", "handler.jar"]

--- a/src/rpdk/core/data/build-image-src/Dockerfile-java8
+++ b/src/rpdk/core/data/build-image-src/Dockerfile-java8
@@ -1,0 +1,4 @@
+FROM openjdk:8-alpine
+ARG executable_name
+ADD target/${executable_name}.jar handler.jar
+ENTRYPOINT ["java", "-Xmx256M", "-cp", "handler.jar"]

--- a/src/rpdk/core/invoke.py
+++ b/src/rpdk/core/invoke.py
@@ -23,7 +23,13 @@ def invoke(args):
     project.load()
 
     client = ResourceClient(
-        args.function_name, args.endpoint, args.region, project.schema, {}
+        args.function_name,
+        args.endpoint,
+        args.region,
+        project.schema,
+        {},
+        executable_entrypoint=project.executable_entrypoint,
+        docker_image=args.docker_image,
     )
 
     action = Action[args.action]
@@ -79,5 +85,10 @@ def setup_subparser(subparsers, parents):
         help="Maximum number of IN_PROGRESS re-invocations allowed before "
         "exiting. If not specified, will continue to "
         "re-invoke until terminal status is reached.",
+    )
+    parser.add_argument(
+        "--docker-image",
+        help="Docker image name to run. If specified, invoke will use docker instead "
+        "of SAM",
     )
     _sam_arguments(parser)

--- a/src/rpdk/core/jsonutils/pointer.py
+++ b/src/rpdk/core/jsonutils/pointer.py
@@ -99,21 +99,21 @@ def fragment_decode(pointer, prefix="#", output=tuple):
 
 def fragment_list(segments, prefix="properties", output=list):
     """Decode all segments of a JSON pointer from the URI fragment
-        identifier representation.
+    identifier representation.
 
-        >>> fragment_list(["properties"])
-        []
-        >>> fragment_list(["properties", "foo", "bar"])
-        ['foo', 'bar']
-        >>> fragment_list(["properties", "foo", "bar"], output=tuple)
-        ('foo', 'bar')
-        >>> fragment_list(["properties", "0", "%20", "~0"])
-        ['0', ' ', '~']
-        >>> fragment_list(["foo"])
-        Traceback (most recent call last):
-        ...
-        ValueError: Expected prefix 'properties', but was 'foo'
-        """
+    >>> fragment_list(["properties"])
+    []
+    >>> fragment_list(["properties", "foo", "bar"])
+    ['foo', 'bar']
+    >>> fragment_list(["properties", "foo", "bar"], output=tuple)
+    ('foo', 'bar')
+    >>> fragment_list(["properties", "0", "%20", "~0"])
+    ['0', ' ', '~']
+    >>> fragment_list(["foo"])
+    Traceback (most recent call last):
+    ...
+    ValueError: Expected prefix 'properties', but was 'foo'
+    """
     decoded = (part_decode(unquote(segment)) for segment in segments)
     actual = next(decoded)
     if prefix != actual:

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -64,6 +64,7 @@ SETTINGS_VALIDATOR = Draft7Validator(
             "runtime": {"type": "string", "enum": list(LAMBDA_RUNTIMES)},
             "entrypoint": {"type": ["string", "null"]},
             "testEntrypoint": {"type": ["string", "null"]},
+            "executableEntrypoint": {"type": ["string", "null"]},
             "settings": {"type": "object"},
         },
         "required": ["language", "typeName", "runtime", "entrypoint"],
@@ -106,6 +107,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
         self.runtime = "noexec"
         self.entrypoint = None
         self.test_entrypoint = None
+        self.executable_entrypoint = None
 
         self.env = Environment(
             trim_blocks=True,
@@ -174,6 +176,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
         self.runtime = raw_settings["runtime"]
         self.entrypoint = raw_settings["entrypoint"]
         self.test_entrypoint = raw_settings["testEntrypoint"]
+        self.executable_entrypoint = raw_settings.get("executableEntrypoint", None)
         self._plugin = load_plugin(raw_settings["language"])
         self.settings = raw_settings.get("settings", {})
 
@@ -224,6 +227,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
                     "runtime": self.runtime,
                     "entrypoint": self.entrypoint,
                     "testEntrypoint": self.test_entrypoint,
+                    "executableEntrypoint": self.executable_entrypoint,
                     "settings": self.settings,
                 },
                 f,

--- a/src/rpdk/core/test.py
+++ b/src/rpdk/core/test.py
@@ -17,7 +17,7 @@ from jsonschema.exceptions import ValidationError
 
 from rpdk.core.jsonutils.pointer import fragment_decode
 
-from .boto_helpers import create_sdk_session
+from .boto_helpers import create_sdk_session, get_temporary_credentials
 from .contract.contract_plugin import ContractPlugin
 from .contract.interface import Action
 from .contract.resource_client import ResourceClient
@@ -57,9 +57,12 @@ def temporary_ini_file():
         yield str(path)
 
 
-def get_cloudformation_exports(region_name, endpoint_url):
+def get_cloudformation_exports(region_name, endpoint_url, role_arn):
     session = create_sdk_session(region_name)
-    cfn_client = session.client("cloudformation", endpoint_url=endpoint_url)
+    temp_credentials = get_temporary_credentials(session, role_arn=role_arn)
+    cfn_client = session.client(
+        "cloudformation", endpoint_url=endpoint_url, **temp_credentials
+    )
     paginator = cfn_client.get_paginator("list_exports")
     pages = paginator.paginate()
     exports = {}
@@ -68,12 +71,12 @@ def get_cloudformation_exports(region_name, endpoint_url):
     return exports
 
 
-def render_jinja(overrides_string, region_name, endpoint_url):
+def render_jinja(overrides_string, region_name, endpoint_url, role_arn):
     env = Environment(autoescape=True)
     parsed_content = env.parse(overrides_string)
     variables = meta.find_undeclared_variables(parsed_content)
     if variables:
-        exports = get_cloudformation_exports(region_name, endpoint_url)
+        exports = get_cloudformation_exports(region_name, endpoint_url, role_arn)
         invalid_exports = variables - exports.keys()
         if len(invalid_exports) > 0:
             invalid_exports_message = (
@@ -89,14 +92,14 @@ def render_jinja(overrides_string, region_name, endpoint_url):
     return to_return
 
 
-def get_overrides(root, region_name, endpoint_url):
+def get_overrides(root, region_name, endpoint_url, role_arn):
     if not root:
         return empty_override()
 
     path = root / "overrides.json"
     try:
         with path.open("r", encoding="utf-8") as f:
-            overrides_raw = render_jinja(f.read(), region_name, endpoint_url)
+            overrides_raw = render_jinja(f.read(), region_name, endpoint_url, role_arn)
     except FileNotFoundError:
         LOG.debug("Override file '%s' not found. No overrides will be applied", path)
         return empty_override()
@@ -123,7 +126,7 @@ def get_overrides(root, region_name, endpoint_url):
 
 
 # pylint: disable=R0914
-def get_inputs(root, region_name, endpoint_url, value):
+def get_inputs(root, region_name, endpoint_url, value, role_arn):
     inputs = {}
     if not root:
         return None
@@ -144,7 +147,9 @@ def get_inputs(root, region_name, endpoint_url, value):
 
                 file_path = path / file
                 with file_path.open("r", encoding="utf-8") as f:
-                    overrides_raw = render_jinja(f.read(), region_name, endpoint_url)
+                    overrides_raw = render_jinja(
+                        f.read(), region_name, endpoint_url, role_arn
+                    )
                 overrides = {}
                 for pointer, obj in overrides_raw.items():
                     overrides[pointer] = obj
@@ -175,13 +180,17 @@ def test(args):
     project.load()
 
     overrides = get_overrides(
-        project.root, args.region, args.cloudformation_endpoint_url
+        project.root, args.region, args.cloudformation_endpoint_url, args.role_arn
     )
 
     index = 1
     while True:
         inputs = get_inputs(
-            project.root, args.region, args.cloudformation_endpoint_url, index
+            project.root,
+            args.region,
+            args.cloudformation_endpoint_url,
+            index,
+            args.role_arn,
         )
         if not inputs:
             break

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -556,6 +556,46 @@ def test_call_sync(resource_client, action):
     assert response == {"status": OperationStatus.SUCCESS.value}
 
 
+def test_call_docker():
+    patch_sesh = patch(
+        "rpdk.core.contract.resource_client.create_sdk_session", autospec=True
+    )
+    patch_creds = patch(
+        "rpdk.core.contract.resource_client.get_temporary_credentials",
+        autospec=True,
+        return_value={},
+    )
+    patch_account = patch(
+        "rpdk.core.contract.resource_client.get_account",
+        autospec=True,
+        return_value=ACCOUNT,
+    )
+    patch_docker = patch("rpdk.core.contract.resource_client.docker", autospec=True)
+    with patch_sesh as mock_create_sesh, patch_docker as mock_docker, patch_creds:
+        with patch_account:
+            mock_client = mock_docker.from_env.return_value
+            mock_sesh = mock_create_sesh.return_value
+            mock_sesh.region_name = DEFAULT_REGION
+            resource_client = ResourceClient(
+                DEFAULT_FUNCTION,
+                "url",
+                DEFAULT_REGION,
+                {},
+                EMPTY_OVERRIDE,
+                docker_image="docker_image",
+                executable_entrypoint="entrypoint",
+            )
+
+    mock_client.containers.run.return_value = str.encode(
+        'StartResponse-{"status": "SUCCESS"}-EndResponse'
+    )
+    status, response = resource_client.call("CREATE", {"resourceModel": SCHEMA})
+
+    mock_client.containers.run.assert_called_once()
+    assert status == OperationStatus.SUCCESS
+    assert response == {"status": OperationStatus.SUCCESS.value}
+
+
 @pytest.mark.parametrize("action", [Action.CREATE, Action.UPDATE, Action.DELETE])
 def test_call_async(resource_client, action):
     mock_client = resource_client._client

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -80,7 +80,7 @@ def resource_client():
 
     mock_sesh.client.assert_called_once_with("lambda", endpoint_url=endpoint)
     mock_creds.assert_called_once_with(mock_sesh, LOWER_CAMEL_CRED_KEYS, None)
-    mock_account.assert_called_once_with(mock_sesh)
+    mock_account.assert_called_once_with(mock_sesh, {})
     assert client._creds == {}
     assert client._function_name == DEFAULT_FUNCTION
     assert client._schema == {}
@@ -121,7 +121,7 @@ def resource_client_inputs():
 
     mock_sesh.client.assert_called_once_with("lambda", endpoint_url=endpoint)
     mock_creds.assert_called_once_with(mock_sesh, LOWER_CAMEL_CRED_KEYS, None)
-    mock_account.assert_called_once_with(mock_sesh)
+    mock_account.assert_called_once_with(mock_sesh, {})
 
     assert client._creds == {}
     assert client._function_name == DEFAULT_FUNCTION
@@ -213,7 +213,9 @@ def test_init_sam_cli_client():
         "rpdk.core.contract.resource_client.create_sdk_session", autospec=True
     )
     patch_creds = patch(
-        "rpdk.core.contract.resource_client.get_temporary_credentials", autospec=True
+        "rpdk.core.contract.resource_client.get_temporary_credentials",
+        autospec=True,
+        return_value={},
     )
     patch_account = patch(
         "rpdk.core.contract.resource_client.get_account",
@@ -232,7 +234,7 @@ def test_init_sam_cli_client():
         "lambda", endpoint_url=DEFAULT_ENDPOINT, use_ssl=False, verify=False, config=ANY
     )
     mock_creds.assert_called_once_with(mock_sesh, LOWER_CAMEL_CRED_KEYS, None)
-    mock_account.assert_called_once_with(mock_sesh)
+    mock_account.assert_called_once_with(mock_sesh, {})
     assert client.account == ACCOUNT
 
 

--- a/tests/test_boto_helpers.py
+++ b/tests/test_boto_helpers.py
@@ -203,7 +203,37 @@ def test_get_temporary_credentials_assume_role():
 def test_get_account():
     session = create_autospec(spec=Session, spec_set=True)
     client = session.client.return_value
+    session.region_name = "us-east-1"
     get_account(session)
 
-    session.client.assert_called_once_with("sts")
+    session.client.assert_called_once_with(
+        "sts",
+        endpoint_url="https://sts.us-east-1.amazonaws.com",
+        region_name="us-east-1",
+    )
+    client.get_caller_identity.assert_called_once()
+
+
+def test_get_account_with_temporary_credentials():
+    session = create_autospec(spec=Session, spec_set=True)
+    client = session.client.return_value
+    session.region_name = "us-east-1"
+    access_key = object()
+    secret_key = object()
+    token = object()
+    creds = {
+        "accessKeyId": access_key,
+        "secretAccessKey": secret_key,
+        "sessionToken": token,
+    }
+    get_account(session, creds)
+
+    session.client.assert_called_once_with(
+        "sts",
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        aws_session_token=token,
+        endpoint_url="https://sts.us-east-1.amazonaws.com",
+        region_name="us-east-1",
+    )
     client.get_caller_identity.assert_called_once()

--- a/tests/test_boto_helpers.py
+++ b/tests/test_boto_helpers.py
@@ -200,20 +200,6 @@ def test_get_temporary_credentials_assume_role():
     assert tuple(creds.values()) == (access_key, secret_key, token)
 
 
-def test_get_account():
-    session = create_autospec(spec=Session, spec_set=True)
-    client = session.client.return_value
-    session.region_name = "us-east-1"
-    get_account(session)
-
-    session.client.assert_called_once_with(
-        "sts",
-        endpoint_url="https://sts.us-east-1.amazonaws.com",
-        region_name="us-east-1",
-    )
-    client.get_caller_identity.assert_called_once()
-
-
 def test_get_account_with_temporary_credentials():
     session = create_autospec(spec=Session, spec_set=True)
     client = session.client.return_value

--- a/tests/test_build_image.py
+++ b/tests/test_build_image.py
@@ -1,0 +1,55 @@
+from unittest.mock import ANY, Mock, patch
+
+from rpdk.core.build_image import _get_executable_name, build_image
+from rpdk.core.cli import main
+from rpdk.core.project import Project
+
+
+def test_build_image():
+    mock_project = Mock(spec=Project)
+    mock_project.type_info = ("AWS", "color", "red")
+    mock_project.runtime = "java8"
+    executable_name = "aws-color-red-handler-1.0-SNAPSHOT"
+    image_name = "aws-color-red"
+
+    patch_docker = patch("rpdk.core.build_image.docker", autospec=True)
+    patch_project = patch(
+        "rpdk.core.build_image.Project", autospec=True, return_value=mock_project
+    )
+
+    with patch_project, patch_docker as mock_docker:
+        mock_client = mock_docker.from_env.return_value
+        main(args_in=["build-image"])
+
+    mock_project.load.assert_called_once_with()
+    mock_docker.from_env.assert_called_once()
+    build_arguments = {
+        "buildargs": {"executable_name": executable_name},
+        "dockerfile": ANY,
+        "path": ANY,
+        "tag": image_name,
+    }
+    mock_client.images.build.assert_called_once_with(**build_arguments)
+
+
+def test_build_image_unsupported_runtime():
+    mock_project = Mock(spec=Project)
+    mock_project.type_info = ("AWS", "color", "red")
+    mock_project.runtime = "not_supported"
+
+    patch_project = patch(
+        "rpdk.core.build_image.Project", autospec=True, return_value=mock_project
+    )
+
+    with patch_project:
+        try:
+            build_image({})
+        except ValueError:
+            pass
+
+    mock_project.load.assert_called_once_with()
+
+
+def test_get_executable_name_unknown_runtime():
+    result = _get_executable_name("not_supported", ("AWS", "color", "red"))
+    assert result is None

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -87,6 +87,7 @@ def test_value_error_on_json_load(capsys, invalid_payload, command):
     mock_project = Mock(spec=Project)
     mock_project.schema = {}
     mock_project.root = None
+    mock_project.executable_entrypoint = None
 
     patch_project = patch(
         "rpdk.core.invoke.Project", autospec=True, return_value=mock_project
@@ -118,6 +119,7 @@ def test_keyboard_interrupt(capsys, payload_path, command):
     mock_project = Mock(spec=Project)
     mock_project.schema = {}
     mock_project.root = None
+    mock_project.executable_entrypoint = None
 
     patch_project = patch(
         "rpdk.core.invoke.Project", autospec=True, return_value=mock_project
@@ -167,6 +169,7 @@ def _invoke_and_expect(status, payload_path, command, *args):
     mock_project = Mock(spec=Project)
     mock_project.schema = {}
     mock_project.root = None
+    mock_project.executable_entrypoint = None
 
     patch_project = patch(
         "rpdk.core.invoke.Project", autospec=True, return_value=mock_project


### PR DESCRIPTION
*Description of changes:* This introduces a new command cfn build-image and changes to resource_client.

The command build-image will initially only support the java plugin, but can be expanded to other plugins. The command will create an image based off of the jar in the target folder. The image can then be run with docker in order to provide an alternative to sam cli. The entry point to the container is a new entry point that does not have a dependency on lambda. 

When an image name and entry point is specified for the resource client, it will start a docker container instead of invoking a lambda. 

Relevant java plugin cr: https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/pull/308   

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.