### PR TITLE
Compared create/update input to read output

### DIFF
--- a/src/rpdk/core/contract/suite/handler_create.py
+++ b/src/rpdk/core/contract/suite/handler_create.py
@@ -32,7 +32,7 @@ def created_resource(resource_client):
         )
         model = response["resourceModel"]
         test_input_equals_output(resource_client, input_model, model)
-        yield model, request
+        yield input_model, model, request
     finally:
         resource_client.call_and_assert(Action.DELETE, OperationStatus.SUCCESS, model)
 
@@ -76,21 +76,24 @@ def _create_with_invalid_model(resource_client):
 @pytest.mark.create
 @skip_not_writable_identifier
 def contract_create_duplicate(created_resource, resource_client):
-    _created_model, request = created_resource
+    _input_model, _created_model, request = created_resource
     test_create_failure_if_repeat_writeable_id(resource_client, request)
 
 
 @pytest.mark.create
 @pytest.mark.read
 def contract_create_read_success(created_resource, resource_client):
-    created_model, _request = created_resource
-    test_read_success(resource_client, created_model)
+    input_model, created_model, _request = created_resource
+    read_response = test_read_success(resource_client, created_model)
+    test_input_equals_output(
+        resource_client, input_model, read_response["resourceModel"]
+    )
 
 
 @pytest.mark.create
 @pytest.mark.list
 @pytest.mark.read
 def contract_create_list_success(created_resource, resource_client):
-    created_model, _request = created_resource
+    _input_model, created_model, _request = created_resource
     assert test_model_in_list(resource_client, created_model)
     test_read_success(resource_client, created_model)

--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -32,7 +32,9 @@ def updated_resource(resource_client):
         updated_model = response["resourceModel"]
         test_input_equals_output(resource_client, updated_input_model, updated_model)
 
-        yield create_request, created_model, update_request, updated_model
+        # flake8: noqa: B950
+        # pylint: disable=C0301
+        yield create_request, created_model, update_request, updated_model, updated_input_model
     finally:
         resource_client.call_and_assert(Action.DELETE, OperationStatus.SUCCESS, model)
 
@@ -42,12 +44,21 @@ def updated_resource(resource_client):
 def contract_update_read_success(updated_resource, resource_client):
     # should be able to use the created model
     # to read since physical resource id is immutable
-    _create_request, _created_model, _update_request, updated_model = updated_resource
+    (
+        _create_request,
+        _created_model,
+        _update_request,
+        updated_model,
+        updated_input_model,
+    ) = updated_resource
     assert resource_client.is_primary_identifier_equal(
         resource_client.primary_identifier_paths, _created_model, updated_model
     ), "The primaryIdentifier returned must match\
          the primaryIdentifier passed into the request"
-    test_read_success(resource_client, updated_model)
+    read_response = test_read_success(resource_client, updated_model)
+    test_input_equals_output(
+        resource_client, updated_input_model, read_response["resourceModel"]
+    )
 
 
 @pytest.mark.update
@@ -55,7 +66,13 @@ def contract_update_read_success(updated_resource, resource_client):
 def contract_update_list_success(updated_resource, resource_client):
     # should be able to use the created model
     # to read since physical resource id is immutable
-    _create_request, _created_model, _update_request, updated_model = updated_resource
+    (
+        _create_request,
+        _created_model,
+        _update_request,
+        updated_model,
+        _updated_input_model,
+    ) = updated_resource
     assert resource_client.is_primary_identifier_equal(
         resource_client.primary_identifier_paths, _created_model, updated_model
     ), "The primaryIdentifier returned must match\


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This ensures the input to create/update handler is equal to the output of read handler. This ensure the resource is not falsely drifted.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
