### PR TITLE
Remove cloudformation.amazonaws.com Service principal

### DIFF
--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -106,7 +106,6 @@ Resources:
         - Effect: Allow
           Principal:
             Service:
-              - cloudformation.amazonaws.com
               - resources.cloudformation.amazonaws.com
           Action: sts:AssumeRole
       Path: "/"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*. The `LogAndMetricsDeliveryRole` will only be assumed-role by `resources.cloudformation.amazonaws.com`. Remove unused service principal.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
