### PR TITLE
Fix cfn invoke with TypeFunction entry point

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ branch = True
 omit = */contract/suite/*
 
 [report]
-fail_under = 99.91
+fail_under = 100

--- a/src/rpdk/core/invoke.py
+++ b/src/rpdk/core/invoke.py
@@ -31,7 +31,9 @@ def invoke(args):
         request = json.load(args.request)
     except ValueError as e:
         raise SysExitRecommendedError(f"Invalid JSON: {e}") from e
-    payload = client._make_payload(action, request)
+    payload = client._make_payload(
+        action, request["desiredResourceState"], request["previousResourceState"]
+    )
 
     current_invocation = 0
 

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -20,8 +20,8 @@ def payload_path(tmp_path):
     with path.open("w", encoding="utf-8") as f:
         json.dump(
             {
-                "desiredResourceState": None,
-                "previousResourceState": None,
+                "desiredResourceState": {"foo": "bar"},
+                "previousResourceState": {"foo": "prev_bar"},
                 "logicalResourceIdentifier": None,
             },
             f,


### PR DESCRIPTION
*Issue #, if available:*https://github.com/aws-cloudformation/cloudformation-cli/issues/594

*Description of changes:*

* Updated the coverage to 100%
* Fixed the cfn invoke functionality

*Test:*

Ran cfn invoke

```
=== Handler input ===
{
  "requestData": {
    "callerCredentials": {
      "accessKeyId": "",
      "secretAccessKey": "",
      "sessionToken": ""
    },
    "resourceProperties": {
      "AlarmName": "TestAlarm1",
      "AlarmDescription": "TestAlarmDimensions Description",
      "Namespace": "CloudWatchNamespace",
      "MetricName": "Fault",
      "Statistic": "Average",
      "Period": 60,
      "EvaluationPeriods": 5,
      "Threshold": 0.01,
      "ComparisonOperator": "GreaterThanOrEqualToThreshold"
    },
    "previousResourceProperties": {
      "AlarmName": "TestAlarm1",
      "AlarmDescription": "TestAlarmDimensions Description",
      "Namespace": "CloudWatchNamespace",
      "MetricName": "Fault",
      "Statistic": "Average",
      "Period": 60,
      "EvaluationPeriods": 5,
      "Threshold": 0.01,
      "ComparisonOperator": "GreaterThanOrEqualToThreshold"
    }
  },
  "region": "us-east-1",
  "awsAccountId": "594820947549",
  "action": "CREATE",
  "callbackContext": null,
  "bearerToken": "db8eae3e-57d5-4f77-b94a-951fb0036bdf",
  "credentials": "<redacted>"
}
=== Handler response ===
{
  "status": "SUCCESS",
  "callbackContext": {
    "callGraphs": {
      "monitoring:PutMetricAlarm-cloudwatch::create-alarm-764210360.request": [
        "software.amazon.awssdk.services.cloudwatch.model.PutMetricAlarmRequest",
        {
          "AlarmName": "TestAlarm1",
          "AlarmDescription": "TestAlarmDimensions Description",
          "OKActions": [],
          "AlarmActions": [],
          "InsufficientDataActions": [],
          "MetricName": "Fault",
          "Namespace": "CloudWatchNamespace",
          "Statistic": "Average",
          "Dimensions": [],
          "Period": 60,
          "EvaluationPeriods": 5,
          "Threshold": 0.01,
          "ComparisonOperator": "GreaterThanOrEqualToThreshold",
          "Metrics": [],
          "Tags": []
        }
      ],
      "monitoring:PutMetricAlarm-cloudwatch::create-alarm-764210360.attempts": 1,
      "monitoring:PutMetricAlarm-cloudwatch::create-alarm-764210360.response": [
        "software.amazon.awssdk.services.cloudwatch.model.PutMetricAlarmResponse",
        {}
      ]
    }
  },
  "callbackDelaySeconds": 0,
  "resourceModel": {
    "ComparisonOperator": "GreaterThanOrEqualToThreshold",
    "Period": 60,
    "EvaluationPeriods": 5,
    "Namespace": "CloudWatchNamespace",
    "MetricName": "Fault",
    "AlarmDescription": "TestAlarmDimensions Description",
    "AlarmName": "TestAlarm1",
    "Statistic": "Average",
    "Arn": "arn:aws:cloudwatch:us-east-1:594820947549:alarm:TestAlarm1",
    "Threshold": 0.01
  }
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
