### PR TITLE
Add replacement Strategy to schema

### DIFF
--- a/src/rpdk/core/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.v1.json
@@ -74,9 +74,7 @@
         "replacementStrategy": {
             "type": "string",
             "description": "The valid replacement strategies are create_then_delete and delete_then_create. All other inputs are invalid.",
-            "default": [
-                "create_then_delete"
-            ],
+            "default": "create_then_delete",
             "enum": [
                 "create_then_delete",
                 "delete_then_create"

--- a/src/rpdk/core/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.v1.json
@@ -71,6 +71,17 @@
                 }
             }
         },
+        "replacementStrategy": {
+            "type": "string",
+            "description": "The valid replacement strategies are [create_then_delete] and [delete_then_create]. All other inputs are invalid.",
+            "default": [
+                "create_then_delete"
+            ],
+            "enum": [
+                "create_then_delete",
+                "delete_then_create"
+            ]
+        },
         "properties": {
             "allOf": [
                 {
@@ -291,6 +302,10 @@
                 "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/CHAP_Using.html"
             ],
             "$ref": "#/definitions/httpsUrl"
+        },
+        "replacementStrategy": {
+            "$comment": "The order of replacement for an immutable resource update.",
+            "$ref": "#/definitions/replacementStrategy"
         },
         "additionalProperties": {
             "$comment": "All properties of a resource must be expressed in the schema - arbitrary inputs are not allowed",

--- a/src/rpdk/core/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.v1.json
@@ -73,7 +73,7 @@
         },
         "replacementStrategy": {
             "type": "string",
-            "description": "The valid replacement strategies are [create_then_delete] and [delete_then_create]. All other inputs are invalid.",
+            "description": "The valid replacement strategies are create_then_delete and delete_then_create. All other inputs are invalid.",
             "default": [
                 "create_then_delete"
             ],


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-cloudformation/aws-cloudformation-resource-schema/pull/86

*Description of changes:*
Description of changes: Allow replacement Strategy in the schema. This allows immutable singleton resources to update in the order of delete then create.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
