### PR TITLE
Set strict timestamp to false in zip file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "hypothesis>=4.32",
         "colorama>=0.4.1",
         "docker>=4.3.1",
+        "zipfile38>=0.0.2,<0.2",
     ],
     entry_points={
         "console_scripts": ["cfn-cli = rpdk.core.cli:main", "cfn = rpdk.core.cli:main"]

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -375,7 +375,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
             # pylint: disable=unexpected-keyword-arg
             # the default compression is ZIP_STORED, which helps with the
             # file-size check on upload
-            with ZipFile(f, mode="w", strict_timestamps=False) as zip_file:
+            with ZipFile(f, mode="w", strict_timestamps=True) as zip_file:
                 zip_file.write(self.schema_path, SCHEMA_UPLOAD_FILENAME)
                 zip_file.write(self.settings_path, SETTINGS_FILENAME)
                 try:

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 import zipfile
 from pathlib import Path
 from tempfile import TemporaryFile
@@ -26,6 +27,12 @@ from .jsonutils.pointer import fragment_decode, fragment_encode
 from .jsonutils.utils import traverse
 from .plugin_registry import load_plugin
 from .upload import Uploader
+
+if sys.version_info >= (3, 8):  # pragma: no cover
+    from zipfile import ZipFile
+else:  # pragma: no cover
+    from zipfile38 import ZipFile
+
 
 LOG = logging.getLogger(__name__)
 
@@ -365,9 +372,10 @@ class Project:  # pylint: disable=too-many-instance-attributes
             context_mgr = TemporaryFile("w+b")
 
         with context_mgr as f:
+            # pylint: disable=unexpected-keyword-arg
             # the default compression is ZIP_STORED, which helps with the
             # file-size check on upload
-            with zipfile.ZipFile(f, mode="w") as zip_file:
+            with ZipFile(f, mode="w", strict_timestamps=False) as zip_file:
                 zip_file.write(self.schema_path, SCHEMA_UPLOAD_FILENAME)
                 zip_file.write(self.settings_path, SETTINGS_FILENAME)
                 try:

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -374,7 +374,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
             # pylint: disable=unexpected-keyword-arg
             # the default compression is ZIP_STORED, which helps with the
             # file-size check on upload
-            with ZipFile(f, mode="w", strict_timestamps=True) as zip_file:
+            with ZipFile(f, mode="w", strict_timestamps=False) as zip_file:
                 zip_file.write(self.schema_path, SCHEMA_UPLOAD_FILENAME)
                 zip_file.write(self.settings_path, SETTINGS_FILENAME)
                 try:

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -3,7 +3,6 @@ import logging
 import os
 import shutil
 import sys
-import zipfile
 from pathlib import Path
 from tempfile import TemporaryFile
 from uuid import uuid4

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -569,6 +569,7 @@ def test_submit_dry_run(project):
 
     with project.schema_path.open("w", encoding="utf-8") as f:
         f.write(CONTENTS_UTF8)
+    os.utime(project.schema_path, (1602179630, 10000))
 
     with project.overrides_path.open("w", encoding="utf-8") as f:
         f.write(json.dumps(empty_override()))

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -6,7 +6,7 @@ import logging
 import os
 import random
 import string
-import zipfile
+import sys
 from contextlib import contextmanager
 from io import StringIO
 from pathlib import Path
@@ -36,6 +36,12 @@ from rpdk.core.test import empty_override
 from rpdk.core.upload import Uploader
 
 from .utils import CONTENTS_UTF8, UnclosingBytesIO
+
+if sys.version_info >= (3, 8):  # pragma: no cover
+    from zipfile import ZipFile
+else:  # pragma: no cover
+    from zipfile38 import ZipFile
+
 
 LANGUAGE = "BQHDBC"
 TYPE_NAME = "AWS::Color::Red"
@@ -595,7 +601,8 @@ def test_submit_dry_run(project):
     mock_plugin.package.assert_called_once_with(project, ANY)
     mock_upload.assert_not_called()
 
-    with zipfile.ZipFile(zip_path, mode="r") as zip_file:
+    # pylint: disable=unexpected-keyword-arg
+    with ZipFile(zip_path, mode="r", strict_timestamps=False) as zip_file:
         assert set(zip_file.namelist()) == {
             SCHEMA_UPLOAD_FILENAME,
             SETTINGS_FILENAME,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Writing to a zip file will fail with the following message whenever the file have an old modified timestamp:
```
ZIP does not support timestamps before 1980
```

To avoid that, we will use a new argument called `strict_timestamps ` introduced to the [ZipFile library](https://docs.python.org/3.8/library/zipfile.html#zipfile-objects) in Python 3.8.

This is related to the following issue with Node.js dependencies: https://github.com/aws/aws-cli/issues/2639.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.