### PR TITLE
Ensure required property is present in generated documentation

### DIFF
--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -421,6 +421,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
             name: self._set_docs_properties(name, value, (name,))
             for name, value in self._flattened_schema[()]["properties"].items()
         }
+        docs_schema["required"] = self._flattened_schema[()].get("required")
 
         LOG.debug("Finished documenting nested properties")
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Whenever the required property was part of a combiner (e.g. `anyOf`) in a resource schema, the generated documentation would ignored it. This changed will ensure that required fields will be flattened and then used by the documentation generator.

You can check a documentation example [here](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-cloudformation/tree/master/aws-cloudformation-resourcedefaultversion/docs) where the required property are ignored.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
