### PR TITLE
Add check for insertionOrder and unique for drift parity

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -166,6 +166,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         self.read_only_paths = self._properties_to_paths("readOnlyProperties")
         self.write_only_paths = self._properties_to_paths("writeOnlyProperties")
         self.create_only_paths = self._properties_to_paths("createOnlyProperties")
+        self.insertion_order = self.get_metadata("insertionOrder")
 
         additional_identifiers = self._schema.get("additionalIdentifiers", [])
         self._additional_identifiers_paths = [
@@ -185,6 +186,21 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
                 for write_only_property in self.write_only_paths
             ), "The model MUST NOT return properties defined as \
                 writeOnlyProperties in the resource schema"
+
+    def get_metadata(self, metadata_key):
+        metadata = []
+        try:
+            properties = self._schema["properties"]
+        except KeyError:
+            return metadata
+
+        for prop in properties:
+            try:
+                if properties[prop][metadata_key] == "false":
+                    metadata.append(prop)
+            except KeyError:
+                continue
+        return metadata
 
     @property
     def strategy(self):

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -166,7 +166,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         self.read_only_paths = self._properties_to_paths("readOnlyProperties")
         self.write_only_paths = self._properties_to_paths("writeOnlyProperties")
         self.create_only_paths = self._properties_to_paths("createOnlyProperties")
-        self.insertion_order = self.get_metadata("insertionOrder")
+        self.properties_without_insertion_order = self.get_metadata()
 
         additional_identifiers = self._schema.get("additionalIdentifiers", [])
         self._additional_identifiers_paths = [
@@ -187,20 +187,22 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             ), "The model MUST NOT return properties defined as \
                 writeOnlyProperties in the resource schema"
 
-    def get_metadata(self, metadata_key):
+    def get_metadata(self):
         metadata = []
         try:
             properties = self._schema["properties"]
         except KeyError:
             return metadata
 
-        for prop in properties:
-            try:
-                if properties[prop][metadata_key] == "false":
-                    metadata.append(prop)
-            except KeyError:
-                continue
-        return metadata
+        metadata.append(
+            [
+                prop
+                for prop in properties.keys()
+                if "insertionOrder" in properties[prop]
+                and properties[prop]["insertionOrder"] == "false"
+            ]
+        )
+        return metadata[0]
 
     @property
     def strategy(self):

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -188,21 +188,17 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
                 writeOnlyProperties in the resource schema"
 
     def get_metadata(self):
-        metadata = []
         try:
             properties = self._schema["properties"]
         except KeyError:
-            return metadata
-
-        metadata.append(
-            [
+            return set()
+        else:
+            return {
                 prop
                 for prop in properties.keys()
                 if "insertionOrder" in properties[prop]
                 and properties[prop]["insertionOrder"] == "false"
-            ]
-        )
-        return metadata[0]
+            }
 
     @property
     def strategy(self):

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -169,7 +169,10 @@ def test_input_equals_output(resource_client, input_model, output_model):
     # ignoring extraneous properties that maybe present in output model.
     try:
         for key in pruned_input_model:
-            if pruned_input_model[key] in resource_client.insertion_order:
+            if (
+                pruned_input_model[key]
+                in resource_client.properties_without_insertion_order
+            ):
                 assert test_unordered_list_match(
                     pruned_input_model[key], pruned_output_model[key]
                 )

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -168,9 +168,22 @@ def test_input_equals_output(resource_client, input_model, output_model):
     # only comparing properties in input model to those in output model and
     # ignoring extraneous properties that maybe present in output model.
     try:
-        assert all(
-            pruned_input_model[key] == pruned_output_model[key]
-            for key in pruned_input_model
-        ), assertion_error_message
+        for key in pruned_input_model:
+            if pruned_input_model[key] in resource_client.insertion_order:
+                assert test_unordered_list_match(
+                    pruned_input_model[key], pruned_output_model[key]
+                )
+            else:
+                assert (
+                    pruned_input_model[key] == pruned_output_model[key]
+                ), assertion_error_message
     except KeyError as e:
         raise AssertionError(assertion_error_message) from e
+
+
+def test_unordered_list_match(inputs, outputs):
+    assert len(inputs) == len(outputs)
+    try:
+        assert all(input in outputs for input in inputs)
+    except KeyError as exception:
+        raise AssertionError("lists do not match") from exception

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -264,7 +264,7 @@ def test_get_metadata(resource_client):
         "createOnlyProperties": ["/properties/d"],
     }
     resource_client._update_schema(schema)
-    assert resource_client.get_metadata() == ["b"]
+    assert resource_client.get_metadata() == {"b"}
 
 
 def test_update_schema(resource_client):

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -264,7 +264,7 @@ def test_get_metadata(resource_client):
         "createOnlyProperties": ["/properties/d"],
     }
     resource_client._update_schema(schema)
-    assert resource_client.get_metadata("insertionOrder") == ["b"]
+    assert resource_client.get_metadata() == ["b"]
 
 
 def test_update_schema(resource_client):

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -252,6 +252,21 @@ def test_make_request():
     }
 
 
+def test_get_metadata(resource_client):
+    schema = {
+        "properties": {
+            "a": {"type": "array", "const": 1, "insertionOrder": "true"},
+            "b": {"type": "number", "const": 2, "insertionOrder": "false"},
+            "c": {"type": "number", "const": 3},
+            "d": {"type": "number", "const": 4},
+        },
+        "readOnlyProperties": ["/properties/c"],
+        "createOnlyProperties": ["/properties/d"],
+    }
+    resource_client._update_schema(schema)
+    assert resource_client.get_metadata("insertionOrder") == ["b"]
+
+
 def test_update_schema(resource_client):
     resource_client._strategy = object()
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/cloudformation-cli/issues/580

*Description of changes:* This CR has a change for insertionOrder metadata check. It is added to ensure drift parity. This metadata if set to false ensures order does not matters

*Test*
* unit test
* ran contract test
```
(env) 3c22fbb25c23:aws-cloudwatch-alarm anshikg$ cfn test --enforce-timeout 120
=================================================================================================================== test session starts ====================================================================================================================
platform darwin -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/rpdk/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/rpdk/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm, configfile: ../../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_zitq3qml.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3, black-0.3.10
collected 16 items                                                                                                                                                                                                                                         

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                     [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                                    [ 12%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                                                  [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                               [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                               [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                       [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                                       [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                                     [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                     [ 56%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                                                     [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                  [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                 [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                               [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                               [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                                                                                                               [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                              [100%]

============================================================================================================== 16 passed in 684.48s (0:11:24) ==============================================================================================================

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
