### PR TITLE
prune readonly paths from input model for test_input_equals_output

### DIFF
--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -6,6 +6,7 @@ import pytest
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
 from rpdk.core.contract.interface import Action, OperationStatus
+from rpdk.core.contract.resource_client import prune_properties_from_model
 from rpdk.core.contract.suite.handler_commons import (
     test_input_equals_output,
     test_model_in_list,
@@ -26,6 +27,11 @@ def updated_resource(resource_client):
         updated_input_model = update_request = resource_client.generate_update_example(
             created_model
         )
+
+        updated_input_model = prune_properties_from_model(
+            updated_input_model, resource_client.read_only_paths
+        )
+
         _status, response, _error = resource_client.call_and_assert(
             Action.UPDATE, OperationStatus.SUCCESS, update_request, created_model
         )


### PR DESCRIPTION
If read only paths change with updates, contract tests fail because the readonly property value does not match the previous value.
This change prunes readonly paths from the input model so when comparing input model to output model, readonly paths are not considered.

*Issue #, if available:* [609](https://github.com/aws-cloudformation/cloudformation-cli/issues/609)

*Description of changes:* prune readonly paths from input model in `test_input_equals_output`, and update the message accordingly. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
