### PR TITLE
Add propertyTransform to transform the properties to expected output

### DIFF
--- a/src/rpdk/core/data/schema/meta-schema.json
+++ b/src/rpdk/core/data/schema/meta-schema.json
@@ -241,5 +241,13 @@
             "$ref": "#"
         }
     },
+    "propertyTransform": {
+        "type": "object",
+        "patternProperties": {
+            "^[A-Za-z0-9]{1,64}$": {
+                "type": "string"
+            }
+        }
+    },
     "default": true
 }

--- a/src/rpdk/core/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.v1.json
@@ -316,6 +316,14 @@
             },
             "additionalProperties": false
         },
+        "propertyTransform": {
+            "type": "object",
+            "patternProperties": {
+                "^[A-Za-z0-9]{1,64}$": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers": {
             "description": "Defines the provisioning operations which can be performed on this resource type",
             "type": "object",


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:* Adding a property transform function to define what the read handler would return for created/updated property. This change is ensuring the cfn validate does not fail on propertyTransform.

*Test:*
* pre-commit run --all-files
* run ```cfn validate``` for a schema file with ```propertyTransform``` set.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
