### PR TITLE
use dict key instead of value when checking properties without insert…

### DIFF
--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -169,10 +169,7 @@ def test_input_equals_output(resource_client, input_model, output_model):
     # ignoring extraneous properties that maybe present in output model.
     try:
         for key in pruned_input_model:
-            if (
-                pruned_input_model[key]
-                in resource_client.properties_without_insertion_order
-            ):
+            if key in resource_client.properties_without_insertion_order:
                 assert test_unordered_list_match(
                     pruned_input_model[key], pruned_output_model[key]
                 )


### PR DESCRIPTION
*Issue #, if available:* #613 

*Description of changes:* Use dict key of `pruned_input_model` to check property key existence in `resource_client.properties_without_insertion_order`, instead of dict value. Otherwise Python will complain "TypeError: unhashable type: 'dict'" when input model has nested dicts (json objects)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
