### PR TITLE
Remove redundant check

### DIFF
--- a/src/rpdk/core/contract/suite/contract_asserts.py
+++ b/src/rpdk/core/contract/suite/contract_asserts.py
@@ -78,17 +78,6 @@ def response_does_not_contain_write_only_properties(resource_client, response):
 
 
 @decorate()
-def response_contains_resource_model_equal_current_model(
-    response, current_resource_model
-):
-    assert (
-        response["resourceModel"] == current_resource_model
-    ), "All properties specified in the request MUST be present in the model \
-        returned, and they MUST match exactly, with the exception of properties\
-             defined as writeOnlyProperties in the resource schema"
-
-
-@decorate()
 def response_contains_resource_model_equal_updated_model(
     response, current_resource_model, update_resource_model
 ):

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -8,7 +8,6 @@ from rpdk.core.contract.resource_client import (
 from rpdk.core.contract.suite.contract_asserts import (
     failed_event,
     response_contains_primary_identifier,
-    response_contains_resource_model_equal_current_model,
     response_contains_resource_model_equal_updated_model,
     response_contains_unchanged_primary_identifier,
     response_does_not_contain_write_only_properties,
@@ -47,7 +46,6 @@ def test_create_failure_if_repeat_writeable_id(resource_client, current_resource
 
 @response_contains_primary_identifier
 @response_does_not_contain_write_only_properties
-@response_contains_resource_model_equal_current_model
 def test_read_success(resource_client, current_resource_model):
     _status, response, _error_code = resource_client.call_and_assert(
         Action.READ, OperationStatus.SUCCESS, current_resource_model


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Read handler output does not need to be compared with the create handler output. We already make a check for read handler output with create handler input [here](https://github.com/aws-cloudformation/cloudformation-cli/blob/master/src/rpdk/core/contract/suite/handler_create.py#L88-L90)

*Test:*
* pre-commit run --all-files
* cfn test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
