### PR TITLE
Dedup plugin choices after fetching them from registry

### DIFF
--- a/src/rpdk/core/plugin_registry.py
+++ b/src/rpdk/core/plugin_registry.py
@@ -11,7 +11,7 @@ def get_plugin_choices():
         entry_point.name
         for entry_point in pkg_resources.iter_entry_points("rpdk.v1.languages")
     ]
-    return sorted(plugin_choices)
+    return sorted(set(plugin_choices))
 
 
 def get_parsers():


### PR DESCRIPTION
*Issue #, if available:* #616 

*Description of changes:*
Multiple entries of the same language were being returned as a plugin choice. Use set() to return only unique choices

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
