### PR TITLE
Multi Ref Support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,8 @@ pytest-random-order>=1.0.4
 hypothesis>=4.32.3
 pytest-localserver>=0.5.0
 
+ordered-set>=4.0.2
+
 # commit hooks
 pre-commit>=1.18.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ include_trailing_comma = true
 combine_as_imports = True
 force_grid_wrap = 0
 known_first_party = rpdk
-known_third_party = boto3,botocore,colorama,docker,hypothesis,jinja2,jsonschema,pkg_resources,pytest,pytest_localserver,setuptools,yaml
+known_third_party = boto3,botocore,colorama,docker,hypothesis,jinja2,jsonschema,ordered_set,pkg_resources,pytest,pytest_localserver,setuptools,yaml
 
 [tool:pytest]
 # can't do anything about 3rd part modules, so don't spam us

--- a/src/rpdk/core/jsonutils/flattener.py
+++ b/src/rpdk/core/jsonutils/flattener.py
@@ -156,7 +156,7 @@ class JsonSchemaFlattener:
             try:
                 schema_array = sub_schema.pop(arr_key)
             except KeyError:
-                continue
+                pass
             else:
                 for i, nested_schema in enumerate(schema_array):
 
@@ -171,10 +171,13 @@ class JsonSchemaFlattener:
                     else:
                         resolved_schema = self._schema_map.pop(ref_path, walked_schema)
                     schema_merge(sub_schema, resolved_schema, path)
-
         if REF in sub_schema and isinstance(
             sub_schema.get(TYPE), list
         ):  # check if there are conflicting $ref and type at the same sub schema
+            # conflicting $ref could happen only on combiners because method merges
+            # two json objects without losing any previous info, hence have to pop
+            # e.g. "oneOf": [{"$ref": "..#1.."},{"$ref": "..#2.."}] ->
+            # { "ref": "..#1..", "type": [{},{}] }
             sub_schema.pop(REF)
         return sub_schema
 

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -646,7 +646,6 @@ class Project:  # pylint: disable=too-many-instance-attributes
             prop[jsontype] = __join(prop.get(jsontype), type_json)
             prop[yamltype] = __join(prop.get(yamltype), type_yaml)
             prop[longformtype] = __join(prop.get(longformtype), type_longform)
-
             if "enum" in prop:
                 prop["allowedvalues"] = prop["enum"]
 
@@ -657,12 +656,19 @@ class Project:  # pylint: disable=too-many-instance-attributes
             prop_type = [prop_type]
             single_item = True
 
-        visited = set()
         for prop_item in prop_type:
-            if prop_item not in visited:
-                visited.add(prop_item)
+            if isinstance(prop_item, tuple):  # if tuple, then it's a ref
+                # using doc method to generate the mdo and reassign the ref
+                resolved = self._set_docs_properties(
+                    propname, {"$ref": prop_item}, proppath
+                )
+                prop[jsontype] = __join(prop.get(jsontype), resolved[jsontype])
+                prop[yamltype] = __join(prop.get(yamltype), resolved[yamltype])
+                prop[longformtype] = __join(
+                    prop.get(longformtype), resolved[longformtype]
+                )
+            else:
                 __set_property_type(prop_item, single_type=single_item)
-
         return prop
 
     def _upload(

--- a/tests/data/schema/target_output/multiref.md
+++ b/tests/data/schema/target_output/multiref.md
@@ -1,0 +1,74 @@
+# AWS::Color::Red
+
+a test schema
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "Type" : "AWS::Color::Red",
+    "Properties" : {
+        "<a href="#propertya" title="PropertyA">PropertyA</a>" : <i><a href="properties4.md">Properties4</a>, <a href="properties3.md">Properties3</a></i>,
+        "<a href="#propertyj" title="PropertyJ">PropertyJ</a>" : <i>String</i>,
+        "<a href="#multiproperty" title="MultiProperty">MultiProperty</a>" : <i><a href="properties2.md">Properties2</a>, <a href="properties4.md">Properties4</a>, <a href="properties3.md">Properties3</a>, Map</i>,
+        "<a href="#multiproperty2" title="MultiProperty2">MultiProperty2</a>" : <i>Integer, Map</i>
+    }
+}
+</pre>
+
+### YAML
+
+<pre>
+Type: AWS::Color::Red
+Properties:
+    <a href="#propertya" title="PropertyA">PropertyA</a>: <i><a href="properties4.md">Properties4</a>, <a href="properties3.md">Properties3</a></i>
+    <a href="#propertyj" title="PropertyJ">PropertyJ</a>: <i>String</i>
+    <a href="#multiproperty" title="MultiProperty">MultiProperty</a>: <i><a href="properties2.md">Properties2</a>, <a href="properties4.md">Properties4</a>, <a href="properties3.md">Properties3</a>, Map</i>
+    <a href="#multiproperty2" title="MultiProperty2">MultiProperty2</a>: <i>Integer, Map</i>
+</pre>
+
+## Properties
+
+#### PropertyA
+
+_Required_: No
+
+_Type_: <a href="properties4.md">Properties4</a>, <a href="properties3.md">Properties3</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### PropertyJ
+
+_Required_: No
+
+_Type_: String
+
+_Minimum_: <code>13</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MultiProperty
+
+_Required_: No
+
+_Type_: <a href="properties2.md">Properties2</a>, <a href="properties4.md">Properties4</a>, <a href="properties3.md">Properties3</a>, Map
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### MultiProperty2
+
+_Required_: No
+
+_Type_: Integer, Map
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+## Return Values
+
+### Ref
+
+When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the MultiProperty.

--- a/tests/data/schema/target_output/multiref.md
+++ b/tests/data/schema/target_output/multiref.md
@@ -14,11 +14,12 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "Properties" : {
         "<a href="#primaryid" title="primaryID">primaryID</a>" : <i>String</i>,
         "<a href="#propertywithmultipleconstraints" title="PropertyWithMultipleConstraints">PropertyWithMultipleConstraints</a>" : <i>String</i>,
+        "<a href="#propertywithmultiplemultiples" title="PropertyWithMultipleMultiples">PropertyWithMultipleMultiples</a>" : <i>String, Map, Integer, Boolean</i>,
         "<a href="#propertywithmultipleprimitives" title="PropertyWithMultiplePrimitives">PropertyWithMultiplePrimitives</a>" : <i>Integer, String, Map</i>,
         "<a href="#propertywithtwocomplextypes" title="PropertyWithTwoComplexTypes">PropertyWithTwoComplexTypes</a>" : <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a></i>,
         "<a href="#propertywithmultiplecomplextypes" title="PropertyWithMultipleComplexTypes">PropertyWithMultipleComplexTypes</a>" : <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a>, <a href="complextypewithcircularref.md">ComplexTypeWithCircularRef</a></i>,
         "<a href="#propertywithmultiplecomplextypesandoneprimitive" title="PropertyWithMultipleComplexTypesAndOnePrimitive">PropertyWithMultipleComplexTypesAndOnePrimitive</a>" : <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a>, <a href="complextypewithcircularref.md">ComplexTypeWithCircularRef</a>, Map</i>,
-        "<a href="#propertywithcomplextypeandprimitive" title="PropertyWithComplexTypeAndPrimitive">PropertyWithComplexTypeAndPrimitive</a>" : <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a></i>,
+        "<a href="#propertywithcomplextypeandprimitive" title="PropertyWithComplexTypeAndPrimitive">PropertyWithComplexTypeAndPrimitive</a>" : <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, Map</i>,
         "<a href="#multiproperty3" title="MultiProperty3">MultiProperty3</a>" : <i>Integer, Map</i>
     }
 }
@@ -31,11 +32,12 @@ Type: AWS::Color::Red
 Properties:
     <a href="#primaryid" title="primaryID">primaryID</a>: <i>String</i>
     <a href="#propertywithmultipleconstraints" title="PropertyWithMultipleConstraints">PropertyWithMultipleConstraints</a>: <i>String</i>
+    <a href="#propertywithmultiplemultiples" title="PropertyWithMultipleMultiples">PropertyWithMultipleMultiples</a>: <i>String, Map, Integer, Boolean</i>
     <a href="#propertywithmultipleprimitives" title="PropertyWithMultiplePrimitives">PropertyWithMultiplePrimitives</a>: <i>Integer, String, Map</i>
     <a href="#propertywithtwocomplextypes" title="PropertyWithTwoComplexTypes">PropertyWithTwoComplexTypes</a>: <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a></i>
     <a href="#propertywithmultiplecomplextypes" title="PropertyWithMultipleComplexTypes">PropertyWithMultipleComplexTypes</a>: <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a>, <a href="complextypewithcircularref.md">ComplexTypeWithCircularRef</a></i>
     <a href="#propertywithmultiplecomplextypesandoneprimitive" title="PropertyWithMultipleComplexTypesAndOnePrimitive">PropertyWithMultipleComplexTypesAndOnePrimitive</a>: <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a>, <a href="complextypewithcircularref.md">ComplexTypeWithCircularRef</a>, Map</i>
-    <a href="#propertywithcomplextypeandprimitive" title="PropertyWithComplexTypeAndPrimitive">PropertyWithComplexTypeAndPrimitive</a>: <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a></i>
+    <a href="#propertywithcomplextypeandprimitive" title="PropertyWithComplexTypeAndPrimitive">PropertyWithComplexTypeAndPrimitive</a>: <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, Map</i>
     <a href="#multiproperty3" title="MultiProperty3">MultiProperty3</a>: <i>Integer, Map</i>
 </pre>
 
@@ -54,6 +56,16 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 _Required_: No
 
 _Type_: String
+
+_Minimum_: <code>13</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### PropertyWithMultipleMultiples
+
+_Required_: No
+
+_Type_: String, Map, Integer, Boolean
 
 _Minimum_: <code>13</code>
 
@@ -95,7 +107,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 _Required_: No
 
-_Type_: <a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>
+_Type_: <a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, Map
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/tests/data/schema/target_output/multiref.md
+++ b/tests/data/schema/target_output/multiref.md
@@ -12,10 +12,14 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 {
     "Type" : "AWS::Color::Red",
     "Properties" : {
-        "<a href="#propertya" title="PropertyA">PropertyA</a>" : <i><a href="properties4.md">Properties4</a>, <a href="properties3.md">Properties3</a></i>,
-        "<a href="#propertyj" title="PropertyJ">PropertyJ</a>" : <i>String</i>,
-        "<a href="#multiproperty" title="MultiProperty">MultiProperty</a>" : <i><a href="properties2.md">Properties2</a>, <a href="properties4.md">Properties4</a>, <a href="properties3.md">Properties3</a>, Map</i>,
-        "<a href="#multiproperty2" title="MultiProperty2">MultiProperty2</a>" : <i>Integer, Map</i>
+        "<a href="#primaryid" title="primaryID">primaryID</a>" : <i>String</i>,
+        "<a href="#propertywithmultipleconstraints" title="PropertyWithMultipleConstraints">PropertyWithMultipleConstraints</a>" : <i>String</i>,
+        "<a href="#propertywithmultipleprimitives" title="PropertyWithMultiplePrimitives">PropertyWithMultiplePrimitives</a>" : <i>Integer, String, Map</i>,
+        "<a href="#propertywithtwocomplextypes" title="PropertyWithTwoComplexTypes">PropertyWithTwoComplexTypes</a>" : <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a></i>,
+        "<a href="#propertywithmultiplecomplextypes" title="PropertyWithMultipleComplexTypes">PropertyWithMultipleComplexTypes</a>" : <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a>, <a href="complextypewithcircularref.md">ComplexTypeWithCircularRef</a></i>,
+        "<a href="#propertywithmultiplecomplextypesandoneprimitive" title="PropertyWithMultipleComplexTypesAndOnePrimitive">PropertyWithMultipleComplexTypesAndOnePrimitive</a>" : <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a>, <a href="complextypewithcircularref.md">ComplexTypeWithCircularRef</a>, Map</i>,
+        "<a href="#propertywithcomplextypeandprimitive" title="PropertyWithComplexTypeAndPrimitive">PropertyWithComplexTypeAndPrimitive</a>" : <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a></i>,
+        "<a href="#multiproperty3" title="MultiProperty3">MultiProperty3</a>" : <i>Integer, Map</i>
     }
 }
 </pre>
@@ -25,23 +29,27 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 Type: AWS::Color::Red
 Properties:
-    <a href="#propertya" title="PropertyA">PropertyA</a>: <i><a href="properties4.md">Properties4</a>, <a href="properties3.md">Properties3</a></i>
-    <a href="#propertyj" title="PropertyJ">PropertyJ</a>: <i>String</i>
-    <a href="#multiproperty" title="MultiProperty">MultiProperty</a>: <i><a href="properties2.md">Properties2</a>, <a href="properties4.md">Properties4</a>, <a href="properties3.md">Properties3</a>, Map</i>
-    <a href="#multiproperty2" title="MultiProperty2">MultiProperty2</a>: <i>Integer, Map</i>
+    <a href="#primaryid" title="primaryID">primaryID</a>: <i>String</i>
+    <a href="#propertywithmultipleconstraints" title="PropertyWithMultipleConstraints">PropertyWithMultipleConstraints</a>: <i>String</i>
+    <a href="#propertywithmultipleprimitives" title="PropertyWithMultiplePrimitives">PropertyWithMultiplePrimitives</a>: <i>Integer, String, Map</i>
+    <a href="#propertywithtwocomplextypes" title="PropertyWithTwoComplexTypes">PropertyWithTwoComplexTypes</a>: <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a></i>
+    <a href="#propertywithmultiplecomplextypes" title="PropertyWithMultipleComplexTypes">PropertyWithMultipleComplexTypes</a>: <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a>, <a href="complextypewithcircularref.md">ComplexTypeWithCircularRef</a></i>
+    <a href="#propertywithmultiplecomplextypesandoneprimitive" title="PropertyWithMultipleComplexTypesAndOnePrimitive">PropertyWithMultipleComplexTypesAndOnePrimitive</a>: <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a>, <a href="complextypewithcircularref.md">ComplexTypeWithCircularRef</a>, Map</i>
+    <a href="#propertywithcomplextypeandprimitive" title="PropertyWithComplexTypeAndPrimitive">PropertyWithComplexTypeAndPrimitive</a>: <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a></i>
+    <a href="#multiproperty3" title="MultiProperty3">MultiProperty3</a>: <i>Integer, Map</i>
 </pre>
 
 ## Properties
 
-#### PropertyA
+#### primaryID
 
 _Required_: No
 
-_Type_: <a href="properties4.md">Properties4</a>, <a href="properties3.md">Properties3</a>
+_Type_: String
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
-#### PropertyJ
+#### PropertyWithMultipleConstraints
 
 _Required_: No
 
@@ -51,15 +59,47 @@ _Minimum_: <code>13</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
-#### MultiProperty
+#### PropertyWithMultiplePrimitives
 
 _Required_: No
 
-_Type_: <a href="properties2.md">Properties2</a>, <a href="properties4.md">Properties4</a>, <a href="properties3.md">Properties3</a>, Map
+_Type_: Integer, String, Map
 
-_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
-#### MultiProperty2
+#### PropertyWithTwoComplexTypes
+
+_Required_: No
+
+_Type_: <a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### PropertyWithMultipleComplexTypes
+
+_Required_: No
+
+_Type_: <a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a>, <a href="complextypewithcircularref.md">ComplexTypeWithCircularRef</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### PropertyWithMultipleComplexTypesAndOnePrimitive
+
+_Required_: No
+
+_Type_: <a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a>, <a href="complextypewithcircularref.md">ComplexTypeWithCircularRef</a>, Map
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### PropertyWithComplexTypeAndPrimitive
+
+_Required_: No
+
+_Type_: <a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MultiProperty3
 
 _Required_: No
 
@@ -71,4 +111,4 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 ### Ref
 
-When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the MultiProperty.
+When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the primaryID.

--- a/tests/data/schema/valid/valid_multiref_property.json
+++ b/tests/data/schema/valid/valid_multiref_property.json
@@ -49,6 +49,27 @@
                 }
             ]
         },
+        "PropertyWithMultipleMultiples": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "minLength": 3
+                },
+                {
+                    "type": "string",
+                    "minLength": 13
+                },
+                {
+                    "type": "object"
+                },
+                {
+                    "type": [
+                        "integer",
+                        "boolean"
+                    ]
+                }
+            ]
+        },
         "PropertyWithMultiplePrimitives": {
             "oneOf": [
                 {

--- a/tests/data/schema/valid/valid_multiref_property.json
+++ b/tests/data/schema/valid/valid_multiref_property.json
@@ -2,46 +2,42 @@
     "typeName": "AWS::Valid::TypeName",
     "description": "a test schema",
     "definitions": {
-        "Properties2": {
+        "ComplexTypeWithOnePrimitive": {
             "type": "object",
             "properties": {
-                "PropertyC": {
+                "PrimitiveProperty": {
                     "type": "string"
                 }
             }
         },
-        "Properties3": {
+        "ComplexTypeWithMultiplePrimitives": {
             "type": "object",
             "properties": {
-                "PropertyB": {
+                "PrimitiveProperty1": {
                     "type": "string"
                 },
-                "PropertyZ": {
-                    "$ref": "#/definitions/Properties3"
+                "PrimitiveProperty2": {
+                    "type": "string"
                 }
             }
         },
-        "Properties4": {
+        "ComplexTypeWithCircularRef": {
             "type": "object",
             "properties": {
-                "PropertyB": {
+                "PrimitiveProperty": {
                     "type": "string"
+                },
+                "CircularProperty": {
+                    "$ref": "#/definitions/ComplexTypeWithCircularRef"
                 }
             }
         }
     },
     "properties": {
-        "PropertyA": {
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/Properties4"
-                },
-                {
-                    "$ref": "#/definitions/Properties3"
-                }
-            ]
+        "primaryID": {
+            "type": "string"
         },
-        "PropertyJ": {
+        "PropertyWithMultipleConstraints": {
             "oneOf": [
                 {
                     "type": "string",
@@ -53,26 +49,69 @@
                 }
             ]
         },
-        "MultiProperty": {
+        "PropertyWithMultiplePrimitives": {
             "oneOf": [
                 {
-                    "$ref": "#/definitions/Properties2"
+                    "type": "integer"
                 },
                 {
-                    "$ref": "#/definitions/Properties4"
-                },
-                {
-                    "$ref": "#/definitions/Properties4"
-                },
-                {
-                    "$ref": "#/definitions/Properties3"
+                    "type": "string"
                 },
                 {
                     "type": "object"
                 }
             ]
         },
-        "MultiProperty2": {
+        "PropertyWithTwoComplexTypes": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/ComplexTypeWithOnePrimitive"
+                },
+                {
+                    "$ref": "#/definitions/ComplexTypeWithMultiplePrimitives"
+                }
+            ]
+        },
+        "PropertyWithMultipleComplexTypes": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/ComplexTypeWithOnePrimitive"
+                },
+                {
+                    "$ref": "#/definitions/ComplexTypeWithMultiplePrimitives"
+                },
+                {
+                    "$ref": "#/definitions/ComplexTypeWithCircularRef"
+                }
+            ]
+        },
+        "PropertyWithMultipleComplexTypesAndOnePrimitive": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/ComplexTypeWithOnePrimitive"
+                },
+                {
+                    "$ref": "#/definitions/ComplexTypeWithMultiplePrimitives"
+                },
+                {
+                    "$ref": "#/definitions/ComplexTypeWithCircularRef"
+                },
+                {
+                    "type": "object"
+                }
+            ]
+        },
+        "PropertyWithComplexTypeAndPrimitive": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/ComplexTypeWithOnePrimitive"
+                },
+                {
+                    "type": "object"
+                }
+            ]
+        },
+        "MultiProperty3": {
             "oneOf": [
                 {
                     "type": "integer"
@@ -85,9 +124,9 @@
     },
     "additionalProperties": false,
     "createOnlyProperties": [
-        "/properties/MultiProperty"
+        "/properties/primaryID"
     ],
     "primaryIdentifier": [
-        "/properties/MultiProperty"
+        "/properties/primaryID"
     ]
 }

--- a/tests/data/schema/valid/valid_multiref_property.json
+++ b/tests/data/schema/valid/valid_multiref_property.json
@@ -1,0 +1,93 @@
+{
+    "typeName": "AWS::Valid::TypeName",
+    "description": "a test schema",
+    "definitions": {
+        "Properties2": {
+            "type": "object",
+            "properties": {
+                "PropertyC": {
+                    "type": "string"
+                }
+            }
+        },
+        "Properties3": {
+            "type": "object",
+            "properties": {
+                "PropertyB": {
+                    "type": "string"
+                },
+                "PropertyZ": {
+                    "$ref": "#/definitions/Properties3"
+                }
+            }
+        },
+        "Properties4": {
+            "type": "object",
+            "properties": {
+                "PropertyB": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "properties": {
+        "PropertyA": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/Properties4"
+                },
+                {
+                    "$ref": "#/definitions/Properties3"
+                }
+            ]
+        },
+        "PropertyJ": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "minLength": 3
+                },
+                {
+                    "type": "string",
+                    "minLength": 13
+                }
+            ]
+        },
+        "MultiProperty": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/Properties2"
+                },
+                {
+                    "$ref": "#/definitions/Properties4"
+                },
+                {
+                    "$ref": "#/definitions/Properties4"
+                },
+                {
+                    "$ref": "#/definitions/Properties3"
+                },
+                {
+                    "type": "object"
+                }
+            ]
+        },
+        "MultiProperty2": {
+            "oneOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "object"
+                }
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "createOnlyProperties": [
+        "/properties/MultiProperty"
+    ],
+    "primaryIdentifier": [
+        "/properties/MultiProperty"
+    ]
+}

--- a/tests/jsonutils/test_flattener.py
+++ b/tests/jsonutils/test_flattener.py
@@ -327,10 +327,8 @@ def test_flatten_combiners_flattened_before_merge_failed_but_should_not(combiner
         },
     }
 
-    flattener = JsonSchemaFlattener(test_schema)
-    with pytest.raises(ConstraintError) as excinfo:
-        flattener.flatten_schema()
-    assert "declared multiple values for '$ref'" in str(excinfo.value)
+    flattened_schema = JsonSchemaFlattener(test_schema).flatten_schema()
+    assert isinstance(flattened_schema[()]["properties"]["p"]["type"], list)
 
 
 def test_contraint_array_additional_items_valid():

--- a/tests/jsonutils/test_flattener.py
+++ b/tests/jsonutils/test_flattener.py
@@ -306,7 +306,7 @@ def test_flatten_combiners_resolve_types_nested_should_fail(combiner):
 
 
 @pytest.mark.parametrize("combiner", COMBINERS)
-def test_flatten_combiners_flattened_before_merge_failed_but_should_not(combiner):
+def test_flatten_combiners_flattened_before_merge(combiner):
     # this should not fail, since the refs are actually compatible with each other
     # https://github.com/aws-cloudformation/aws-cloudformation-rpdk/issues/333
     ref = ("definitions", "obj")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -283,6 +283,42 @@ def test_generate_docs_with_multityped_property(project, tmp_path_factory):
     assert read_me_stripped == read_me_target_stripped
 
 
+def test_generate_docs_with_multiref_property(project, tmp_path_factory):
+    project.schema = resource_json(
+        __name__, "data/schema/valid/valid_multiref_property.json"
+    )
+
+    project.type_name = "AWS::Color::Red"
+    # tmpdir conflicts with other tests, make a unique one
+    project.root = tmp_path_factory.mktemp("generate_with_docs_type_complex")
+    mock_plugin = MagicMock(spec=["generate"])
+    with patch.object(project, "_plugin", mock_plugin):
+        project.generate()
+        project.generate_docs()
+    mock_plugin.generate.assert_called_once_with(project)
+
+    docs_dir = project.root / "docs"
+    readme_file = project.root / "docs" / "README.md"
+
+    assert docs_dir.is_dir()
+    assert readme_file.is_file()
+    with patch.object(project, "_plugin", mock_plugin):
+        project.generate()
+    readme_contents = readme_file.read_text(encoding="utf-8")
+    readme_contents_target = resource_stream(
+        __name__, "data/schema/target_output/multiref.md"
+    )
+
+    read_me_stripped = readme_contents.strip().replace(" ", "")
+    read_me_target_stripped = readme_contents_target.read().strip().replace(" ", "")
+
+    LOG.debug("read_me_stripped %s", read_me_stripped)
+    LOG.debug("read_me_target_stripped %s", read_me_target_stripped)
+
+    assert project.type_name in readme_contents
+    assert read_me_stripped == read_me_target_stripped
+
+
 def test_generate_with_docs_invalid_property_type(project, tmp_path_factory):
     project.schema = resource_json(
         __name__, "data/schema/invalid/invalid_property_type_invalid.json"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

## Valid Schema Case:

adding multi `$ref` support to enrich schema capabilities to support multiple types; 
usecases:
```json
{
    "properties": {
        "propertyA": {
            "oneOf": [
                {"$ref": "#..."},
                {"$ref": "#..."},
                {"type": "..."}
            ]
        }
    }
}
```
--------------------------------------
## Example AWS::Valid::TypeName

### Resource Schema:

```json
{
    "typeName": "AWS::Valid::TypeName",
    "description": "a test schema",
    "definitions": {
        "ComplexTypeWithOnePrimitive": {
            "type": "object",
            "properties": {
                "PrimitiveProperty": {
                    "type": "string"
                }
            }
        },
        "ComplexTypeWithMultiplePrimitives": {
            "type": "object",
            "properties": {
                "PrimitiveProperty1": {
                    "type": "string"
                },
                "PrimitiveProperty2": {
                    "type": "string"
                }
            }
        }
    },
    "properties": {
        "primaryID": {
            "type": "string"
        },
        "PropertyWithTwoComplexTypes": {
            "oneOf": [
                {
                    "$ref": "#/definitions/ComplexTypeWithOnePrimitive"
                },
                {
                    "$ref": "#/definitions/ComplexTypeWithMultiplePrimitives"
                }
            ]
        }
    },
    "additionalProperties": false,
    "createOnlyProperties": [
        "/properties/primaryID"
    ],
    "primaryIdentifier": [
        "/properties/primaryID"
    ]
}
```

### Generated Docs
#### README.md

```md
# AWS::Valid::TypeName

a test schema

## Syntax

To declare this entity in your AWS CloudFormation template, use the following syntax:

### JSON

<pre>
{
    "Type" : "AWS::Valid::TypeName",
    "Properties" : {
        "<a href="#primaryid" title="primaryID">primaryID</a>" : <i>String</i>,
        "<a href="#propertywithtwocomplextypes" title="PropertyWithTwoComplexTypes">PropertyWithTwoComplexTypes</a>" : <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a></i>
    }
}
</pre>

### YAML

<pre>
Type: AWS::Valid::TypeName
Properties:
    <a href="#primaryid" title="primaryID">primaryID</a>: <i>String</i>
    <a href="#propertywithtwocomplextypes" title="PropertyWithTwoComplexTypes">PropertyWithTwoComplexTypes</a>: <i><a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a></i>
</pre>

## Properties

#### primaryID

_Required_: No

_Type_: String

_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)

#### PropertyWithTwoComplexTypes

_Required_: No

_Type_: <a href="complextypewithoneprimitive.md">ComplexTypeWithOnePrimitive</a>, <a href="complextypewithmultipleprimitives.md">ComplexTypeWithMultiplePrimitives</a>

_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

## Return Values

### Ref

When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the primaryID.

```

#### complextypewithoneprimitive.md

```md
# AWS::Valid::TypeName ComplexTypeWithOnePrimitive

## Syntax

To declare this entity in your AWS CloudFormation template, use the following syntax:

### JSON

<pre>
{
    "<a href="#primitiveproperty" title="PrimitiveProperty">PrimitiveProperty</a>" : <i>String</i>
}
</pre>

### YAML

<pre>
<a href="#primitiveproperty" title="PrimitiveProperty">PrimitiveProperty</a>: <i>String</i>
</pre>

## Properties

#### PrimitiveProperty

_Required_: No

_Type_: String

_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

```

#### complextypewithmultipleprimitives.md

```md
# AWS::Valid::TypeName ComplexTypeWithMultiplePrimitives

## Syntax

To declare this entity in your AWS CloudFormation template, use the following syntax:

### JSON

<pre>
{
    "<a href="#primitiveproperty1" title="PrimitiveProperty1">PrimitiveProperty1</a>" : <i>String</i>,
    "<a href="#primitiveproperty2" title="PrimitiveProperty2">PrimitiveProperty2</a>" : <i>String</i>
}
</pre>

### YAML

<pre>
<a href="#primitiveproperty1" title="PrimitiveProperty1">PrimitiveProperty1</a>: <i>String</i>
<a href="#primitiveproperty2" title="PrimitiveProperty2">PrimitiveProperty2</a>: <i>String</i>
</pre>

## Properties

#### PrimitiveProperty1

_Required_: No

_Type_: String

_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

#### PrimitiveProperty2

_Required_: No

_Type_: String

_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

```

### Generated Source Code

#### ResourceModel.java

```java
@Data
@Builder
@AllArgsConstructor
@NoArgsConstructor
@JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
public class ResourceModel {
    @JsonIgnore
    public static final String TYPE_NAME = "AWS::Valid::TypeName";

    @JsonIgnore
    public static final String IDENTIFIER_KEY_PRIMARYID = "/properties/primaryID";

    @JsonProperty("primaryID")
    private String primaryID;

    @JsonProperty("PropertyWithTwoComplexTypes")
    private Object propertyWithTwoComplexTypes;

    @JsonIgnore
    public JSONObject getPrimaryIdentifier() {
        final JSONObject identifier = new JSONObject();
        if (this.getPrimaryID() != null) {
            identifier.put(IDENTIFIER_KEY_PRIMARYID, this.getPrimaryID());
        }

        // only return the identifier if it can be used, i.e. if all components are present
        return identifier.length() == 1 ? identifier : null;
    }

    @JsonIgnore
    public List<JSONObject> getAdditionalIdentifiers() {
        final List<JSONObject> identifiers = new ArrayList<JSONObject>();
        // only return the identifiers if any can be used
        return identifiers.isEmpty() ? null : identifiers;
    }
}
```

#### ComplexTypeWithMultiplePrimitives.java
```java
@Data
@Builder
@AllArgsConstructor
@NoArgsConstructor
@JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
public class ComplexTypeWithMultiplePrimitives {
    @JsonProperty("PrimitiveProperty1")
    private String primitiveProperty1;

    @JsonProperty("PrimitiveProperty2")
    private String primitiveProperty2;

}
```

#### ComplexTypeWithOnePrimitive.java

```java
@Data
@Builder
@AllArgsConstructor
@NoArgsConstructor
@JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
public class ComplexTypeWithOnePrimitive {
    @JsonProperty("PrimitiveProperty")
    private String primitiveProperty;

}
```
--------------------------------------------


### Rationale:
schema flattener combines multiple types into a collection of types: `{ "oneOf": [{"type": "string"},{"type": "integer"}] }` => `"type": ["string", "integer"]`
similarly schema flattener combines `$ref` types in a similar way `{ "oneOf": [{"$ref": "..."},{"$ref": "..."}] }` => `"type": [(..., ...), (..., ....)]`

having know this flattened types, schema resolver will resolve list as `MULTIPLE` hence both will be defaulted to `java.lang.Object`/`Any`

------------------------------------------

## Edge Cases:
#### Type and oneOf on the same level
Such schema is considered to be valid by json engine but any input would be invalid as two attributes are mutually exclusive:
```json
{
    "property": {
        "type": "string",
        "oneOf": [
            { "type": "boolean" },
            { "type": "integer" }
        ]
    }
}
```
CLI will prioritize `type` over combiner:
resulted Resource Model
```java
@Data
@Builder
@AllArgsConstructor
@NoArgsConstructor
@JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
public class ResourceModel {
    ...
    @JsonProperty("property")
    private String property;
```

#### Ref and oneOf on the same level
Such schema is considered to be valid by json engine but any input would be invalid as two attributes are mutually exclusive:
```json
{
    "property": {
        "$ref": "#/definitions/ComplexType",
        "oneOf": [
            { "type": "boolean" },
            { "type": "integer" }
        ]
    }
}
```
CLI will prioritize `$ref` over combiner:
resulted Resource Model
```java
@Data
@Builder
@AllArgsConstructor
@NoArgsConstructor
@JsonAutoDetect(fieldVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
public class ResourceModel {
    ...
    @JsonProperty("property")
    private ComplexType property;
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
