### PR TITLE
Nicer CLI experience when asking user for inputs on the terminal

### DIFF
--- a/src/rpdk/core/init.py
+++ b/src/rpdk/core/init.py
@@ -3,6 +3,7 @@
 import argparse
 import logging
 import re
+import readline  # noqa: F401 (This is implicitly used by the input() method) pylint: disable=unused-import
 from functools import wraps
 
 from colorama import Fore, Style


### PR DESCRIPTION
As documented [here](https://docs.python.org/3/library/functions.html#input), this mechanism provides a nicer experience when we ask the user for input. When the user uses the cursor keys, they can actually navigate back and forth when using left and right and can navigate the history using up and down keys.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
