### PR TITLE
Include format in ResolvedType

### DIFF
--- a/src/rpdk/core/__init__.py
+++ b/src/rpdk/core/__init__.py
@@ -1,5 +1,5 @@
 import logging
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/rpdk/core/jsonutils/resolver.py
+++ b/src/rpdk/core/jsonutils/resolver.py
@@ -7,7 +7,7 @@ from .utils import BASE, fragment_encode
 
 UNDEFINED = "undefined"
 MULTIPLE = "multiple"
-DEFAULT = "default"
+FORMAT_DEFAULT = "default"
 
 
 class ContainerType(Enum):
@@ -20,7 +20,7 @@ class ContainerType(Enum):
 
 
 class ResolvedType:
-    def __init__(self, container, item_type, type_format=DEFAULT):
+    def __init__(self, container, item_type, type_format=FORMAT_DEFAULT):
         self.container = container
         self.type = item_type
         self.type_format = type_format
@@ -135,7 +135,9 @@ class ModelResolver:
     @staticmethod
     def _get_primitive_lang_type(schema_type, property_schema):
         return ResolvedType(
-            ContainerType.PRIMITIVE, schema_type, property_schema.get("format", DEFAULT)
+            ContainerType.PRIMITIVE,
+            schema_type,
+            property_schema.get("format", FORMAT_DEFAULT),
         )
 
     def _get_array_lang_type(self, property_schema):

--- a/src/rpdk/core/jsonutils/resolver.py
+++ b/src/rpdk/core/jsonutils/resolver.py
@@ -7,6 +7,7 @@ from .utils import BASE, fragment_encode
 
 UNDEFINED = "undefined"
 MULTIPLE = "multiple"
+DEFAULT = "default"
 
 
 class ContainerType(Enum):
@@ -19,9 +20,10 @@ class ContainerType(Enum):
 
 
 class ResolvedType:
-    def __init__(self, container, item_type):
+    def __init__(self, container, item_type, type_format=DEFAULT):
         self.container = container
         self.type = item_type
+        self.type_format = type_format
 
     def __repr__(self):
         return f"<ResolvedType({self.container}, {self.type})>"
@@ -114,7 +116,7 @@ class ModelResolver:
             return self._get_array_lang_type(property_schema)
         if schema_type == "object":
             return self._get_object_lang_type(property_schema)
-        return self._get_primitive_lang_type(schema_type)
+        return self._get_primitive_lang_type(schema_type, property_schema)
 
     @staticmethod
     def _get_array_container_type(property_schema):
@@ -131,8 +133,10 @@ class ModelResolver:
         return ResolvedType(ContainerType.MULTIPLE, schema_type)
 
     @staticmethod
-    def _get_primitive_lang_type(schema_type):
-        return ResolvedType(ContainerType.PRIMITIVE, schema_type)
+    def _get_primitive_lang_type(schema_type, property_schema):
+        return ResolvedType(
+            ContainerType.PRIMITIVE, schema_type, property_schema.get("format", DEFAULT)
+        )
 
     def _get_array_lang_type(self, property_schema):
         container = self._get_array_container_type(property_schema)
@@ -140,7 +144,7 @@ class ModelResolver:
         try:
             items = property_schema["items"]
         except KeyError:
-            items = self._get_primitive_lang_type(UNDEFINED)
+            items = self._get_primitive_lang_type(UNDEFINED, property_schema)
         else:
             items = self._schema_to_lang_type(items)
 
@@ -159,7 +163,7 @@ class ModelResolver:
           we set the value type to the UNDEFINED constant for language implementations
           to distinguish it from a JSON object.
         """
-        items = self._get_primitive_lang_type(UNDEFINED)
+        items = self._get_primitive_lang_type(UNDEFINED, property_schema)
         try:
             pattern_properties = list(property_schema["patternProperties"].items())
         except KeyError:

--- a/tests/jsonutils/test_resolver.py
+++ b/tests/jsonutils/test_resolver.py
@@ -3,7 +3,7 @@ import pytest
 
 from rpdk.core.exceptions import ModelResolverError
 from rpdk.core.jsonutils.resolver import (
-    DEFAULT,
+    FORMAT_DEFAULT,
     UNDEFINED,
     ContainerType,
     ModelResolver,
@@ -106,7 +106,7 @@ def test_modelresolver__get_primitive_lang_type():
     resolved_type = ModelResolver._get_primitive_lang_type(sentinel, {})
     assert resolved_type.container == ContainerType.PRIMITIVE
     assert resolved_type.type is sentinel
-    assert resolved_type.type_format == DEFAULT
+    assert resolved_type.type_format == FORMAT_DEFAULT
 
 
 @pytest.mark.parametrize(
@@ -153,7 +153,7 @@ def test_modelresolver__get_object_lang_type(schema, result):
     item_type = resolved_type.type
     assert item_type.container == ContainerType.PRIMITIVE
     assert item_type.type == result
-    assert item_type.type_format == DEFAULT
+    assert item_type.type_format == FORMAT_DEFAULT
 
 
 def test_modelresolver__schema_to_lang_type_ref():
@@ -182,7 +182,7 @@ def test_modelresolver__schema_to_lang_type_object():
     item_type = resolved_type.type
     assert item_type.container == ContainerType.PRIMITIVE
     assert item_type.type == UNDEFINED
-    assert item_type.type_format == DEFAULT
+    assert item_type.type_format == FORMAT_DEFAULT
 
 
 def test_modelresolver__schema_to_lang_type_undef():
@@ -200,7 +200,7 @@ def test_modelresolver__schema_to_lang_type_primitive():
     resolved_type = resolver._schema_to_lang_type({"type": "string"})
     assert resolved_type.container == ContainerType.PRIMITIVE
     assert resolved_type.type == "string"
-    assert resolved_type.type_format == DEFAULT
+    assert resolved_type.type_format == FORMAT_DEFAULT
 
 
 def test_modelresolver__schema_to_lang_type_multiple():

--- a/tests/jsonutils/test_resolver.py
+++ b/tests/jsonutils/test_resolver.py
@@ -3,6 +3,7 @@ import pytest
 
 from rpdk.core.exceptions import ModelResolverError
 from rpdk.core.jsonutils.resolver import (
+    DEFAULT,
     UNDEFINED,
     ContainerType,
     ModelResolver,
@@ -102,9 +103,10 @@ def test_modelresolver__get_array_container_type(schema, result):
 
 def test_modelresolver__get_primitive_lang_type():
     sentinel = object()
-    resolved_type = ModelResolver._get_primitive_lang_type(sentinel)
+    resolved_type = ModelResolver._get_primitive_lang_type(sentinel, {})
     assert resolved_type.container == ContainerType.PRIMITIVE
     assert resolved_type.type is sentinel
+    assert resolved_type.type_format == DEFAULT
 
 
 @pytest.mark.parametrize(
@@ -151,6 +153,7 @@ def test_modelresolver__get_object_lang_type(schema, result):
     item_type = resolved_type.type
     assert item_type.container == ContainerType.PRIMITIVE
     assert item_type.type == result
+    assert item_type.type_format == DEFAULT
 
 
 def test_modelresolver__schema_to_lang_type_ref():
@@ -179,6 +182,7 @@ def test_modelresolver__schema_to_lang_type_object():
     item_type = resolved_type.type
     assert item_type.container == ContainerType.PRIMITIVE
     assert item_type.type == UNDEFINED
+    assert item_type.type_format == DEFAULT
 
 
 def test_modelresolver__schema_to_lang_type_undef():
@@ -196,6 +200,7 @@ def test_modelresolver__schema_to_lang_type_primitive():
     resolved_type = resolver._schema_to_lang_type({"type": "string"})
     assert resolved_type.container == ContainerType.PRIMITIVE
     assert resolved_type.type == "string"
+    assert resolved_type.type_format == DEFAULT
 
 
 def test_modelresolver__schema_to_lang_type_multiple():
@@ -210,3 +215,13 @@ def test_modelresolver__schema_to_lang_duplicatetype():
     resolved_type = resolver._schema_to_lang_type({"type": ["string", "string"]})
     assert resolved_type.container == ContainerType.PRIMITIVE
     assert resolved_type.type == "string"
+
+
+def test_modelresolver__schema_to_lang_type_primitive_nondefault_format():
+    resolver = ModelResolver({})
+    resolved_type = resolver._schema_to_lang_type(
+        {"type": "integer", "format": "int64"}
+    )
+    assert resolved_type.container == ContainerType.PRIMITIVE
+    assert resolved_type.type == "integer"
+    assert resolved_type.type_format == "int64"


### PR DESCRIPTION
*Issue #, if available:*  https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/issues/151

*Description of changes:* This allows the [format keyword](https://github.com/aws-cloudformation/aws-cloudformation-resource-schema/blob/master/src/main/resources/schema/provider.definition.schema.v1.json#L201-L203) to be passed to plugins to allow construction of types with specific format akin to the OpenAPI specification for certain primitives (thanks @bkabrda for the suggestion.) This is to be reviewed alongside this java plugin PR: https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/pull/328

TL;DR (for specific https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/issues/151 issue):
Customers can now add format to their integer schemas to specify int or long for java. The below schema would result in an Long type being generated in java when both prs are merged & released (omitting format preserves existing functionality)
```
{
    "type": "integer",
    "format": "int64"
}
```
Results in a Long type being generated in resource model pojos.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
