### PR TITLE
fix update handler bug

### DIFF
--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -24,12 +24,10 @@ def updated_resource(resource_client):
         created_model = model = response["resourceModel"]
         test_input_equals_output(resource_client, input_model, created_model)
 
-        updated_input_model = update_request = resource_client.generate_update_example(
-            created_model
-        )
+        update_request = resource_client.generate_update_example(created_model)
 
         updated_input_model = prune_properties_from_model(
-            updated_input_model.copy(), resource_client.read_only_paths
+            update_request.copy(), resource_client.read_only_paths
         )
 
         _status, response, _error = resource_client.call_and_assert(

--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -29,7 +29,7 @@ def updated_resource(resource_client):
         )
 
         updated_input_model = prune_properties_from_model(
-            updated_input_model, resource_client.read_only_paths
+            updated_input_model.copy(), resource_client.read_only_paths
         )
 
         _status, response, _error = resource_client.call_and_assert(


### PR DESCRIPTION
*Issue #, if available:* #624
*Description of changes:*
we must clone before modifying the resource model read from output of create handler so that we are not incorrectly modifying the payload for update request. Previously the code was stripping readOnly properties from `update_request` payload. Due to this, update handler contract tests were failing for some resources.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
