### PR TITLE
Create temporary credential for each invocation and limit duration to 15 mins

### DIFF
--- a/src/rpdk/core/boto_helpers.py
+++ b/src/rpdk/core/boto_helpers.py
@@ -44,7 +44,7 @@ def get_temporary_credentials(session, key_names=BOTO_CRED_KEYS, role_arn=None):
         )
         try:
             response = sts_client.assume_role(
-                RoleArn=role_arn, RoleSessionName=session_name
+                RoleArn=role_arn, RoleSessionName=session_name, DurationSeconds=900
             )
         except ClientError:
             # pylint: disable=W1201
@@ -64,7 +64,7 @@ def get_temporary_credentials(session, key_names=BOTO_CRED_KEYS, role_arn=None):
             creds = (frozen.access_key, frozen.secret_key, frozen.token)
         else:
             try:
-                response = sts_client.get_session_token()
+                response = sts_client.get_session_token(DurationSeconds=900)
             except ClientError as e:
                 LOG.debug(
                     "Getting session token resulted in unknown ClientError", exc_info=e

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -117,6 +117,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
     ):  # pylint: disable=too-many-arguments
         self._schema = schema
         self._session = create_sdk_session(region)
+        self._role_arn = role_arn
         self._creds = get_temporary_credentials(
             self._session, LOWER_CAMEL_CRED_KEYS, role_arn
         )
@@ -409,7 +410,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             self.region,
             self.account,
             action,
-            self._creds.copy(),
+            get_temporary_credentials(self._session, LOWER_CAMEL_CRED_KEYS, self._role_arn),
             self.generate_token(),
             **kwargs
         )

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -118,11 +118,11 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         self._schema = schema
         self._session = create_sdk_session(region)
         self._role_arn = role_arn
-        self._creds = get_temporary_credentials(
-            self._session, LOWER_CAMEL_CRED_KEYS, role_arn
-        )
         self.region = region
-        self.account = get_account(self._session, self._creds)
+        self.account = get_account(
+            self._session,
+            get_temporary_credentials(self._session, LOWER_CAMEL_CRED_KEYS, role_arn),
+        )
         self._function_name = function_name
         if endpoint.startswith("http://"):
             self._client = self._session.client(

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -410,7 +410,9 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             self.region,
             self.account,
             action,
-            get_temporary_credentials(self._session, LOWER_CAMEL_CRED_KEYS, self._role_arn),
+            get_temporary_credentials(
+                self._session, LOWER_CAMEL_CRED_KEYS, self._role_arn
+            ),
             self.generate_token(),
             **kwargs
         )

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -82,7 +82,6 @@ def resource_client():
     mock_sesh.client.assert_called_once_with("lambda", endpoint_url=endpoint)
     mock_creds.assert_called_once_with(mock_sesh, LOWER_CAMEL_CRED_KEYS, None)
     mock_account.assert_called_once_with(mock_sesh, {})
-    assert client._creds == {}
     assert client._function_name == DEFAULT_FUNCTION
     assert client._schema == {}
     assert client._overrides == EMPTY_OVERRIDE
@@ -124,7 +123,6 @@ def resource_client_inputs():
     mock_creds.assert_called_once_with(mock_sesh, LOWER_CAMEL_CRED_KEYS, None)
     mock_account.assert_called_once_with(mock_sesh, {})
 
-    assert client._creds == {}
     assert client._function_name == DEFAULT_FUNCTION
     assert client._schema == {}
     assert client._overrides == EMPTY_OVERRIDE

--- a/tests/test_boto_helpers.py
+++ b/tests/test_boto_helpers.py
@@ -101,7 +101,7 @@ def test_get_temporary_credentials_needs_token():
         endpoint_url="https://sts.us-east-2.amazonaws.com",
         region_name="us-east-2",
     )
-    client.get_session_token.assert_called_once_with()
+    client.get_session_token.assert_called_once_with(DurationSeconds=900)
 
     assert len(creds) == 3
     assert tuple(creds.keys()) == LOWER_CAMEL_CRED_KEYS
@@ -135,7 +135,7 @@ def test_get_temporary_credentials_invalid_credentials():
         endpoint_url="https://sts.us-east-2.amazonaws.com",
         region_name="us-east-2",
     )
-    client.get_session_token.assert_called_once_with()
+    client.get_session_token.assert_called_once_with(DurationSeconds=900)
 
 
 def test_get_temporary_credentials_assume_role_fails():
@@ -163,7 +163,7 @@ def test_get_temporary_credentials_assume_role_fails():
         region_name="us-east-2",
     )
     client.assume_role.assert_called_once_with(
-        RoleArn=EXPECTED_ROLE, RoleSessionName=ANY
+        RoleArn=EXPECTED_ROLE, RoleSessionName=ANY, DurationSeconds=900
     )
 
 
@@ -192,7 +192,7 @@ def test_get_temporary_credentials_assume_role():
         region_name="cn-north-1",
     )
     client.assume_role.assert_called_once_with(
-        RoleArn=EXPECTED_ROLE, RoleSessionName=ANY
+        RoleArn=EXPECTED_ROLE, RoleSessionName=ANY, DurationSeconds=900
     )
 
     assert len(creds) == 3

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -199,6 +199,6 @@ def _invoke_and_expect(status, payload_path, command, *args):
         }
         main(args_in=["invoke", command, str(payload_path), *args])
     # fmt: on
-    mock_creds.assert_called_once()
+    mock_creds.assert_called()
 
     return mock_project, mock_client.invoke


### PR DESCRIPTION
*Issue #, if available:*. N/A

*Description of changes:*

There are 2 problems to fix here:
 - Only create temporary credential once during the whole contract test is not right.  The resource stabilization could be more than default credential time 1 hour and it will fail. Also this doesn't match how cloudformation get temporary credential for each invocation.

 - With above change, we can limit the credential to 15 mins to enhance the security.

### Testing

Run contract test with log group. (some contract test failed with log group but it's not because of this change)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
