### PR TITLE
Fix to copy only unique identifiers into update example

### DIFF
--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -16,7 +16,8 @@ from rpdk.core.contract.suite.handler_commons import (
 
 @pytest.fixture(scope="module")
 def updated_resource(resource_client):
-    create_request = input_model = model = resource_client.generate_create_example()
+    create_request = input_model = resource_client.generate_create_example()
+    model = {}
     try:
         _status, response, _error = resource_client.call_and_assert(
             Action.CREATE, OperationStatus.SUCCESS, create_request


### PR DESCRIPTION
*Issue #, if available:* #626 
*Description of changes:*
Problem: 
payload for update request was created by merging all properties from the resourceModel** and inputs_#_update
Fix: 
- create the payload by merging only unique identifiers i.e primaryIdentifiers and additionalIdentifiers from the resourceModel into inputs_#_update
- check that createOnly primaryIdentifier(s) are not changed between the resourceModel and inputs_#_update

**resourceModel is model returned after a successful create.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
