### PR TITLE
Add ordered-set requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "hypothesis>=4.32",
         "colorama>=0.4.1",
         "docker>=4.3.1",
+        "ordered-set>=4.0.2",
     ],
     entry_points={
         "console_scripts": ["cfn-cli = rpdk.core.cli:main", "cfn = rpdk.core.cli:main"]


### PR DESCRIPTION
This fixes a ModuleNotFoundError

The dependency was added in the requirements in https://github.com/aws-cloudformation/cloudformation-cli/commit/55c2ad02bfd86fba484f197d3d77c8f8486505dd / https://github.com/aws-cloudformation/cloudformation-cli/pull/619 but the setup.py was not updated.

This broke the tool when installing with pip


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

-------
To make this googleable, this was the error: "ModuleNotFoundError: No module named 'ordered_set'"

```
Traceback (most recent call last):
  File "[...]/bin/cfn", line 33, in <module>
    sys.exit(load_entry_point('cloudformation-cli', 'console_scripts', 'cfn')())
  File "[...]/bin/cfn", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "[...]/src/cloudformation-cli/src/rpdk/core/cli.py", line 12, in <module>
    from .build_image import setup_subparser as build_image_setup_subparser
  File "[...]/src/cloudformation-cli/src/rpdk/core/build_image.py", line 11, in <module>
    from .project import Project
  File "/[...]/src/cloudformation-cli/src/rpdk/core/project.py", line 15, in <module>
    from rpdk.core.jsonutils.flattener import JsonSchemaFlattener
  File "[...]/cfn-modules-jPGoMnNE/src/cloudformation-cli/src/rpdk/core/jsonutils/flattener.py", line 4, in <module>
    from ordered_set import OrderedSet
ModuleNotFoundError: No module named 'ordered_set'
```