### PR TITLE
Add ordered_set as a package dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,6 @@ pytest-random-order>=1.0.4
 hypothesis>=4.32.3
 pytest-localserver>=0.5.0
 
-ordered-set>=4.0.2
-
 # commit hooks
 pre-commit>=1.18.1
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "hypothesis>=4.32",
         "colorama>=0.4.1",
         "docker>=4.3.1",
+        "ordered-set>=4.0.2"
     ],
     entry_points={
         "console_scripts": ["cfn-cli = rpdk.core.cli:main", "cfn = rpdk.core.cli:main"]

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "hypothesis>=4.32",
         "colorama>=0.4.1",
         "docker>=4.3.1",
-        "ordered-set>=4.0.2"
+        "ordered-set>=4.0.2",
     ],
     entry_points={
         "console_scripts": ["cfn-cli = rpdk.core.cli:main", "cfn = rpdk.core.cli:main"]

--- a/src/rpdk/core/__init__.py
+++ b/src/rpdk/core/__init__.py
@@ -1,5 +1,5 @@
 import logging
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Need to add the ordered_set dependency to the package dependencies and not the dev dependencies. 

On 0.2.0:

```
(env) jotompki@3c22fb7f6043 test-cli % cfn init
Traceback (most recent call last):
  File "/Users/jotompki/test-cli/env/bin/cfn", line 5, in <module>
    from rpdk.core.cli import main
  File "/Users/jotompki/test-cli/env/lib/python3.9/site-packages/rpdk/core/cli.py", line 12, in <module>
    from .build_image import setup_subparser as build_image_setup_subparser
  File "/Users/jotompki/test-cli/env/lib/python3.9/site-packages/rpdk/core/build_image.py", line 11, in <module>
    from .project import Project
  File "/Users/jotompki/test-cli/env/lib/python3.9/site-packages/rpdk/core/project.py", line 15, in <module>
    from rpdk.core.fragment.generator import TemplateFragment
  File "/Users/jotompki/test-cli/env/lib/python3.9/site-packages/rpdk/core/fragment/generator.py", line 16, in <module>
    from rpdk.core.data_loaders import resource_json
  File "/Users/jotompki/test-cli/env/lib/python3.9/site-packages/rpdk/core/data_loaders.py", line 14, in <module>
    from .jsonutils.inliner import RefInliner
  File "/Users/jotompki/test-cli/env/lib/python3.9/site-packages/rpdk/core/jsonutils/inliner.py", line 7, in <module>
    from .utils import BASE, rewrite_ref, traverse
  File "/Users/jotompki/test-cli/env/lib/python3.9/site-packages/rpdk/core/jsonutils/utils.py", line 4, in <module>
    from ordered_set import OrderedSet
ModuleNotFoundError: No module named 'ordered_set'
(env) jotompki@3c22fb7f6043 test-cli % pip install ordered_set
Collecting ordered_set
  Using cached ordered-set-4.0.2.tar.gz (10 kB)
Using legacy 'setup.py install' for ordered-set, since package 'wheel' is not installed.
Installing collected packages: ordered-set
    Running setup.py install for ordered-set ... done
Successfully installed ordered-set-4.0.2
WARNING: You are using pip version 20.2.3; however, version 20.2.4 is available.
You should consider upgrading via the '/Users/jotompki/test-cli/env/bin/python3 -m pip install --upgrade pip' command.
(env) jotompki@3c22fb7f6043 test-cli % cfn init               
Initializing new project
Do you want to develop a new resource(r) or a module(m)?.
>> 
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
