### PR TITLE
Add additional checks on structured properties to not leak the additional properties to handlers during validation

### DIFF
--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -74,6 +74,33 @@ def make_resource_validator():
     return make_validator(schema)
 
 
+def make_resource_validator_with_additional_properties_check():
+    schema = resource_json(__name__, "data/schema/provider.definition.schema.v1.json")
+    dependencies = schema["definitions"]["validations"]["dependencies"]
+    properties_check = {
+        "properties": {
+            "$comment": "An object cannot have both defined and undefined"
+            + " properties; therefore, patternProperties is not allowed "
+            + "when properties is specified.",
+            "not": {"required": ["patternProperties"]},
+            "required": ["additionalProperties"],
+        }
+    }
+    pattern_properties_check = {
+        "patternProperties": {
+            "$comment": "An object cannot have both defined and undefined"
+            + " properties; therefore, properties is not allowed when"
+            + " patternProperties is specified.",
+            "not": {"required": ["properties"]},
+            "required": ["additionalProperties"],
+        }
+    }
+    dependencies.update(properties_check)
+    dependencies.update(pattern_properties_check)
+    schema["definitions"]["validations"]["dependencies"] = dependencies
+    return make_validator(schema)
+
+
 def get_file_base_uri(file):
     try:
         name = file.name
@@ -107,12 +134,25 @@ def load_resource_spec(resource_spec_file):  # noqa: C901
         raise SpecValidationError(str(e)) from e
 
     validator = make_resource_validator()
+    additional_properties_validator = (
+        make_resource_validator_with_additional_properties_check()
+    )
     try:
         validator.validate(resource_spec)
     except ValidationError as e:
         LOG.debug("Resource spec validation failed", exc_info=True)
         raise SpecValidationError(str(e)) from e
 
+    try:
+        additional_properties_validator.validate(resource_spec)
+    except ValidationError as e:
+        LOG.warning(
+            "Resource spec validation would fail from next"
+            " major version. Provider should mark additionalProperties"
+            " as false if it is a structured property."
+            " Please fix the below warnings: %s",
+            str(e),
+        )
     in_readonly = _is_in(resource_spec, "readOnlyProperties")
     in_createonly = _is_in(resource_spec, "createOnlyProperties")
 

--- a/tests/data/schema/valid/valid_pattern_properties.json
+++ b/tests/data/schema/valid/valid_pattern_properties.json
@@ -14,7 +14,6 @@
         },
         "obj2def": {
             "type": "object",
-            "additionalProperties": false,
             "patternProperties": {
                 ".*": {
                     "type": "string"

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -98,6 +98,31 @@ def test_load_resource_spec_valid_snippets(example):
         assert load_resource_spec(f)
 
 
+def test_load_resource_spec_object_property_missing_additional_properties(caplog):
+    schema = BASEDIR / "data" / "schema" / "valid" / "valid_nested_property_object.json"
+    with schema.open("r", encoding="utf-8") as f:
+        assert load_resource_spec(f)
+    assert "Resource spec validation would fail from next major version" in caplog.text
+
+
+def test_load_resource_spec_pattern_property_missing_additional_properties(caplog):
+    schema = BASEDIR / "data" / "schema" / "valid" / "valid_pattern_properties.json"
+    with schema.open("r", encoding="utf-8") as f:
+        assert load_resource_spec(f)
+    assert "Resource spec validation would fail from next major version" in caplog.text
+
+
+def test_load_resource_spec_unmodeled_object_property_missing_additional_properties(
+    caplog,
+):
+    schema = BASEDIR / "data" / "schema" / "valid" / "valid_no_properties.json"
+    with schema.open("r", encoding="utf-8") as f:
+        assert load_resource_spec(f)
+    assert (
+        "Resource spec validation would fail from next major version" not in caplog.text
+    )
+
+
 @pytest.mark.parametrize(
     "example", json_files_params(BASEDIR / "data" / "schema" / "invalid")
 )


### PR DESCRIPTION
*Description of changes:*
Currently, in the provider definition schema we do not restrict the structured property to specify the additionalProperties as false. Structured properties should define the additionalProperties as false otherwise properties with different case or pattern could not be caught during validation. 

Tested by running the `cfn validate`

```
Resource spec validation would fail from next major version. Provider should mark additionalProperties as false if it is a structured property. Please fix the below warnings: 'additionalProperties' is a required property

Failed validating 'required' in schema['properties']['definitions']['patternProperties']['^[A-Za-z0-9]{1,64}$']['allOf'][0]['dependencies']['properties']:
    {'$comment': 'An object cannot have both defined and undefined '
                 'properties; therefore, patternProperties is not allowed '
                 'when properties is specified.',
     'not': {'required': ['patternProperties']},
     'required': ['additionalProperties']}

On instance['definitions']['Term']:
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
