### PR TITLE
Add additional checks on structured properties to not leak the additional properties to handlers during validation

### DIFF
--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -80,7 +80,10 @@ def make_resource_validator_with_additional_properties_check():
     properties_check = {
         "properties": {
             "$comment": "An object cannot have both defined and undefined \
-properties; therefore, patternProperties is not allowed when properties is specified.",
+properties; therefore, patternProperties is not allowed when properties is specified.\
+ Provider should mark additionalProperties as false if the \
+property is of object type and has properties defined \
+in it.",
             "not": {"required": ["patternProperties"]},
             "required": ["additionalProperties"],
         }
@@ -88,7 +91,9 @@ properties; therefore, patternProperties is not allowed when properties is speci
     pattern_properties_check = {
         "patternProperties": {
             "$comment": "An object cannot have both defined and undefined \
-properties; therefore, properties is not allowed when patternProperties is specified.",
+properties; therefore, properties is not allowed when patternProperties is specified. \
+Provider should mark additionalProperties as false if the property is of object type \
+and has patternProperties defined in it.",
             "not": {"required": ["properties"]},
             "required": ["additionalProperties"],
         }

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -93,9 +93,11 @@ properties; therefore, properties is not allowed when patternProperties is speci
             "required": ["additionalProperties"],
         }
     }
-    dependencies.update(properties_check)
-    dependencies.update(pattern_properties_check)
-    schema["definitions"]["validations"]["dependencies"] = dependencies
+    schema["definitions"]["validations"]["dependencies"] = {
+        **dependencies,
+        **properties_check,
+        **pattern_properties_check,
+    }
     return make_validator(schema)
 
 
@@ -147,7 +149,8 @@ def load_resource_spec(resource_spec_file):  # noqa: C901
         LOG.warning(
             "[Warning] Resource spec validation would fail from next \
 major version. Provider should mark additionalProperties as false if the \
-property is defined as a structured property. Please fix the warnings: %s",
+property is of object type and has properties or patternProperties defined \
+in it. Please fix the warnings: %s",
             str(e),
         )
     in_readonly = _is_in(resource_spec, "readOnlyProperties")

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -74,6 +74,33 @@ def make_resource_validator():
     return make_validator(schema)
 
 
+def make_resource_validator_with_additional_properties_check():
+    schema = resource_json(__name__, "data/schema/provider.definition.schema.v1.json")
+    dependencies = schema["definitions"]["validations"]["dependencies"]
+    properties_check = {
+        "properties": {
+            "$comment": "An object cannot have both defined and undefined \
+             properties; therefore, patternProperties is not allowed \
+             when properties is specified.",
+            "not": {"required": ["patternProperties"]},
+            "required": ["additionalProperties"],
+        }
+    }
+    pattern_properties_check = {
+        "patternProperties": {
+            "$comment": "An object cannot have both defined and undefined \
+             properties; therefore, properties is not allowed when \
+             patternProperties is specified.",
+            "not": {"required": ["properties"]},
+            "required": ["additionalProperties"],
+        }
+    }
+    dependencies.update(properties_check)
+    dependencies.update(pattern_properties_check)
+    schema["definitions"]["validations"]["dependencies"] = dependencies
+    return make_validator(schema)
+
+
 def get_file_base_uri(file):
     try:
         name = file.name
@@ -107,12 +134,25 @@ def load_resource_spec(resource_spec_file):  # noqa: C901
         raise SpecValidationError(str(e)) from e
 
     validator = make_resource_validator()
+    additional_properties_validator = (
+        make_resource_validator_with_additional_properties_check()
+    )
     try:
         validator.validate(resource_spec)
     except ValidationError as e:
         LOG.debug("Resource spec validation failed", exc_info=True)
         raise SpecValidationError(str(e)) from e
 
+    try:
+        additional_properties_validator.validate(resource_spec)
+    except ValidationError as e:
+        LOG.warning(
+            "[Warning] Resource spec validation would fail from next \
+             major version. Provider should mark additionalProperties \
+             as false if the property is defined as a structured property. \
+             Please fix the warnings: %s",
+            str(e),
+        )
     in_readonly = _is_in(resource_spec, "readOnlyProperties")
     in_createonly = _is_in(resource_spec, "createOnlyProperties")
 
@@ -122,7 +162,7 @@ def load_resource_spec(resource_spec_file):  # noqa: C901
         if not in_readonly(primary_id) and not in_createonly(primary_id):
             LOG.warning(
                 "Property 'primaryIdentifier' - %s must be specified \
-as either readOnly or createOnly",
+                as either readOnly or createOnly",
                 primary_id,
             )
 

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -80,8 +80,7 @@ def make_resource_validator_with_additional_properties_check():
     properties_check = {
         "properties": {
             "$comment": "An object cannot have both defined and undefined \
-             properties; therefore, patternProperties is not allowed \
-             when properties is specified.",
+properties; therefore, patternProperties is not allowed when properties is specified.",
             "not": {"required": ["patternProperties"]},
             "required": ["additionalProperties"],
         }
@@ -89,8 +88,7 @@ def make_resource_validator_with_additional_properties_check():
     pattern_properties_check = {
         "patternProperties": {
             "$comment": "An object cannot have both defined and undefined \
-             properties; therefore, properties is not allowed when \
-             patternProperties is specified.",
+properties; therefore, properties is not allowed when patternProperties is specified.",
             "not": {"required": ["properties"]},
             "required": ["additionalProperties"],
         }
@@ -148,9 +146,8 @@ def load_resource_spec(resource_spec_file):  # noqa: C901
     except ValidationError as e:
         LOG.warning(
             "[Warning] Resource spec validation would fail from next \
-             major version. Provider should mark additionalProperties \
-             as false if the property is defined as a structured property. \
-             Please fix the warnings: %s",
+major version. Provider should mark additionalProperties as false if the \
+property is defined as a structured property. Please fix the warnings: %s",
             str(e),
         )
     in_readonly = _is_in(resource_spec, "readOnlyProperties")
@@ -162,7 +159,7 @@ def load_resource_spec(resource_spec_file):  # noqa: C901
         if not in_readonly(primary_id) and not in_createonly(primary_id):
             LOG.warning(
                 "Property 'primaryIdentifier' - %s must be specified \
-                as either readOnly or createOnly",
+as either readOnly or createOnly",
                 primary_id,
             )
 

--- a/tests/data/schema/invalid/invalid_nested_property_object_additionalProperties_true_warning.json
+++ b/tests/data/schema/invalid/invalid_nested_property_object_additionalProperties_true_warning.json
@@ -1,0 +1,22 @@
+{
+    "typeName": "AWS::Valid::TypeName",
+    "description": "a test schema",
+    "properties": {
+        "property1": {
+            "type": "object",
+            "properties": {
+                "property1": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": true
+        }
+    },
+    "primaryIdentifier": [
+        "/properties/property1"
+    ],
+    "readOnlyProperties": [
+        "/properties/property1"
+    ],
+    "additionalProperties": false
+}

--- a/tests/data/schema/invalid/invalid_pattern_properties_additionalProperties_true_warning.json
+++ b/tests/data/schema/invalid/invalid_pattern_properties_additionalProperties_true_warning.json
@@ -1,0 +1,29 @@
+{
+    "typeName": "AWS::Valid::TypeName",
+    "description": "a test schema",
+    "definitions": {
+        "obj2def": {
+            "type": "object",
+            "patternProperties": {
+                ".*": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": true
+        }
+    },
+    "properties": {
+        "obj2": {
+            "type": "object",
+            "description": "",
+            "$ref": "#/definitions/obj2def"
+        },
+        "enum1": {
+            "type": "string"
+        }
+    },
+    "primaryIdentifier": [
+        "/properties/enum1"
+    ],
+    "additionalProperties": false
+}

--- a/tests/data/schema/valid/valid_nested_property_object_no_additionalProperties_warning.json
+++ b/tests/data/schema/valid/valid_nested_property_object_no_additionalProperties_warning.json
@@ -8,8 +8,7 @@
                 "property1": {
                     "type": "integer"
                 }
-            },
-            "additionalProperties": false
+            }
         }
     },
     "primaryIdentifier": [

--- a/tests/data/schema/valid/valid_pattern_properties.json
+++ b/tests/data/schema/valid/valid_pattern_properties.json
@@ -14,6 +14,7 @@
         },
         "obj2def": {
             "type": "object",
+            "additionalProperties": false,
             "patternProperties": {
                 ".*": {
                     "type": "string"

--- a/tests/data/schema/valid/valid_pattern_properties.json
+++ b/tests/data/schema/valid/valid_pattern_properties.json
@@ -14,7 +14,6 @@
         },
         "obj2def": {
             "type": "object",
-            "additionalProperties": false,
             "patternProperties": {
                 ".*": {
                     "type": "string"

--- a/tests/data/schema/valid/valid_pattern_properties_no_additionalProperties_warning.json
+++ b/tests/data/schema/valid/valid_pattern_properties_no_additionalProperties_warning.json
@@ -1,0 +1,28 @@
+{
+    "typeName": "AWS::Valid::TypeName",
+    "description": "a test schema",
+    "definitions": {
+        "obj2def": {
+            "type": "object",
+            "patternProperties": {
+                ".*": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "properties": {
+        "obj2": {
+            "type": "object",
+            "description": "",
+            "$ref": "#/definitions/obj2def"
+        },
+        "enum1": {
+            "type": "string"
+        }
+    },
+    "primaryIdentifier": [
+        "/properties/enum1"
+    ],
+    "additionalProperties": false
+}

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -98,6 +98,31 @@ def test_load_resource_spec_valid_snippets(example):
         assert load_resource_spec(f)
 
 
+def test_load_resource_spec_object_property_missing_additional_properties(caplog):
+    schema = BASEDIR / "data" / "schema" / "valid" / "valid_nested_property_object.json"
+    with schema.open("r", encoding="utf-8") as f:
+        assert load_resource_spec(f)
+    assert "Resource spec validation would fail from next major version" in caplog.text
+
+
+def test_load_resource_spec_pattern_property_missing_additional_properties(caplog):
+    schema = BASEDIR / "data" / "schema" / "valid" / "valid_pattern_properties.json"
+    with schema.open("r", encoding="utf-8") as f:
+        assert load_resource_spec(f)
+    assert "Resource spec validation would fail from next major version" in caplog.text
+
+
+def test_load_resource_spec_unmodeled_object_property_missing_additional_properties(
+    caplog,
+):
+    schema = BASEDIR / "data" / "schema" / "valid" / "valid_no_properties.json"
+    with schema.open("r", encoding="utf-8") as f:
+        assert load_resource_spec(f)
+    assert (
+        "Resource spec validation would fail from next major version" not in caplog.text
+    )
+
+
 @pytest.mark.parametrize(
     "example", json_files_params(BASEDIR / "data" / "schema" / "invalid")
 )

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -99,14 +99,26 @@ def test_load_resource_spec_valid_snippets(example):
 
 
 def test_load_resource_spec_object_property_missing_additional_properties(caplog):
-    schema = BASEDIR / "data" / "schema" / "valid" / "valid_nested_property_object.json"
+    schema = (
+        BASEDIR
+        / "data"
+        / "schema"
+        / "valid"
+        / "valid_nested_property_object_no_additionalProperties_warning.json"
+    )
     with schema.open("r", encoding="utf-8") as f:
         assert load_resource_spec(f)
     assert "Resource spec validation would fail from next major version" in caplog.text
 
 
 def test_load_resource_spec_pattern_property_missing_additional_properties(caplog):
-    schema = BASEDIR / "data" / "schema" / "valid" / "valid_pattern_properties.json"
+    schema = (
+        BASEDIR
+        / "data"
+        / "schema"
+        / "valid"
+        / "valid_pattern_properties_no_additionalProperties_warning.json"
+    )
     with schema.open("r", encoding="utf-8") as f:
         assert load_resource_spec(f)
     assert "Resource spec validation would fail from next major version" in caplog.text

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -98,27 +98,17 @@ def test_load_resource_spec_valid_snippets(example):
         assert load_resource_spec(f)
 
 
-def test_load_resource_spec_object_property_missing_additional_properties(caplog):
-    schema = (
-        BASEDIR
-        / "data"
-        / "schema"
-        / "valid"
-        / "valid_nested_property_object_no_additionalProperties_warning.json"
-    )
-    with schema.open("r", encoding="utf-8") as f:
-        assert load_resource_spec(f)
-    assert "Resource spec validation would fail from next major version" in caplog.text
-
-
-def test_load_resource_spec_pattern_property_missing_additional_properties(caplog):
-    schema = (
-        BASEDIR
-        / "data"
-        / "schema"
-        / "valid"
-        / "valid_pattern_properties_no_additionalProperties_warning.json"
-    )
+@pytest.mark.parametrize(
+    "schema",
+    [
+        "valid_nested_property_object_no_additionalProperties_warning.json",
+        "valid_pattern_properties_no_additionalProperties_warning.json",
+    ],
+)
+def test_load_resource_spec_object_property_missing_additional_properties(
+    schema, caplog
+):
+    schema = BASEDIR / "data" / "schema" / "valid" / schema
     with schema.open("r", encoding="utf-8") as f:
         assert load_resource_spec(f)
     assert "Resource spec validation would fail from next major version" in caplog.text
@@ -133,6 +123,21 @@ def test_load_resource_spec_unmodeled_object_property_missing_additional_propert
     assert (
         "Resource spec validation would fail from next major version" not in caplog.text
     )
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        "invalid_nested_property_object_additionalProperties_true_warning.json",
+        "invalid_pattern_properties_additionalProperties_true_warning.json",
+    ],
+)
+def test_load_resource_spec_object_property_additional_properties_true(schema):
+    schema = BASEDIR / "data" / "schema" / "invalid" / schema
+    with schema.open("r", encoding="utf-8") as f:
+        with pytest.raises(SpecValidationError) as excinfo:
+            load_resource_spec(f)
+    assert "False was expected" in str(excinfo.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Description of changes:*
Currently, in the provider definition schema we do not restrict the structured property to specify the additionalProperties as false. Structured properties should define the additionalProperties as false otherwise properties with different case or pattern could not be caught during validation.

Tested by running the `cfn validate`
```
⋊> ~/c/NrqlAlertCondition on master ⨯ cfn validate                                                                                                                                                       
[Warning] Resource spec validation would fail from next major version. Provider should mark additionalProperties as false if the property is defined as a structured property. Please fix the warnings: 'additionalProperties' is a required property

Failed validating 'required' in schema['properties']['definitions']['patternProperties']['^[A-Za-z0-9]{1,64}$']['allOf'][0]['dependencies']['properties']:
    {'$comment': 'An object cannot have both defined and undefined '
                 'properties; therefore, patternProperties is not allowed '
                 'when properties is specified.',
     'not': {'required': ['patternProperties']},
     'required': ['additionalProperties']}

On instance['definitions']['Term']:
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
