### PR TITLE
Call cfn-lint for module fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ cfn test --enforce-timeout 60 -- -k contract_delete_update # combine args
 
 ### Command: validate
 
-To validate the auto-generated code, use the `validate` command.
+To validate the schema, use the `validate` command.
 
-This command is automatically run whenever one attempts to submit a resource or module. Any module fragments will be automatically validated via `cfn-lint`, however any warnings or errors detected by `cfn-lint` will not cause this step to fail.
+This command is automatically run whenever one attempts to submit a resource or module. Any module fragments will be automatically validated via [`cfn-lint`](https://github.com/aws-cloudformation/cfn-python-lint/), however any warnings or errors detected by [`cfn-lint`](https://github.com/aws-cloudformation/cfn-python-lint/) will not cause this step to fail.
 
 ```bash
 cfn validate

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ cfn test --enforce-timeout 60 #set the RL handler timeout to 60 seconds and CUD 
 cfn test --enforce-timeout 60 -- -k contract_delete_update # combine args
 ```
 
+### Command: validate
+
+To validate the auto-generated code, use the `validate` command.
+
+This command is automatically run whenever one attempts to submit a resource or module. Any module fragments will be automatically validated via `cfn-lint`, however any warnings or errors detected by `cfn-lint` will not cause this step to fail.
+
+```bash
+cfn validate
+```
+
 ### Command: build-image
 
 To build an image for a resource type. This image provides a minimalistic execution environment for the resource handler that does not depend on AWS Lambda in anyway. This image can be used during cfn invoke and cfn test instead of using sam cli.

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ include_trailing_comma = true
 combine_as_imports = True
 force_grid_wrap = 0
 known_first_party = rpdk
-known_third_party = boto3,botocore,colorama,docker,hypothesis,jinja2,jsonschema,ordered_set,pkg_resources,pytest,pytest_localserver,setuptools,yaml
+known_third_party = boto3,botocore,cfnlint,colorama,docker,hypothesis,jinja2,jsonschema,ordered_set,pkg_resources,pytest,pytest_localserver,setuptools,yaml
 
 [tool:pytest]
 # can't do anything about 3rd part modules, so don't spam us

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "colorama>=0.4.1",
         "docker>=4.3.1",
         "ordered-set>=4.0.2",
-        "cfn-lint>=0.35.0",
+        "cfn-lint>=0.43.0",
     ],
     entry_points={
         "console_scripts": ["cfn-cli = rpdk.core.cli:main", "cfn = rpdk.core.cli:main"]

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "colorama>=0.4.1",
         "docker>=4.3.1",
         "ordered-set>=4.0.2",
+        "cfn-lint>=0.35.0",
     ],
     entry_points={
         "console_scripts": ["cfn-cli = rpdk.core.cli:main", "cfn = rpdk.core.cli:main"]

--- a/src/rpdk/core/fragment/generator.py
+++ b/src/rpdk/core/fragment/generator.py
@@ -86,6 +86,10 @@ class TemplateFragment:  # pylint: disable=too-many-instance-attributes
                 "warnings/errors from cfn-lint "
                 "(https://github.com/aws-cloudformation/cfn-python-lint):"
             )
+            self.__print_cfn_lint_warnings(lint_warnings)
+
+    @staticmethod
+    def __print_cfn_lint_warnings(lint_warnings):
         for lint_warning in lint_warnings:
             print(
                 "\t{} (from rule {})".format(lint_warning.message, lint_warning.rule),

--- a/src/rpdk/core/fragment/generator.py
+++ b/src/rpdk/core/fragment/generator.py
@@ -11,6 +11,8 @@ import logging
 import os
 from pathlib import Path
 
+import cfnlint.config
+import cfnlint.core
 import yaml
 
 from rpdk.core.data_loaders import resource_json
@@ -75,10 +77,42 @@ class TemplateFragment:  # pylint: disable=too-many-instance-attributes
         self.__validate_no_transforms_present(raw_fragments)
         self.__validate_outputs(raw_fragments)
         self.__validate_mappings(raw_fragments)
+        lint_warnings = self.__validate_fragment_through_cfn_lint(raw_fragments)
+        if not lint_warnings:
+            LOG.warning("Module fragment is valid.")
+        else:
+            LOG.warning(
+                "Module fragment is valid, but there are warnings from cfn-lint "
+                "(https://github.com/aws-cloudformation/cfn-python-lint):"
+            )
+        for lint_warning in lint_warnings:
+            print(
+                "\t{} (from rule {})".format(lint_warning.message, lint_warning.rule),
+            )
 
     def __validate_outputs(self, raw_fragments):
         self.__validate_no_exports_present(raw_fragments)
         self.__validate_output_limit(raw_fragments)
+
+    @staticmethod
+    def __validate_fragment_through_cfn_lint(raw_fragment):
+        filename = "temporary_fragment.json"
+
+        with open(filename, "w") as outfile:
+            json.dump(raw_fragment, outfile, indent=4)
+
+        template = cfnlint.decode.cfn_json.load(filename)
+
+        # Initialize the ruleset to be applied (no overrules, no excludes)
+        rules = cfnlint.core.get_rules([], [], [], [], False, [])
+
+        regions = ["us-east-1"]
+
+        matches = cfnlint.core.run_checks(filename, template, rules, regions)
+
+        os.remove(filename)
+
+        return matches
 
     @staticmethod
     def __validate_no_exports_present(raw_fragments):

--- a/src/rpdk/core/fragment/generator.py
+++ b/src/rpdk/core/fragment/generator.py
@@ -82,7 +82,8 @@ class TemplateFragment:  # pylint: disable=too-many-instance-attributes
             LOG.warning("Module fragment is valid.")
         else:
             LOG.warning(
-                "Module fragment is valid, but there are warnings from cfn-lint "
+                "Module fragment is probably valid, but there are "
+                "warnings/errors from cfn-lint "
                 "(https://github.com/aws-cloudformation/cfn-python-lint):"
             )
         for lint_warning in lint_warnings:
@@ -104,6 +105,7 @@ class TemplateFragment:  # pylint: disable=too-many-instance-attributes
         template = cfnlint.decode.cfn_json.load(filename)
 
         # Initialize the ruleset to be applied (no overrules, no excludes)
+        # Runs Warning and Error rules
         rules = cfnlint.core.get_rules([], [], [], [], False, [])
 
         regions = ["us-east-1"]

--- a/src/rpdk/core/fragment/generator.py
+++ b/src/rpdk/core/fragment/generator.py
@@ -77,7 +77,10 @@ class TemplateFragment:  # pylint: disable=too-many-instance-attributes
         self.__validate_no_transforms_present(raw_fragments)
         self.__validate_outputs(raw_fragments)
         self.__validate_mappings(raw_fragments)
-        lint_warnings = self.__validate_fragment_through_cfn_lint(raw_fragments)
+        self.__validate_fragment_thru_cfn_lint(raw_fragments)
+
+    def __validate_fragment_thru_cfn_lint(self, raw_fragments):
+        lint_warnings = self.__get_cfn_lint_matches(raw_fragments)
         if not lint_warnings:
             LOG.warning("Module fragment is valid.")
         else:
@@ -86,21 +89,19 @@ class TemplateFragment:  # pylint: disable=too-many-instance-attributes
                 "warnings/errors from cfn-lint "
                 "(https://github.com/aws-cloudformation/cfn-python-lint):"
             )
-            self.__print_cfn_lint_warnings(lint_warnings)
-
-    @staticmethod
-    def __print_cfn_lint_warnings(lint_warnings):
-        for lint_warning in lint_warnings:
-            print(
-                "\t{} (from rule {})".format(lint_warning.message, lint_warning.rule),
-            )
+            for lint_warning in lint_warnings:
+                print(
+                    "\t{} (from rule {})".format(
+                        lint_warning.message, lint_warning.rule
+                    ),
+                )
 
     def __validate_outputs(self, raw_fragments):
         self.__validate_no_exports_present(raw_fragments)
         self.__validate_output_limit(raw_fragments)
 
     @staticmethod
-    def __validate_fragment_through_cfn_lint(raw_fragment):
+    def __get_cfn_lint_matches(raw_fragment):
         filename = "temporary_fragment.json"
 
         with open(filename, "w") as outfile:
@@ -109,11 +110,12 @@ class TemplateFragment:  # pylint: disable=too-many-instance-attributes
         template = cfnlint.decode.cfn_json.load(filename)
 
         # Initialize the ruleset to be applied (no overrules, no excludes)
-        # Runs Warning and Error rules
         rules = cfnlint.core.get_rules([], [], [], [], False, [])
 
+        # Default region used by cfn-lint
         regions = ["us-east-1"]
 
+        # Runs Warning and Error rules
         matches = cfnlint.core.run_checks(filename, template, rules, regions)
 
         os.remove(filename)

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -428,6 +428,7 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             LOG.info("Validating your resource specification...")
             try:
                 self.load_schema()
+                LOG.warning("Resource schema is valid.")
             except FileNotFoundError as e:
                 self._raise_invalid_project("Resource specification not found.", e)
             except SpecValidationError as e:

--- a/src/rpdk/core/validate.py
+++ b/src/rpdk/core/validate.py
@@ -13,8 +13,6 @@ def validate(_args):
     project = Project()
     project.load()
 
-    LOG.warning("Resource schema for %s is valid", project.type_name)
-
 
 def setup_subparser(subparsers, parents):
     parser = subparsers.add_parser("validate", description=__doc__, parents=parents)

--- a/tests/data/sample_fragments/template_without_parameter_section.json
+++ b/tests/data/sample_fragments/template_without_parameter_section.json
@@ -5,6 +5,7 @@
         "S3Bucket": {
             "Type": "AWS::S3::Bucket",
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "VersioningConfiguration": {
                     "Status": "Enabled"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -653,6 +653,17 @@ def test_load_module_project_succeeds(project):
         project.load()
 
 
+def test_load_resource_succeeds(project):
+    project.artifact_type = "Resource"
+    project.type_name = "Unit::Test::Resource"
+    patch_load_settings = patch.object(
+        project, "load_settings", return_value={"artifact_type": "RESOURCE"}
+    )
+    project._write_example_schema()
+    with patch_load_settings:
+        project.load()
+
+
 def test_load_module_project_with_invalid_fragments(project):
     project.artifact_type = "MODULE"
     project.type_name = "Unit::Test::Malik::MODULE"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* when calling `cfn validate` on a module, run `cfn-lint` on the fragment for extra validations.

(Future improvement: support `cfn validate --region` so that we can pass the `region` value to `cfn-lint`. Related: https://github.com/aws-cloudformation/cfn-python-lint/issues/607)

Sample output:

```bash
MacBook@ ~/Desktop/modules/cfnlint $ cat fragments/sample.json
{
    "AWSTemplateFormatVersion": "2010-09-09",
    "Resources": {
        "S3Bucket": {
            "Type": "AWS::S3::Bucket",
            "DeletionPolicy": "Something",
            "UpdateReplacePolicy": "Retain"
        }
    }
}
MacBook@ ~/Desktop/modules/cfnlint $ cfn validate
Module fragment is probably valid, but there are warnings/errors from cfn-lint (https://github.com/aws-cloudformation/cfn-python-lint):
	DeletionPolicy should be only one of Delete, Retain, Snapshot at Resources/S3Bucket/DeletionPolicy (from rule E3035: Check DeletionPolicy values for Resources)
MacBook@ ~/Desktop/modules/cfnlint $ cat fragments/sample.json
{
    "AWSTemplateFormatVersion": "2010-09-09",
    "Resources": {
        "S3Bucket": {
            "Type": "AWS::S3::Bucket",
            "DeletionPolicy": "Retain",
            "UpdateReplacePolicy": "Retain"
        }
    }
}
MacBook@ ~/Desktop/modules/cfnlint $ cfn validate
Module fragment is valid.
```

---


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
