### PR TITLE
Adding taggable support for resource schema.

### DIFF
--- a/src/rpdk/core/data/schema/provider.definition.schema.modules.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.modules.v1.json
@@ -71,6 +71,11 @@
                 }
             }
         },
+        "taggable": {
+            "$comment": "A boolean flag indicating whether this resource type supports updatable tagging.",
+            "type": "boolean",
+            "default": "true"
+        },
         "replacementStrategy": {
             "type": "string",
             "description": "The valid replacement strategies are [create_then_delete] and [delete_then_create]. All other inputs are invalid.",

--- a/src/rpdk/core/data/schema/provider.definition.schema.modules.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.modules.v1.json
@@ -71,11 +71,6 @@
                 }
             }
         },
-        "taggable": {
-            "$comment": "A boolean flag indicating whether this resource type supports updatable tagging.",
-            "type": "boolean",
-            "default": "true"
-        },
         "replacementStrategy": {
             "type": "string",
             "description": "The valid replacement strategies are [create_then_delete] and [delete_then_create]. All other inputs are invalid.",

--- a/src/rpdk/core/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.v1.json
@@ -71,6 +71,11 @@
                 }
             }
         },
+        "taggable": {
+            "$comment": "A boolean flag indicating whether this resource type supports updatable tagging.",
+            "type": "boolean",
+            "default": "true"
+        },
         "replacementStrategy": {
             "type": "string",
             "description": "The valid replacement strategies are create_then_delete and delete_then_create. All other inputs are invalid.",


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/aws-cloudformation-resource-schema/pull/105

*Description of changes:*
This is for adding `taggable` support for schema.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
