### PR TITLE
automating CloudFormation Resource Provider Definition MetaSchema updates with Github actions

### DIFF
--- a/.github/workflows/schema-updater.yaml
+++ b/.github/workflows/schema-updater.yaml
@@ -1,0 +1,16 @@
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          curl https://raw.githubusercontent.com/aws-cloudformation/aws-cloudformation-resource-schema/master/src/main/resources/schema/provider.definition.schema.v1.json > src/rpdk/core/data/schema/provider.definition.schema.v1.json
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: |
+            CloudFormation Resource Provider Definition MetaSchema update
+          delete-branch: true
+          title: CloudFormation Resource Provider Definition MetaSchema update


### PR DESCRIPTION
[tested in my fork](https://github.com/PatMyron/cloudformation-cli/pull/1/files)

currently picks up https://github.com/aws-cloudformation/aws-cloudformation-resource-schema/pull/84 and reverts https://github.com/aws-cloudformation/cloudformation-cli/pull/612 unless it's added there too