### PR TITLE
catch common resource schema issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -21,4 +21,4 @@ good-names=e,ex,f,fp,i,j,k,n,_
 [FORMAT]
 
 indent-string='    '
-max-line-length=88
+max-line-length=160

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ exclude =
     .eggs,
     .tox
 max-complexity = 10
-max-line-length = 80
+max-line-length = 160
 select = C,E,F,W,B,B950
 # C812, C815, W503 clash with black
 ignore = E501,C812,C816,C815,W503

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -141,7 +141,7 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R0912 # noqa: C90
         LOG.debug("Resource spec validation failed", exc_info=True)
         raise SpecValidationError(str(e)) from e
 
-    if {
+    list_options = {
         "maxresults",
         "maxrecords",
         "maxitems",
@@ -150,9 +150,12 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R0912 # noqa: C90
         "nextpagetoken",
         "pagetoken",
         "paginationtoken",
-    } & set(map(str.lower, resource_spec.get("properties", []))):
+    } & set(map(str.lower, resource_spec.get("properties", [])))
+    if list_options:
         LOG.warning(
-            "LIST API inputs like MaxResults, MaxRecords, MaxItems, NextToken, NextMarker, NextPageToken, PageToken, and Filters are not resource properties"
+            "LIST API inputs like MaxResults, MaxRecords, MaxItems, NextToken, NextMarker, NextPageToken, PageToken, and Filters are not resource properties. \
+%s should not be present in resource schema",
+            list_options,
         )
 
     if set(resource_spec.get("readOnlyProperties", [])) & set(

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -123,7 +123,7 @@ def get_file_base_uri(file):
     return path.resolve().as_uri()
 
 
-def load_resource_spec(resource_spec_file):  # noqa: C901
+def load_resource_spec(resource_spec_file):  # pylint: disable=R0912 # noqa: C901
     """Load a resource provider definition from a file, and validate it."""
     try:
         resource_spec = json.load(resource_spec_file)
@@ -163,6 +163,14 @@ def load_resource_spec(resource_spec_file):  # noqa: C901
         LOG.warning(
             "readOnlyProperties cannot be specified by customers and should not overlap with writeOnlyProperties or createOnlyProperties"
         )
+
+    for handler in resource_spec.get("handlers", []):
+        for permission in resource_spec.get("handlers", [])[handler]["permissions"]:
+            if "*" in permission:
+                LOG.warning(
+                    "Use specific handler permissions instead of using wildcards: %s",
+                    permission,
+                )
 
     try:
         additional_properties_validator.validate(resource_spec)

--- a/tests/data/schema/valid/invalid_list_api_options_as_properties.json
+++ b/tests/data/schema/valid/invalid_list_api_options_as_properties.json
@@ -1,0 +1,14 @@
+{
+  "typeName" : "AWS::Service::Type",
+  "description" : "",
+  "additionalProperties" : false,
+  "properties" : {
+    "NextToken" : {
+      "type" : "string"
+    }
+  },
+  "readOnlyProperties": [
+    "/properties/NextToken"
+  ],
+  "primaryIdentifier" : [ "/properties/NextToken" ]
+}

--- a/tests/data/schema/valid/invalid_readOnlyProperties_overlap.json
+++ b/tests/data/schema/valid/invalid_readOnlyProperties_overlap.json
@@ -1,0 +1,17 @@
+{
+  "typeName" : "AWS::Service::Type",
+  "description" : "",
+  "additionalProperties" : false,
+  "properties" : {
+    "Property" : {
+      "type" : "string"
+    }
+  },
+  "readOnlyProperties": [
+    "/properties/Property"
+  ],
+  "createOnlyProperties": [
+    "/properties/Property"
+  ],
+  "primaryIdentifier" : [ "/properties/Property" ]
+}

--- a/tests/data/schema/valid/invalid_wildcard_handler_permissions.json
+++ b/tests/data/schema/valid/invalid_wildcard_handler_permissions.json
@@ -1,0 +1,21 @@
+{
+  "typeName" : "AWS::Service::Type",
+  "description" : "",
+  "additionalProperties" : false,
+  "properties" : {
+    "Property" : {
+      "type" : "string"
+    }
+  },
+  "readOnlyProperties": [
+    "/properties/Property"
+  ],
+  "primaryIdentifier" : [ "/properties/Property" ],
+  "handlers": {
+    "create": {
+      "permissions": [
+        "service:create*"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
**resource types with LIST API options like `MaxResults`, `NextToken`, `Filters`, etc as properties of the resource itself:**
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-licensemanager/pull/3
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-iotwireless/pull/3
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-ssm/pull/75

```shell
botocore $ grep -h 'input_token' botocore/data/*/*/paginators-1.json | tr '[:upper:]' '[:lower:]' | sort | uniq -ic | sort -nr | head
1147       "input_token": "nexttoken",
 328       "input_token": "marker",
  40       "input_token": "pagetoken",
  18       "input_token": "position",
  16       "input_token": "nextmarker",
   7       "input_token": "nextpagetoken",
   5       "input_token": "paginationtoken",

botocore $ grep -h 'output_token' botocore/data/*/*/paginators-1.json | tr '[:upper:]' '[:lower:]' | sort | uniq -ic | sort -nr | head
1147       "output_token": "nexttoken",
 199       "output_token": "marker",
  57       "output_token": "nextmarker",
  45       "output_token": "nextpagetoken",

botocore $ grep -h 'limit_key' botocore/data/*/*/paginators-1.json | tr '[:upper:]' '[:lower:]' | sort | uniq -ic | sort -nr | head
 931       "limit_key": "maxresults",
 159       "limit_key": "maxrecords",
 144       "limit_key": "limit",
 129       "limit_key": "maxitems",
  42       "limit_key": "pagesize",
  ```

---

**[`readOnlyProperties` overlapping with `writeOnlyProperties` or `createOnlyProperties`](https://github.com/aws-cloudformation/aws-cloudformation-resource-schema/#resource-semantics):**
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-auditmanager/pull/2
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-codeartifact/pull/38
[`AWS::Events::Archive.ArchiveName`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-archive.html#cfn-events-archive-name)

---

**wildcards in [handler permissions](https://github.com/aws-cloudformation/aws-cloudformation-resource-schema/#permissions)**:
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-greengrassv2/pull/4
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-imagebuilder/commit/55fa9bfa47406e29def2bf1812fbce8cc7c17b8b#r46035310
[`AWS::ApiGateway::DomainName`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-domainname.html)
[`AWS::ServiceCatalog::CloudFormationProvisionedProduct`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-cloudformationprovisionedproduct.html)

---
TODO in future PRs:
* [incorrect min/max constraints](https://github.com/aws-cloudformation/cloudformation-cli/issues/414)
* [invalid regular expression patterns](https://github.com/aws-cloudformation/cloudformation-cli/issues/459)
* [nested property definitions that can't be properly backported to the Resource Specification yet](https://w.amazon.com/bin/view/AWS21/Design/Uluru/Schema/AvoidNestedProperties)
* hardcoding constantly evolving enums like instance types, lambda runtimes, partitions, regions, availability zones, etc. that get outdated quickly
---

**[how to run new validations on all existing resource provider schemas](https://github.com/aws-cloudformation/cloudformation-cli/pull/604#issuecomment-756521889)**