### PR TITLE
Add taggable support in schema

### DIFF
--- a/src/rpdk/core/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.v1.json
@@ -301,6 +301,11 @@
             ],
             "$ref": "#/definitions/httpsUrl"
         },
+        "taggable": {
+            "$comment": "A boolean flag indicating whether this resource type supports updatable tagging.",
+            "type": "boolean",
+            "default": true
+        },
         "replacementStrategy": {
             "$comment": "The order of replacement for an immutable resource update.",
             "$ref": "#/definitions/replacementStrategy"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Add taggable support to the schema to keep in match with https://github.com/aws-cloudformation/aws-cloudformation-resource-schema/blob/master/src/main/resources/schema/provider.definition.schema.v1.json


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
