### PR TITLE
enable manual CloudFormation Resource Provider Definition MetaSchema syncing

### DIFF
--- a/.github/workflows/schema-updater.yaml
+++ b/.github/workflows/schema-updater.yaml
@@ -1,7 +1,7 @@
 on:
   schedule:
     - cron: '*/5 * * * *'
-  workflow_dispatch: # Enables on-demand/manual triggering
+  workflow_dispatch: # Enables on-demand/manual triggering: https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
 jobs:
   job:
     runs-on: ubuntu-latest

--- a/.github/workflows/schema-updater.yaml
+++ b/.github/workflows/schema-updater.yaml
@@ -1,6 +1,7 @@
 on:
   schedule:
     - cron: '*/5 * * * *'
+  workflow_dispatch: # Enables on-demand/manual triggering
 jobs:
   job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[Manual triggers with `workflow_dispatch`](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) in addition to [`cron schedule`](https://github.com/aws-cloudformation/cloudformation-cli/pull/647)