### PR TITLE
catch common resource schema issues

### DIFF
--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -163,7 +163,7 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R0912 # noqa: C90
     ) & (
         set(resource_spec.get("createOnlyProperties", []))
         | set(resource_spec.get("writeOnlyProperties", []))
-        | set(["/properties/" + s for s in resource_spec.get("required", [])])
+        | {"/properties/" + s for s in resource_spec.get("required", [])}
     )
     if readOnlyProperties_intersection:
         LOG.warning(

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -158,17 +158,17 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R0912 # noqa: C90
             list_options,
         )
 
-    readOnlyProperties_intersection = set(
+    read_only_properties_intersection = set(
         resource_spec.get("readOnlyProperties", [])
     ) & (
         set(resource_spec.get("createOnlyProperties", []))
         | set(resource_spec.get("writeOnlyProperties", []))
         | {"/properties/" + s for s in resource_spec.get("required", [])}
     )
-    if readOnlyProperties_intersection:
+    if read_only_properties_intersection:
         LOG.warning(
             "readOnlyProperties cannot be specified by customers and should not overlap with writeOnlyProperties, createOnlyProperties, or required: %s",
-            readOnlyProperties_intersection,
+            read_only_properties_intersection,
         )
 
     for handler in resource_spec.get("handlers", []):

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -158,13 +158,17 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R0912 # noqa: C90
             list_options,
         )
 
-    if set(resource_spec.get("readOnlyProperties", [])) & set(
-        resource_spec.get("createOnlyProperties", [])
-    ) or set(resource_spec.get("readOnlyProperties", [])) & set(
-        resource_spec.get("writeOnlyProperties", [])
-    ):
+    readOnlyProperties_intersection = set(
+        resource_spec.get("readOnlyProperties", [])
+    ) & (
+        set(resource_spec.get("createOnlyProperties", []))
+        | set(resource_spec.get("writeOnlyProperties", []))
+        | set(["/properties/" + s for s in resource_spec.get("required", [])])
+    )
+    if readOnlyProperties_intersection:
         LOG.warning(
-            "readOnlyProperties cannot be specified by customers and should not overlap with writeOnlyProperties or createOnlyProperties"
+            "readOnlyProperties cannot be specified by customers and should not overlap with writeOnlyProperties, createOnlyProperties, or required: %s",
+            readOnlyProperties_intersection,
         )
 
     for handler in resource_spec.get("handlers", []):


### PR DESCRIPTION
continuing https://github.com/aws-cloudformation/cloudformation-cli/pull/663

---

**[`readOnlyProperties overlapping with required:`](https://github.com/aws-cloudformation/aws-cloudformation-resource-schema/#resource-semantics)**
`AWS::CodeArtifact::Repository.DomainName`
[`AWS::MWAA::Environment.Name`](https://github.com/aws/aws-cdk/issues/12611)

---

**[how to run new validations on all existing resource provider schemas](https://github.com/aws-cloudformation/cloudformation-cli/pull/604#issuecomment-756521889)**