### PR TITLE
Add cli version information in package artifact during cfn submit

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,5 @@ branch = True
 omit = */contract/suite/*
 
 [report]
+show_missing = True
 fail_under = 100

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -51,7 +51,7 @@ DEFAULT_ROLE_TIMEOUT_MINUTES = 120  # 2 hours
 MIN_ROLE_TIMEOUT_SECONDS = 3600  # 1 hour
 MAX_ROLE_TIMEOUT_SECONDS = 43200  # 12 hours
 
-CFN_METADATA_FILE_NAME = "_cfn_metadata.json"
+CFN_METADATA_FILENAME = ".cfn_metadata.json"
 
 LAMBDA_RUNTIMES = {
     "noexec",  # cannot be executed, schema only
@@ -500,7 +500,7 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                             "%s not found. Not writing to package.", INPUTS_FOLDER
                         )
 
-                    metadata_file = open(CFN_METADATA_FILE_NAME, "w+")
+                    metadata_file = open(CFN_METADATA_FILENAME, "w+")
                     self._plugin.package(self, zip_file)
 
                     # Plugin package method adds the plugin language and version info
@@ -519,9 +519,9 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                         json.dump(version_metadata, metadata_file)
                         metadata_file.close()
 
-                        zip_file.write(CFN_METADATA_FILE_NAME)
+                        zip_file.write(CFN_METADATA_FILENAME)
                     finally:
-                        os.remove(CFN_METADATA_FILE_NAME)
+                        os.remove(CFN_METADATA_FILENAME)
 
             if dry_run:
                 LOG.error("Dry run complete: %s", path.resolve())

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -512,6 +512,10 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
                         if file_content:
                             version_metadata = json.loads(file_content)
+                        else:
+                            LOG.debug(
+                                "Plugin version information not added to metadata file"
+                            )
 
                         version_metadata["cli-version"] = __version__
 

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -499,6 +499,8 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                         LOG.debug(
                             "%s not found. Not writing to package.", INPUTS_FOLDER
                         )
+
+                    metadata_file = open(CFN_METADATA_FILE_NAME, "w+")
                     self._plugin.package(self, zip_file)
 
                     # Plugin package method adds the plugin language and version info
@@ -506,12 +508,16 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     # to the zip artifact
                     try:
                         version_metadata = {}
-                        with open(CFN_METADATA_FILE_NAME, "r") as metadata_file:
-                            version_metadata = json.load(metadata_file)
+                        file_content = metadata_file.read().replace("\n", "")
 
-                        with open(CFN_METADATA_FILE_NAME, "w") as metadata_file:
-                            version_metadata["cli-version"] = __version__
-                            json.dump(version_metadata, metadata_file)
+                        if file_content:
+                            version_metadata = json.loads(file_content)
+
+                        version_metadata["cli-version"] = __version__
+
+                        metadata_file.seek(0)
+                        json.dump(version_metadata, metadata_file)
+                        metadata_file.close()
 
                         zip_file.write(CFN_METADATA_FILE_NAME)
                     finally:

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -500,7 +500,10 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                             "%s not found. Not writing to package.", INPUTS_FOLDER
                         )
 
-                    metadata_file = open(CFN_METADATA_FILENAME, "w+")
+                    metadata_file_path = self.root / CFN_METADATA_FILENAME
+                    metadata_file_path.touch(exist_ok=True)
+                    metadata_file = open(metadata_file_path, "r+")
+
                     self._plugin.package(self, zip_file)
 
                     # Plugin package method adds the plugin language and version info
@@ -523,9 +526,9 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                         json.dump(version_metadata, metadata_file)
                         metadata_file.close()
 
-                        zip_file.write(CFN_METADATA_FILENAME)
+                        zip_file.write(metadata_file_path, CFN_METADATA_FILENAME)
                     finally:
-                        os.remove(CFN_METADATA_FILENAME)
+                        os.remove(metadata_file_path)
 
             if dry_run:
                 LOG.error("Dry run complete: %s", path.resolve())

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -445,6 +445,7 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     # pylint: disable=too-many-locals
     # pylint: disable=too-many-branches
     # pylint: disable=too-many-public-methods
+    # pylint: disable=too-many-statements
     def submit(
         self, dry_run, endpoint_url, region_name, role_arn, use_role, set_default
     ):  # pylint: disable=too-many-arguments

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -6,7 +6,7 @@ import zipfile
 from pathlib import Path
 from tempfile import TemporaryFile
 from uuid import uuid4
-from . import __version__
+
 from botocore.exceptions import ClientError, WaiterError
 from jinja2 import Environment, PackageLoader, select_autoescape
 from jsonschema import Draft7Validator
@@ -15,6 +15,7 @@ from jsonschema.exceptions import ValidationError
 from rpdk.core.fragment.generator import TemplateFragment
 from rpdk.core.jsonutils.flattener import JsonSchemaFlattener
 
+from . import __version__
 from .boto_helpers import create_sdk_session
 from .data_loaders import load_resource_spec, resource_json
 from .exceptions import (
@@ -455,7 +456,6 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             context_mgr = TemporaryFile("w+b")
 
         with context_mgr as f:
-
             # the default compression is ZIP_STORED, which helps with the
             # file-size check on upload
             with zipfile.ZipFile(f, mode="w") as zip_file:
@@ -510,7 +510,7 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                             version_metadata = json.load(metadata_file)
 
                         with open(CFN_METADATA_FILE_NAME, "w") as metadata_file:
-                            version_metadata['cli-version'] = __version__
+                            version_metadata["cli-version"] = __version__
                             json.dump(version_metadata, metadata_file)
 
                         zip_file.write(CFN_METADATA_FILE_NAME)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -68,7 +68,7 @@ CREATE_INPUTS_FILE = "inputs/inputs_1_create.json"
 UPDATE_INPUTS_FILE = "inputs/inputs_1_update.json"
 INVALID_INPUTS_FILE = "inputs/inputs_1_invalid.json"
 
-METADATA_FILE_CONTENTS = {"plugin-version": "2.1.3", "plugin-name": "java"}
+PLUGIN_INFORMATION = {"plugin-version": "2.1.3", "plugin-name": "java"}
 
 
 @pytest.mark.parametrize("string", ["^[a-z]$", "([a-z])", ".*", "*."])
@@ -743,11 +743,6 @@ def test_submit_dry_run(project):
     with project.overrides_path.open("w", encoding="utf-8") as f:
         f.write(json.dumps(empty_override()))
 
-    metadata_file_path = project.root / CFN_METADATA_FILENAME
-
-    with metadata_file_path.open("w") as f:
-        json.dump(METADATA_FILE_CONTENTS, f)
-
     create_input_file(project.root)
 
     project.write_settings()
@@ -761,6 +756,8 @@ def test_submit_dry_run(project):
     # these context managers can't be wrapped by black, but it removes the \
     with patch_plugin as mock_plugin, patch_path as mock_path, \
             patch_temp as mock_temp, patch_upload as mock_upload:
+        mock_plugin.get_plugin_information = MagicMock(return_value=PLUGIN_INFORMATION)
+
         project.submit(
             True,
             endpoint_url=ENDPOINT,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -30,6 +30,7 @@ from rpdk.core.project import (
     OVERRIDES_FILENAME,
     SCHEMA_UPLOAD_FILENAME,
     SETTINGS_FILENAME,
+    CFN_METADATA_FILENAME,
     Project,
     escape_markdown,
 )
@@ -776,6 +777,7 @@ def test_submit_dry_run(project):
             CREATE_INPUTS_FILE,
             INVALID_INPUTS_FILE,
             UPDATE_INPUTS_FILE,
+            CFN_METADATA_FILENAME,
         }
         schema_contents = zip_file.read(SCHEMA_UPLOAD_FILENAME).decode("utf-8")
         assert schema_contents == CONTENTS_UTF8

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -68,6 +68,8 @@ CREATE_INPUTS_FILE = "inputs/inputs_1_create.json"
 UPDATE_INPUTS_FILE = "inputs/inputs_1_update.json"
 INVALID_INPUTS_FILE = "inputs/inputs_1_invalid.json"
 
+METADATA_FILE_CONTENTS = {"plugin-version": "2.1.3", "plugin-name": "java"}
+
 
 @pytest.mark.parametrize("string", ["^[a-z]$", "([a-z])", ".*", "*."])
 def test_escape_markdown_with_regex_names(string):
@@ -741,6 +743,11 @@ def test_submit_dry_run(project):
     with project.overrides_path.open("w", encoding="utf-8") as f:
         f.write(json.dumps(empty_override()))
 
+    metadata_file_path = project.root / CFN_METADATA_FILENAME
+
+    with metadata_file_path.open("w") as f:
+        json.dump(METADATA_FILE_CONTENTS, f)
+
     create_input_file(project.root)
 
     project.write_settings()
@@ -793,8 +800,9 @@ def test_submit_dry_run(project):
         input_update = json.loads(zip_file.read(INVALID_INPUTS_FILE).decode("utf-8"))
         assert input_update == {}
         assert zip_file.testzip() is None
-        version_info = json.loads(zip_file.read(CFN_METADATA_FILENAME).decode("utf-8"))
-        assert "cli-version" in version_info
+        metadata_info = json.loads(zip_file.read(CFN_METADATA_FILENAME).decode("utf-8"))
+        assert "cli-version" in metadata_info
+        assert "plugin-version" in metadata_info
 
 
 def test_submit_dry_run_modules(project):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -26,11 +26,11 @@ from rpdk.core.exceptions import (
 )
 from rpdk.core.plugin_base import LanguagePlugin
 from rpdk.core.project import (
+    CFN_METADATA_FILENAME,
     LAMBDA_RUNTIMES,
     OVERRIDES_FILENAME,
     SCHEMA_UPLOAD_FILENAME,
     SETTINGS_FILENAME,
-    CFN_METADATA_FILENAME,
     Project,
     escape_markdown,
 )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -793,6 +793,8 @@ def test_submit_dry_run(project):
         input_update = json.loads(zip_file.read(INVALID_INPUTS_FILE).decode("utf-8"))
         assert input_update == {}
         assert zip_file.testzip() is None
+        version_info = json.loads(zip_file.read(CFN_METADATA_FILENAME).decode("utf-8"))
+        assert "cli-version" in version_info
 
 
 def test_submit_dry_run_modules(project):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding CLI version information in a metadata file named _cfn_metadata.json. This file will be included in the package artifact zip being uploaded. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
