### PR TITLE
Add project reference when getting plugin information

### DIFF
--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -502,7 +502,7 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     cli_metadata = {}
 
                     try:
-                        cli_metadata = self._plugin.get_plugin_information()
+                        cli_metadata = self._plugin.get_plugin_information(self)
                     except AttributeError:
                         LOG.debug(
                             "Version info is not available for plugins, not writing to metadata file"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -68,7 +68,11 @@ CREATE_INPUTS_FILE = "inputs/inputs_1_create.json"
 UPDATE_INPUTS_FILE = "inputs/inputs_1_update.json"
 INVALID_INPUTS_FILE = "inputs/inputs_1_invalid.json"
 
-PLUGIN_INFORMATION = {"plugin-version": "2.1.3", "plugin-name": "java"}
+PLUGIN_INFORMATION = {
+    "plugin-version": "2.1.3",
+    "plugin-tool-version": "2.0.8",
+    "plugin-name": "java",
+}
 
 
 @pytest.mark.parametrize("string", ["^[a-z]$", "([a-z])", ".*", "*."])
@@ -801,6 +805,7 @@ def test_submit_dry_run(project):
         metadata_info = json.loads(zip_file.read(CFN_METADATA_FILENAME).decode("utf-8"))
         assert "cli-version" in metadata_info
         assert "plugin-version" in metadata_info
+        assert "plugin-tool-version" in metadata_info
 
 
 def test_submit_dry_run_modules(project):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add project as a param when fetching plugin information, this is needed to get runtime version


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
