### PR TITLE
contract_update_non_existent_resource test fails with Assertion error

### DIFF
--- a/src/rpdk/core/contract/suite/handler_update_invalid.py
+++ b/src/rpdk/core/contract/suite/handler_update_invalid.py
@@ -51,7 +51,7 @@ def contract_update_create_only_property(resource_client):
          if the resource did not exist prior to the update request",
 )
 def contract_update_non_existent_resource(resource_client):
-    create_request = resource_client.generate_invalid_create_example()
+    create_request = resource_client.generate_create_example()
     update_request = resource_client.generate_update_example(create_request)
     _status, response, _error = resource_client.call_and_assert(
         Action.UPDATE, OperationStatus.FAILED, update_request, create_request


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* contract_update_non_existent_resource fails with the exception:
```Any createOnlyProperties specified in update handler input MUST NOT be different from their previous state```

The above issue was happening because the create model's primary Identifier was different from update model. 
https://github.com/aws-cloudformation/cloudformation-cli/blame/629b4767b46becdae168e934b33f65f87146b190/src/rpdk/core/contract/suite/handler_update_invalid.py#L54-L55

The above issue was introduced here: https://github.com/aws-cloudformation/cloudformation-cli/commit/49eac51bf8257b0b2cc63cc26c9338eff592d3e1

* Test result:
```
==================================================================================================================== test session starts =====================================================================================================================
platform darwin -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm, configfile: ../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest__ggjwoch.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3, black-0.3.10
collected 16 items / 15 deselected / 1 selected                                                                                                                                                                                                              

handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                                [100%]

============================================================================================================= 1 passed, 15 deselected in 30.56s ==============================================================================================================
temporary pytest.ini path: /var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_253xbq4u.ini
extra args: ['-k', 'contract_update_non_existent_resource']
pytest args: ['-c', '/private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_253xbq4u.ini', '-m', '', '-k', 'contract_update_non_existent_resource']
==================================================================================================================== test session starts =====================================================================================================================
platform darwin -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm, configfile: ../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_253xbq4u.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3, black-0.3.10
collected 16 items / 15 deselected / 1 selected                                                                                                                                                                                                              

handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                                [100%]

============================================================================================================= 1 passed, 15 deselected in 26.27s ==============================================================================================================
Finished test
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
