### PR TITLE
making input equals to output comparison uniform

### DIFF
--- a/src/rpdk/core/contract/suite/contract_asserts.py
+++ b/src/rpdk/core/contract/suite/contract_asserts.py
@@ -78,17 +78,6 @@ def response_does_not_contain_write_only_properties(resource_client, response):
 
 
 @decorate()
-def response_contains_resource_model_equal_current_model(
-    response, current_resource_model
-):
-    assert (
-        response["resourceModel"] == current_resource_model
-    ), "All properties specified in the request MUST be present in the model \
-        returned, and they MUST match exactly, with the exception of properties\
-             defined as writeOnlyProperties in the resource schema"
-
-
-@decorate()
 def response_contains_resource_model_equal_updated_model(
     response, current_resource_model, update_resource_model
 ):

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -8,7 +8,6 @@ from rpdk.core.contract.resource_client import (
 from rpdk.core.contract.suite.contract_asserts import (
     failed_event,
     response_contains_primary_identifier,
-    response_contains_resource_model_equal_current_model,
     response_contains_resource_model_equal_updated_model,
     response_contains_unchanged_primary_identifier,
     response_does_not_contain_write_only_properties,
@@ -47,10 +46,12 @@ def test_create_failure_if_repeat_writeable_id(resource_client, current_resource
 
 @response_contains_primary_identifier
 @response_does_not_contain_write_only_properties
-@response_contains_resource_model_equal_current_model
 def test_read_success(resource_client, current_resource_model):
     _status, response, _error_code = resource_client.call_and_assert(
         Action.READ, OperationStatus.SUCCESS, current_resource_model
+    )
+    test_input_equals_output(
+        resource_client, current_resource_model, response["resourceModel"]
     )
     return response
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/cloudformation-cli/issues/662

*Description of changes:* This Cr makes the inout == output comparison uniform for both create input == create output && create input == read output.

*Test:*
```
==================================================================================================================== test session starts =====================================================================================================================
platform darwin -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm, configfile: ../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_yxwijb9p.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3, black-0.3.10
collected 16 items                                                                                                                                                                                                                                           

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                       [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                                      [ 12%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                                                    [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                                 [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                                 [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                         [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                                         [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                                       [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                       [ 56%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                                                       [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                    [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                   [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                                 [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                                 [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                                                                                                                 [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                                [100%]

=============================================================================================================== 16 passed in 838.20s (0:13:58) ===============================================================================================================
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
