### PR TITLE
Prune read only properties from input & output

### DIFF
--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -149,10 +149,8 @@ def test_delete_failure_not_found(resource_client, current_resource_model):
 
 def test_input_equals_output(resource_client, input_model, output_model):
     pruned_input_model = prune_properties_from_model(
-        input_model.copy(), resource_client.write_only_paths
-    )
-    pruned_input_model = prune_properties_from_model(
-        pruned_input_model, resource_client.read_only_paths
+        input_model.copy(),
+        list(resource_client.write_only_paths, resource_client.read_only_paths),
     )
 
     pruned_output_model = prune_properties_from_model(

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -151,9 +151,12 @@ def test_input_equals_output(resource_client, input_model, output_model):
     pruned_input_model = prune_properties_from_model(
         input_model.copy(), resource_client.write_only_paths
     )
+    pruned_input_model = prune_properties_from_model(
+        pruned_input_model, resource_client.read_only_paths
+    )
 
-    pruned_output_model = prune_properties_if_not_exist_in_path(
-        output_model.copy(), pruned_input_model, resource_client.read_only_paths
+    pruned_output_model = prune_properties_from_model(
+        output_model.copy(), resource_client.read_only_paths
     )
 
     pruned_output_model = prune_properties_if_not_exist_in_path(

--- a/src/rpdk/core/contract/suite/handler_update.py
+++ b/src/rpdk/core/contract/suite/handler_update.py
@@ -6,7 +6,6 @@ import pytest
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
 from rpdk.core.contract.interface import Action, OperationStatus
-from rpdk.core.contract.resource_client import prune_properties_from_model
 from rpdk.core.contract.suite.handler_commons import (
     test_input_equals_output,
     test_model_in_list,
@@ -27,19 +26,15 @@ def updated_resource(resource_client):
 
         update_request = resource_client.generate_update_example(created_model)
 
-        updated_input_model = prune_properties_from_model(
-            update_request.copy(), resource_client.read_only_paths
-        )
-
         _status, response, _error = resource_client.call_and_assert(
             Action.UPDATE, OperationStatus.SUCCESS, update_request, created_model
         )
         updated_model = response["resourceModel"]
-        test_input_equals_output(resource_client, updated_input_model, updated_model)
+        test_input_equals_output(resource_client, update_request, updated_model)
 
         # flake8: noqa: B950
         # pylint: disable=C0301
-        yield create_request, created_model, update_request, updated_model, updated_input_model
+        yield create_request, created_model, update_request, updated_model, update_request
     finally:
         resource_client.call_and_assert(Action.DELETE, OperationStatus.SUCCESS, model)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* prune read only properties from both input to create/update and output from create/update/read to avoid contract test failure

*Test*:
```
==================================================================================================================== test session starts =====================================================================================================================
platform darwin -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm, configfile: ../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_yxwijb9p.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3, black-0.3.10
collected 16 items                                                                                                                                                                                                                                           

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                       [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                                      [ 12%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                                                    [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                                 [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                                 [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                         [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                                         [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                                       [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                       [ 56%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                                                       [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                    [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                   [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                                 [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                                 [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                                                                                                                 [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                                [100%]

=============================================================================================================== 16 passed in 838.20s (0:13:58) ===============================================================================================================
==================================================================================================================== test session starts =====================================================================================================================
platform darwin -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm, configfile: ../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_6r6z6twd.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3, black-0.3.10
collected 16 items                                                                                                                                                                                                                                           

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                       [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                                      [ 12%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                                                    [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                                 [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                                 [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                         [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                                         [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                                       [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                       [ 56%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                                                       [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                    [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                   [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                                 [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                                 [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                                                                                                                 [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                                [100%]

============================================================================================================== 16 passed in 1042.18s (0:17:22) ===============================================================================================================
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
