### PR TITLE
Refine error message if .rpdk-config doesn't exist

### DIFF
--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -411,7 +411,10 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.load_settings()
         except FileNotFoundError as e:
             self._raise_invalid_project(
-                "Project file not found. Have you run 'init'?", e
+                "Project file {} not found. Have you run 'init' or in a wrong directory?".format(
+                    self.settings_path
+                ),
+                e,
             )
 
         if self.artifact_type == ARTIFACT_TYPE_MODULE:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently it will only show `Project file not found` error message, it's hard to know which file is Project file and where it should be.

### Testing
```
>cfn submit
Project file /Users/libruce/repos/mytest/.rpdk-config not found. Have you run 'init' or in a wrong directory?
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
