### PR TITLE
Add Regex and OR support for transform

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -231,8 +231,8 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
                     property_transform_value = self.property_transform[path].replace(
                         '"', '\\"'
                     )
-                    if "OR" in property_transform_value:
-                        transform_functions = property_transform_value.split("OR")
+                    if "$OR" in property_transform_value:
+                        transform_functions = property_transform_value.split("$OR")
                         for transform_function in transform_functions:
                             transformed_property = self.transform(
                                 transform_function, input_model
@@ -268,9 +268,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
     def compare(document_input, document_output):
         try:
             if isinstance(document_input, str):
-                regex = r"^{}$".format(document_input)
-                re.compile(regex)
-                return re.match(regex, document_output)
+                return re.match(f"^{document_input}$", document_output)
             return document_input == document_output
         except re.error:
             return document_input == document_output
@@ -497,7 +495,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         creds,
         token,
         callback_context=None,
-        **kwargs
+        **kwargs,
     ):
         return {
             "requestData": {
@@ -573,7 +571,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
                 self._session, LOWER_CAMEL_CRED_KEYS, self._role_arn
             ),
             self.generate_token(),
-            **kwargs
+            **kwargs,
         )
 
     def _call(self, payload):

--- a/src/rpdk/core/contract/templates/transformation.template
+++ b/src/rpdk/core/contract/templates/transformation.template
@@ -1,5 +1,5 @@
 var jsonata = require('jsonata')
 var model = {{input_model}}
-var expression = jsonata({{jsonata_expression}});
+var expression = jsonata("{{jsonata_expression}}");
 var result = expression.evaluate(model);
 console.log(result);

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -85,15 +85,21 @@ SCHEMA_WITH_TRANSFORM = {
         "b": {"type": "number"},
         "c": {"type": "number"},
         "d": {"type": "number"},
+        "e": {"type": "string"},
     },
     "readOnlyProperties": ["/properties/b"],
     "createOnlyProperties": ["/properties/c"],
-    "primaryIdentifier": ["/properties/c"],
+    "primaryIdentifier": ["/properties/b"],
     "writeOnlyProperties": ["/properties/d"],
-    "propertyTransform": {"/properties/a": '$join([a, "Test"])'},
+    "propertyTransform": {
+        "/properties/a": '$join([a, "Test"])',
+        "/properties/c": "$power(2, 2)",
+        "/properties/e": '$join([e, "Test"])OR$join([e, "Value"])',
+    },
 }
 
-TRANSFORM_OUTPUT = {"a": "ValueATest", "c": 1}
+TRANSFORM_OUTPUT = {"a": "ValueATest", "c": 4}
+TRANSFORM_OUTPUT_WITHOUT_C = {"a": "ValueATest", "c": 1}
 INPUT = {"a": "ValueA", "c": 1}
 INVALID_OUTPUT = {"a": "ValueB", "c": 1}
 
@@ -834,7 +840,11 @@ def test_call_async(resource_client, action):
     )
 
     mock_client.invoke.side_effect = [
-        {"Payload": StringIO('{"status": "IN_PROGRESS", "resourceModel": {"c": 3} }')},
+        {
+            "Payload": StringIO(
+                '{"status": "IN_PROGRESS", "resourceModel": {"c": 3, "b": 1} }'
+            )
+        },
         {"Payload": StringIO('{"status": "SUCCESS"}')},
     ]
 
@@ -1238,7 +1248,24 @@ def test_transform_model_equal_output(resource_client):
     output_model = TRANSFORM_OUTPUT.copy()
 
     resource_client.transform_model(input_model, output_model)
-    assert input_model == TRANSFORM_OUTPUT
+    assert input_model == output_model
+
+
+def test_transform_model_equal_output_OR(resource_client):
+    input_model = {"e": "new", "a": "ValueA", "c": 1}
+    output_model = {"e": "newValue", "a": "ValueA", "c": 1}
+
+    resource_client.transform_model(input_model, output_model)
+    assert input_model == output_model
+
+
+def test_transform_model_not_equal_output_OR(resource_client):
+    input_model = {"e": "new", "a": "ValueA", "c": 1}
+    output_model = {"e": "newValue", "a": "ValueA", "c": 5}
+
+    resource_client.transform_model(input_model, output_model)
+    assert input_model != output_model
+    assert input_model == {"a": "ValueA", "c": 4, "e": "newValue"}
 
 
 def test_transform_model_unequal_models(resource_client):
@@ -1247,7 +1274,7 @@ def test_transform_model_unequal_models(resource_client):
 
     resource_client.transform_model(input_model, output_model)
     assert input_model != output_model
-    assert input_model == TRANSFORM_OUTPUT
+    assert input_model == TRANSFORM_OUTPUT_WITHOUT_C
 
 
 def test_non_transform_model_not_equal(resource_client_inputs_schema):
@@ -1256,3 +1283,14 @@ def test_non_transform_model_not_equal(resource_client_inputs_schema):
 
     resource_client_inputs_schema.transform_model(input_model, output_model)
     assert input_model != output_model
+
+
+def test_compare_raise_exception(resource_client):
+    assert not resource_client.compare("he(lo", "hello")
+
+
+@pytest.mark.parametrize("value", [1, 2.3, True, "test"])
+def test_convert_type(resource_client, value):
+    converted_value = resource_client.convert_type(value, str(value))
+    assert isinstance(converted_value, type(value))
+    assert converted_value == value

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -94,7 +94,7 @@ SCHEMA_WITH_TRANSFORM = {
     "propertyTransform": {
         "/properties/a": '$join([a, "Test"])',
         "/properties/c": "$power(2, 2)",
-        "/properties/e": '$join([e, "Test"])OR$join([e, "Value"])',
+        "/properties/e": '$join([e, "Test"]) $OR $join([e, "Value"])',
     },
 }
 
@@ -1251,21 +1251,24 @@ def test_transform_model_equal_output(resource_client):
     assert input_model == output_model
 
 
-def test_transform_model_equal_output_OR(resource_client):
+@pytest.mark.parametrize(
+    "output",
+    [{"e": "newValue", "a": "ValueA", "c": 1}, {"e": "newTest", "a": "ValueA", "c": 1}],
+)
+def test_transform_model_equal_output_OR(resource_client, output):
     input_model = {"e": "new", "a": "ValueA", "c": 1}
-    output_model = {"e": "newValue", "a": "ValueA", "c": 1}
 
-    resource_client.transform_model(input_model, output_model)
-    assert input_model == output_model
+    resource_client.transform_model(input_model, output)
+    assert input_model == output
 
 
 def test_transform_model_not_equal_output_OR(resource_client):
     input_model = {"e": "new", "a": "ValueA", "c": 1}
-    output_model = {"e": "newValue", "a": "ValueA", "c": 5}
+    output_model = {"e": "not-newValue", "a": "ValueA", "c": 4}
 
     resource_client.transform_model(input_model, output_model)
     assert input_model != output_model
-    assert input_model == {"a": "ValueA", "c": 4, "e": "newValue"}
+    assert input_model == {"a": "ValueA", "c": 4, "e": "new"}
 
 
 def test_transform_model_unequal_models(resource_client):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add Regex and OR support for property Transform
Property Transform uses regex to compare ARN and OR to support multiple conditions. This change helps contract test support these conditions and make sure we are at parity with drift.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
