### PR TITLE
Issue-692 [Modules] Don't fail validation when version string with no quotes

### DIFF
--- a/src/rpdk/core/contract/interface.py
+++ b/src/rpdk/core/contract/interface.py
@@ -22,6 +22,7 @@ class OperationStatus(AutoName):
     FAILED = auto()
 
 
+# pylint: disable=invalid-name
 class HandlerErrorCode(AutoName):
     NotUpdatable = auto()
     InvalidRequest = auto()

--- a/src/rpdk/core/fragment/generator.py
+++ b/src/rpdk/core/fragment/generator.py
@@ -105,7 +105,7 @@ class TemplateFragment:  # pylint: disable=too-many-instance-attributes
         filename = "temporary_fragment.json"
 
         with open(filename, "w") as outfile:
-            json.dump(raw_fragment, outfile, indent=4)
+            json.dump(raw_fragment, outfile, indent=4, default=str)
 
         template = cfnlint.decode.cfn_json.load(filename)
 

--- a/tests/data/sample_fragments/template_with_date_in_version.yaml
+++ b/tests/data/sample_fragments/template_with_date_in_version.yaml
@@ -1,0 +1,4 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  WaitHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle

--- a/tests/fragments/test_generator.py
+++ b/tests/fragments/test_generator.py
@@ -86,6 +86,12 @@ def test_template_fragments_without_parameter_section_is_valid(template_fragment
     )
 
 
+def test_template_fragments_with_date_in_version(template_fragment):
+    __assert_validation_throws_no_error(
+        "template_with_date_in_version.yaml", template_fragment
+    )
+
+
 def test_template_fragments_without_description(template_fragment):
     schema = __generate_schema("template_without_description.json", template_fragment)
 


### PR DESCRIPTION
[Issue 692](https://github.com/aws-cloudformation/cloudformation-cli/issues/692)

*Description of changes:*
Don't throw an internal error when template uses the version string without quotes
```
AWSTemplateFormatVersion: 2010-09-09
```
Instead of 
```
AWSTemplateFormatVersion: "2010-09-09"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
