### PR TITLE
fix the list and remove unneeded check for delete contract test

### DIFF
--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -150,7 +150,10 @@ def test_delete_failure_not_found(resource_client, current_resource_model):
 def test_input_equals_output(resource_client, input_model, output_model):
     pruned_input_model = prune_properties_from_model(
         input_model.copy(),
-        list(resource_client.write_only_paths, resource_client.read_only_paths),
+        set(
+            list(resource_client.read_only_paths)
+            + list(resource_client.write_only_paths)
+        ),
     )
 
     pruned_output_model = prune_properties_from_model(
@@ -170,9 +173,7 @@ def test_input_equals_output(resource_client, input_model, output_model):
     # only comparing properties in input model to those in output model and
     # ignoring extraneous properties that maybe present in output model.
     try:
-        resource_client.transform_model(
-            pruned_input_model, pruned_output_model, resource_client
-        )
+        resource_client.transform_model(pruned_input_model, pruned_output_model)
         for key in pruned_input_model:
             if key in resource_client.properties_without_insertion_order:
                 assert test_unordered_list_match(

--- a/src/rpdk/core/contract/suite/handler_delete.py
+++ b/src/rpdk/core/contract/suite/handler_delete.py
@@ -7,7 +7,6 @@ import pytest
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
 from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
-from rpdk.core.contract.resource_client import prune_properties_from_model
 from rpdk.core.contract.suite.handler_commons import (
     test_create_success,
     test_delete_failure_not_found,
@@ -91,20 +90,10 @@ def contract_delete_delete(resource_client, deleted_resource):
 @pytest.mark.delete
 def contract_delete_create(resource_client, deleted_resource):
     if resource_client.has_only_writable_identifiers():
-        deleted_model, request = deleted_resource
+        _deleted_model, request = deleted_resource
         response = test_create_success(resource_client, request)
         created_response = response.copy()
-        # read-only properties should be excluded from the comparison
-        prune_properties_from_model(deleted_model, resource_client.read_only_paths)
-        prune_properties_from_model(
-            response["resourceModel"], resource_client.read_only_paths
-        )
 
-        assert (
-            deleted_model == response["resourceModel"]
-        ), "Once a delete operation successfully completes, a subsequent\
-             create request with the same primaryIdentifier or additionalIdentifiers\
-                  MUST NOT return FAILED with an AlreadyExists error code"
         resource_client.call_and_assert(
             Action.DELETE, OperationStatus.SUCCESS, created_response["resourceModel"]
         )

--- a/src/rpdk/core/contract/suite/handler_delete.py
+++ b/src/rpdk/core/contract/suite/handler_delete.py
@@ -92,10 +92,9 @@ def contract_delete_create(resource_client, deleted_resource):
     if resource_client.has_only_writable_identifiers():
         _deleted_model, request = deleted_resource
         response = test_create_success(resource_client, request)
-        created_response = response.copy()
 
         resource_client.call_and_assert(
-            Action.DELETE, OperationStatus.SUCCESS, created_response["resourceModel"]
+            Action.DELETE, OperationStatus.SUCCESS, response["resourceModel"]
         )
     else:
         pytest.skip("No writable identifiers. Skipping test.")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
The Cr has 2 changes:
* Fix the ```TypeError: list expected at most 1 arguments, got 2``` bu adding the 2 sets into one
* remove the check to see if deleted_model == create_output this not required as deleted_model and request are the same model. 
*Test:*
```
(env) 3c22fbb25c23:aws-cloudwatch-alarm anshikg$ cfn test --enforce-timeout 120
[Warning] Resource spec validation would fail from next major version. Provider should mark additionalProperties as false if the property is of object type and has properties or patternProperties defined in it. Please fix the warnings: 'additionalProperties' is a required property

Failed validating 'required' in schema['properties']['properties']['patternProperties']['^[A-Za-z0-9]{1,64}$']['allOf'][0]['dependencies']['patternProperties']:
    {'$comment': 'An object cannot have both defined and undefined '
                 'properties; therefore, properties is not allowed when '
                 'patternProperties is specified. Provider should mark '
                 'additionalProperties as false if the property is of '
                 'object type and has patternProperties defined in it.',
     'not': {'required': ['properties']},
     'required': ['additionalProperties']}

On instance['properties']['ExtendedStatistic']:
    {'description': 'The percentile statistic for the metric associated '
                    'with the alarm. Specify a value between p0.0 and '
                    'p100.',
     'patternProperties': {'^p(\\d{1,2}(\\.\\d{0,2})?|100)$': {'type': 'string'}},
     'type': 'string'}
Resource schema is valid.
========================================================================================================================================================================================================================================= test session starts =========================================================================================================================================================================================================================================
platform darwin -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm, configfile: ../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_05n41riz.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3, black-0.3.10
collected 16 items                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                                                                                                                                                                                                                                                                [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                                                                                                                                                                                                                                                                               [ 12%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                                                  [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                               [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                               [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                       [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                                       [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                                     [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                     [ 56%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                                                     [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                  [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                 [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                               [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                               [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                                                                                                               [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                              [100%]

============================================================================================================== 16 passed in 700.31s (0:11:40) ==============================================================================================================
=================================================================================================================== test session starts ====================================================================================================================
platform darwin -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm, configfile: ../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_rukwsks_.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3, black-0.3.10
collected 16 items                                                                                                                                                                                                                                         

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                     [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                                    [ 12%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                                                  [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                               [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                               [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                       [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                                       [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                                     [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                     [ 56%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                                                     [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                  [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                 [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                               [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                               [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                                                                                                               [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                              [100%]

============================================================================================================== 16 passed in 628.21s (0:10:28) ==============================================================================================================
=================================================================================================================== test session starts ====================================================================================================================
platform darwin -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm, configfile: ../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_b_nup1jo.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3, black-0.3.10
collected 16 items                                                                                                                                                                                                                                         

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                     [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                                    [ 12%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                                                  [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                               [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                               [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                       [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                                       [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                                     [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                     [ 56%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                                                     [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                  [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                 [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                               [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                               [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                                                                                                               [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                              [100%]

============================================================================================================== 16 passed in 629.82s (0:10:29) ==============================================================================================================
(env) 3c22fbb25c23:aws-cloudwatch-alarm anshikg$ 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
