### PR TITLE
Enable Encryption in Modules example fragment

### DIFF
--- a/fragments/sample.json
+++ b/fragments/sample.json
@@ -15,6 +15,15 @@
                 "BucketName": {
                     "Ref": "BucketName"
                 },
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": [
+                        {
+                            "ServerSideEncryptionByDefault": {
+                                "SSEAlgorithm": "AES256"
+                            }
+                        }
+                    ]
+                },
                 "VersioningConfiguration": {
                     "Status": "Enabled"
                 }

--- a/src/rpdk/core/data/examples/module/sample.json
+++ b/src/rpdk/core/data/examples/module/sample.json
@@ -15,6 +15,15 @@
                 "BucketName": {
                     "Ref": "BucketName"
                 },
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": [
+                        {
+                            "ServerSideEncryptionByDefault": {
+                                "SSEAlgorithm": "AES256"
+                            }
+                        }
+                    ]
+                },
                 "VersioningConfiguration": {
                     "Status": "Enabled"
                 }


### PR DESCRIPTION
Enable Encryption in Modules example fragment, because that's good practice in S3


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
