### PR TITLE
[Modules] Support parsing Yaml fragments with CFN short forms

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ include_trailing_comma = true
 combine_as_imports = True
 force_grid_wrap = 0
 known_first_party = rpdk
-known_third_party = boto3,botocore,cfnlint,colorama,docker,hypothesis,jinja2,jsonschema,nested_lookup,ordered_set,pkg_resources,pytest,pytest_localserver,setuptools,yaml
+known_third_party = boto3,botocore,cfn_tools,cfnlint,colorama,docker,hypothesis,jinja2,jsonschema,nested_lookup,ordered_set,pkg_resources,pytest,pytest_localserver,setuptools,yaml
 
 [tool:pytest]
 # can't do anything about 3rd part modules, so don't spam us

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "docker>=4.3.1",
         "ordered-set>=4.0.2",
         "cfn-lint>=0.43.0",
+        "cfn_flip>=1.2.3",
         "nested-lookup",
     ],
     entry_points={

--- a/src/rpdk/core/cli.py
+++ b/src/rpdk/core/cli.py
@@ -131,8 +131,7 @@ def main(args_in=None):  # pylint: disable=too-many-statements
         print("=== Unhandled exception ===", file=sys.stderr)
         print("Please report this issue to the team.", file=sys.stderr)
         print(
-            "Issue tracker: "
-            "https://github.com/aws-cloudformation/aws-cloudformation-rpdk/issues",
+            "Issue tracker: github.com/aws-cloudformation/cloudformation-cli/issues",
             file=sys.stderr,
         )
 

--- a/src/rpdk/core/fragment/lint_warning_printer.py
+++ b/src/rpdk/core/fragment/lint_warning_printer.py
@@ -1,0 +1,53 @@
+import json
+import logging
+
+import cfnlint.config
+import cfnlint.core
+
+from .module_fragment_reader import _get_fragment_file
+
+LOG = logging.getLogger(__name__)
+
+
+def print_cfn_lint_warnings(fragment_dir):
+    lint_warnings = __get_cfn_lint_matches(fragment_dir)
+    if not lint_warnings:
+        LOG.warning("Module fragment is valid.")
+    else:
+        LOG.warning(
+            "Module fragment might be valid, but there are "
+            "warnings from cfn-lint "
+            "(https://github.com/aws-cloudformation/cfn-python-lint):"
+        )
+        for lint_warning in lint_warnings:
+            print(
+                "\t{} (from rule {})".format(lint_warning.message, lint_warning.rule),
+            )
+
+
+def __get_cfn_lint_matches(fragment_dir):
+    filepath = _get_fragment_file(fragment_dir)
+    try:
+        try:
+            template = cfnlint.decode.cfn_json.load(filepath)
+        except json.decoder.JSONDecodeError:
+            template = cfnlint.decode.cfn_yaml.load(filepath)
+    except Exception as e:  # pylint: disable=broad-except
+        LOG.error(
+            "Skipping cfn-lint validation due to an internal error.\n"
+            "Please report this issue to the team (include rpdk.log file)\n"
+            "Issue tracker: github.com/aws-cloudformation/cloudformation-cli/issues"
+        )
+        LOG.error(str(e))
+        return []
+
+    # Initialize the ruleset to be applied (no overrules, no excludes)
+    rules = cfnlint.core.get_rules([], [], [], [], False, [])
+
+    # Default region used by cfn-lint
+    regions = ["us-east-1"]
+
+    # Runs Warning and Error rules
+    matches = cfnlint.core.run_checks(filepath, template, rules, regions)
+
+    return matches

--- a/src/rpdk/core/fragment/module_fragment_reader.py
+++ b/src/rpdk/core/fragment/module_fragment_reader.py
@@ -35,6 +35,10 @@ def _get_fragment_file(fragment_dir):
             ext = os.path.splitext(f)[-1].lower()
             if ext in ALLOWED_EXTENSIONS:
                 all_fragment_files.append(os.path.join(root, f))
+    if len(all_fragment_files) == 0:
+        raise FragmentValidationError(
+            f"No module fragment files found in the fragments folder ending on one of {ALLOWED_EXTENSIONS}"
+        )
     if len(all_fragment_files) > 1:
         raise FragmentValidationError(
             "A Module can only consist of a "

--- a/src/rpdk/core/fragment/module_fragment_reader.py
+++ b/src/rpdk/core/fragment/module_fragment_reader.py
@@ -1,0 +1,73 @@
+import logging
+import os
+
+import yaml
+from cfn_tools import load_yaml
+
+from rpdk.core.exceptions import FragmentValidationError
+
+LOG = logging.getLogger(__name__)
+ALLOWED_EXTENSIONS = {".json", ".yaml", ".yml"}
+
+
+def read_raw_fragments(fragment_dir):
+    return _load_fragment(_get_fragment_file(fragment_dir))
+
+
+def get_template_file_size_in_bytes(fragment_dir):
+    return os.stat(_get_fragment_file(fragment_dir)).st_size
+
+
+def _load_fragment(fragment_file):
+    try:
+        with open(fragment_file, "r", encoding="utf-8") as f:
+            return yaml.safe_load(
+                __first_pass_syntax_check(__convert_function(f.read()))
+            )
+    except yaml.parser.ParserError as e:
+        try:
+            LOG.info("Parsing with cfn_flip")
+            with open(fragment_file, "r", encoding="utf-8") as f:
+                return load_yaml(f.read())
+        except yaml.parser.ParserError as parser_error:
+            raise FragmentValidationError(
+                "Fragment file '{}' is invalid: {}".format(fragment_file, str(e))
+            ) from parser_error
+
+
+def _get_fragment_file(fragment_dir):
+    all_fragment_files = []
+    for root, _directories, files in os.walk(fragment_dir):
+        for f in files:
+            ext = os.path.splitext(f)[-1].lower()
+            if ext in ALLOWED_EXTENSIONS:
+                all_fragment_files.append(os.path.join(root, f))
+    if len(all_fragment_files) > 1:
+        raise FragmentValidationError(
+            "A Module can only consist of a "
+            "single template file, but there are "
+            + str(len(all_fragment_files))
+            + ": "
+            + str(all_fragment_files)
+        )
+    return all_fragment_files[0]
+
+
+def __first_pass_syntax_check(template):
+    if "Fn::ImportValue" in template:
+        raise FragmentValidationError(
+            "Template fragment can't contain any Fn::ImportValue."
+        )
+    return template
+
+
+def __convert_function(template):
+    """
+    When generating schema, we don't care about the actual reference.
+    So the following will only make a valid YAML file.
+    """
+    return (
+        template.replace("!Transform", "Fn::Transform")
+        .replace("!ImportValue", "Fn::ImportValue")
+        .replace("!", "")
+    )

--- a/src/rpdk/core/fragment/module_fragment_reader.py
+++ b/src/rpdk/core/fragment/module_fragment_reader.py
@@ -22,7 +22,7 @@ def _load_fragment(fragment_file):
     try:
         with open(fragment_file, "r", encoding="utf-8") as f:
             return load_yaml(__first_pass_syntax_check(f.read()))
-    except yaml.parser.ParserError as e:
+    except (yaml.parser.ParserError, yaml.scanner.ScannerError) as e:
         raise FragmentValidationError(
             "Fragment file '{}' is invalid: {}".format(fragment_file, str(e))
         ) from e

--- a/tests/data/sample_fragments/ec2withsub.yaml
+++ b/tests/data/sample_fragments/ec2withsub.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  EC2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-09c5e030f74651050
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash -e
+          sudo yum install -y https://s3.region.amazonaws.com/amazon-ssm-region/latest/linux_amd64/amazon-ssm-agent.rpm
+          sudo systemctl status amazon-ssm-agent
+          sudo systemctl enable amazon-ssm-agent
+          sudo systemctl start amazon-ssm-agent

--- a/tests/fragments/test_lint_warning_printer.py
+++ b/tests/fragments/test_lint_warning_printer.py
@@ -1,0 +1,16 @@
+import os
+from shutil import copyfile
+from tempfile import TemporaryDirectory
+
+from rpdk.core.fragment.lint_warning_printer import print_cfn_lint_warnings
+
+directory = os.path.dirname(__file__)
+
+
+def test_print_lint_warnings_for_unparseable_fragment_swallows_exception():
+    with TemporaryDirectory() as temporary_folder:
+        copyfile(
+            os.path.join(directory, "../data/sample_fragments/syntax_error.json"),
+            os.path.join(temporary_folder, "syntax_error.json"),
+        )
+        print_cfn_lint_warnings(temporary_folder)

--- a/tests/fragments/test_module_fragment_reader.py
+++ b/tests/fragments/test_module_fragment_reader.py
@@ -1,0 +1,13 @@
+import os
+
+from rpdk.core.fragment.module_fragment_reader import _load_fragment
+
+directory = os.path.dirname(__file__)
+
+
+def test_fragments_are_loaded_yaml_short():
+    fragment = os.path.join(directory, "../data/sample_fragments/ec2_short.yaml")
+    merged_fragment = _load_fragment(fragment)
+    assert len(merged_fragment) == 2
+    assert len(merged_fragment["Resources"]) == 1
+    assert "MyEC2Instance" in merged_fragment["Resources"]

--- a/tests/fragments/test_module_fragment_reader.py
+++ b/tests/fragments/test_module_fragment_reader.py
@@ -1,6 +1,10 @@
 import os
+from tempfile import TemporaryDirectory
 
-from rpdk.core.fragment.module_fragment_reader import _load_fragment
+import pytest
+
+from rpdk.core.exceptions import FragmentValidationError
+from rpdk.core.fragment.module_fragment_reader import _get_fragment_file, _load_fragment
 
 directory = os.path.dirname(__file__)
 
@@ -11,3 +15,12 @@ def test_fragments_are_loaded_yaml_short():
     assert len(merged_fragment) == 2
     assert len(merged_fragment["Resources"]) == 1
     assert "MyEC2Instance" in merged_fragment["Resources"]
+
+
+def test_get_fragment_file_without_file_throws_exception():
+    with TemporaryDirectory() as path_to_empty_directory:
+        with pytest.raises(FragmentValidationError) as validation_error:
+            _get_fragment_file(path_to_empty_directory)
+        assert "No module fragment files found in the fragments folder" in str(
+            validation_error.value
+        )


### PR DESCRIPTION
Issues #693 and #689 

*Description of changes:*
 * Using [cfn-flip](https://github.com/awslabs/aws-cfn-template-flip) to parse the Module fragments so we can support the full range of CFN yaml syntax. This is solving the problem that we can't currently parse templates like the one below:

```yaml
AWSTemplateFormatVersion: "2010-09-09"
Resources:
  EC2Instance:
    Type: AWS::EC2::Instance
    Properties:
      ImageId: ami-09c5e030f74651050
      UserData:
        Fn::Base64: !Sub |
          #!/bin/bash -e
          sudo yum install -y https://s3.region.amazonaws.com/amazon-ssm-region/latest/linux_amd64/amazon-ssm-agent.rpm
          sudo systemctl status amazon-ssm-agent
          sudo systemctl enable amazon-ssm-agent
          sudo systemctl start amazon-ssm-agent
```
 * Apply cfn-lint on the original, unmodified module fragment file to avoid any false positives from cfn-lint
 * This PR also extracts some module-reading logic from generator.py into a separate module.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
