### PR TITLE
Show master branch badge, instead of release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CloudFormation CLI Release](https://github.com/aws-cloudformation/cloudformation-cli/actions/workflows/pypi-release.yaml/badge.svg)](https://github.com/aws-cloudformation/cloudformation-cli/actions/workflows/pypi-release.yaml)
+[![CloudFormation CLI](https://github.com/aws-cloudformation/cloudformation-cli/actions/workflows/pr-ci.yaml/badge.svg?branch=master)](https://github.com/aws-cloudformation/cloudformation-cli/actions/workflows/pr-ci.yaml)
 
 # AWS CloudFormation CLI
 


### PR DESCRIPTION
*Description of changes:*
It's more interesting to see if the master branch build is passing than the last release

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
