### PR TITLE
Prevent Modules unit tests from leaking files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,4 +115,3 @@ README.html
 .idea
 out.java
 out/
-schema.json

--- a/src/rpdk/core/module/init_module.py
+++ b/src/rpdk/core/module/init_module.py
@@ -24,7 +24,7 @@ def init_module(args, project):
         type_name = input_typename()
 
     project.init_module(type_name)
-    template_fragment = TemplateFragment(type_name)
+    template_fragment = TemplateFragment(type_name, project.root)
     template_fragment.generate_sample_fragment()
 
 

--- a/tests/fragments/test_generator.py
+++ b/tests/fragments/test_generator.py
@@ -141,6 +141,16 @@ def test_generate_sample_fragment(template_fragment, tmpdir):
     assert os.path.exists(sample_fragment_path)
 
 
+def test_generate_sample_fragment_succeeds_even_if_fragment_folder_exists(
+    template_fragment, tmpdir
+):
+    sample_fragment_path = tmpdir.join("fragments").join("sample.json")
+    os.mkdir(tmpdir.join("fragments"))
+    assert not os.path.exists(sample_fragment_path)
+    template_fragment.generate_sample_fragment()
+    assert os.path.exists(sample_fragment_path)
+
+
 def test_fragments_are_loaded_yaml_short(template_fragment):
     __assert_validation_throws_no_error("ec2_short.yaml", template_fragment)
 

--- a/tests/jsonutils/area_definition_flattened.py
+++ b/tests/jsonutils/area_definition_flattened.py
@@ -1,4 +1,3 @@
-# pylint: disable=line-too-long
 AREA_DEFINITION_FLATTENED = {
     (): {
         "typeName": "AWS::geography::areaDescription",

--- a/tests/module/test_init_module.py
+++ b/tests/module/test_init_module.py
@@ -1,3 +1,4 @@
+from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -5,7 +6,6 @@ import pytest
 from rpdk.core.exceptions import WizardValidationError
 from rpdk.core.module import init_module
 from rpdk.core.module.init_module import validate_type_name
-from rpdk.core.project import Project
 
 
 def test_validate_type_name_invalid():
@@ -24,9 +24,11 @@ def test_init_module_falls_back_to_user_input_if_arg_invalid():
     patch_input = patch.object(
         init_module, "input_typename", return_value="Module::Mc::Modulson::MODULE"
     )
-    mock_project = MagicMock(spec=Project)
-    mock_args = MagicMock()
-    mock_args.type_name.return_value = "Not a valid type"
-    with patch_validate, patch_input:
-        init_module.init_module(mock_args, mock_project)
-    mock_project.init_module.assert_called_once_with("Module::Mc::Modulson::MODULE")
+    mock_project = MagicMock()
+    with TemporaryDirectory() as temporary_directory:
+        mock_project.root = temporary_directory
+        mock_args = MagicMock()
+        mock_args.type_name.return_value = "Not a valid type"
+        with patch_validate, patch_input:
+            init_module.init_module(mock_args, mock_project)
+        mock_project.init_module.assert_called_once_with("Module::Mc::Modulson::MODULE")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest.mock import ANY, Mock, PropertyMock, patch
 
 import pytest
@@ -73,8 +75,10 @@ def test_init_module_method_interactive():
     )
     patch_at = patch("rpdk.core.init.init_artifact_type", return_value="MODULE")
 
-    with patch_project, patch_tn as mock_tn, patch_l as mock_l, patch_at as mock_t:
-        main(args_in=["init"])
+    with TemporaryDirectory() as temporary_directory:
+        mock_project.root = Path(temporary_directory)
+        with patch_project, patch_tn as mock_tn, patch_l as mock_l, patch_at as mock_t:
+            main(args_in=["init"])
 
     mock_tn.assert_called_once_with()
     mock_l.assert_not_called()
@@ -95,8 +99,6 @@ def test_init_resource_method_noninteractive():
         "rpdk.core.init.get_parsers", return_value={"dummy": dummy_parser}
     )
 
-    # flake8: noqa: B950
-    # pylint: disable=line-too-long
     with patch_project, patch_get_parser as mock_parser:
         main(
             args_in=[
@@ -146,8 +148,6 @@ def test_init_resource_method_noninteractive_invalid_type_name():
         "rpdk.core.init.get_parsers", return_value={"dummy": dummy_parser}
     )
 
-    # flake8: noqa: B950
-    # pylint: disable=line-too-long
     with patch_project, patch_t, patch_tn as mock_tn, patch_get_parser as mock_parser:
         main(
             args_in=[
@@ -275,20 +275,20 @@ def test_init_module_method_noninteractive():
         "rpdk.core.init.get_parsers", return_value={"dummy": dummy_parser}
     )
 
-    # flake8: noqa: B950
-    # pylint: disable=line-too-long
-    with patch_project, patch_get_parser as mock_parser:
-        main(
-            args_in=[
-                "init",
-                "--type-name",
-                args.type_name,
-                "--artifact-type",
-                args.artifact_type,
-                args.language,
-                "--dummy",
-            ]
-        )
+    with TemporaryDirectory() as temporary_directory:
+        mock_project.root = Path(temporary_directory)
+        with patch_project, patch_get_parser as mock_parser:
+            main(
+                args_in=[
+                    "init",
+                    "--type-name",
+                    args.type_name,
+                    "--artifact-type",
+                    args.artifact_type,
+                    args.language,
+                    "--dummy",
+                ]
+            )
 
     mock_parser.assert_called_once()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -92,7 +92,7 @@ def get_mock_project():
 
     patch_project = patch("rpdk.core.init.Project", return_value=mock_project)
 
-    return (mock_project, patch_project)
+    return mock_project, patch_project
 
 
 def get_args(language=None, type_name=None, artifact_type=None):


### PR DESCRIPTION
*Description of changes:*
Some modules tests were operating on the root folder of this repo and generating files there. This commit changes that to use temporary directories so no files are leaked.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
