### PR TITLE
Redact credentials from invoke console output

### DIFF
--- a/src/rpdk/core/invoke.py
+++ b/src/rpdk/core/invoke.py
@@ -48,9 +48,20 @@ def invoke(args):
         while _needs_reinvocation(args.max_reinvoke, current_invocation):
             print("=== Handler input ===")
 
-            payload_copy = payload.copy()
-            payload_copy["requestData"]["callerCredentials"] = "<redacted>"
-            print(json.dumps({**payload_copy}, indent=2))
+            payload_to_log = {
+                "callbackContext": payload["callbackContext"],
+                "action": payload["action"],
+                "requestData": {
+                    "resourceProperties": payload["requestData"]["resourceProperties"],
+                    "previousResourceProperties": payload["requestData"][
+                        "previousResourceProperties"
+                    ],
+                },
+                "region": payload["region"],
+                "awsAccountId": payload["awsAccountId"],
+                "bearerToken": payload["bearerToken"],
+            }
+            print(json.dumps({**payload_to_log}, indent=2))
 
             response = client._call(payload)
             current_invocation = current_invocation + 1

--- a/src/rpdk/core/invoke.py
+++ b/src/rpdk/core/invoke.py
@@ -47,7 +47,11 @@ def invoke(args):
     try:
         while _needs_reinvocation(args.max_reinvoke, current_invocation):
             print("=== Handler input ===")
-            print(json.dumps({**payload, "credentials": "<redacted>"}, indent=2))
+
+            payload_copy = payload.copy()
+            payload_copy["requestData"]["callerCredentials"] = "<redacted>"
+            print(json.dumps({**payload_copy}, indent=2))
+
             response = client._call(payload)
             current_invocation = current_invocation + 1
             print("=== Handler response ===")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* When calling cfn invoke locally, the temporary credentials are printed out of the console. This could be a potential security issue. Redacted credentials from the console output. Following is the output when I run cfn invoke on my machine:

```
(env) 3c22fbb25c23:typescript anshikg$ cfn invoke CREATE create.json 
Resource schema is valid.
=== Handler input ===
{
  "requestData": {
    "callerCredentials": "<redacted>",
    "resourceProperties": {
      "Color": "000",
      "Name": "000"
    },
    "previousResourceProperties": {},
    "logicalResourceId": "2b62c178-dd3d-453e-aa67-1f0eb259b1ab"
  },
  "region": "us-east-1",
  "awsAccountId": "594820947549",
  "action": "CREATE",
  "callbackContext": null,
  "bearerToken": "2b62c178-dd3d-453e-aa67-1f0eb259b1ab"
}
=== Handler response ===
{
  "message": "",
  "callbackDelaySeconds": 0,
  "status": "SUCCESS",
  "resourceModel": {
    "Id": "4eb2db78",
    "Name": "000",
    "Color": "000"
  }
}

```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
