### PR TITLE
Update prune_properties to support pruning attributes for all sequence members

### DIFF
--- a/tests/jsonutils/test_utils.py
+++ b/tests/jsonutils/test_utils.py
@@ -1,6 +1,11 @@
 import pytest
 
-from rpdk.core.jsonutils.utils import NON_MERGABLE_KEYS, ConstraintError, schema_merge
+from rpdk.core.jsonutils.utils import (
+    NON_MERGABLE_KEYS,
+    ConstraintError,
+    schema_merge,
+    traverse_path_for_sequence_members,
+)
 
 A = "VVNEON"
 B = "HVPOEV"
@@ -58,3 +63,128 @@ def test_schema_merge_overwrite_and_merge():
     rhs = {"foo": {"a": {"aa": "a", "cc": "c"}}}
     result = schema_merge(lhs, rhs, ())
     assert result == {"foo": {"a": {"aa": "a", "bb": "b", "cc": "c"}}, "bar": 1}
+
+
+def test_traverse_path_for_sequence_members_simple():
+    # Arrange
+    case_1 = {"foo": {"bar": [42, 43, 44]}}, ()
+    result_1 = [{"foo": {"bar": [42, 43, 44]}}], [()]
+    case_2 = {"foo": {"bar": [42, 43, 44]}}, ["foo"]
+    result_2 = (
+        [{"bar": [42, 43, 44]}],
+        [tuple(["foo"])],  # noqa: C409
+    )
+    case_3 = {"foo": {"bar": [42, 43, 44]}}, ("foo", "bar")
+    result_3 = [[42, 43, 44]], [("foo", "bar")]
+    case_4_key_error = {}, ["foo"]
+    case_5_value_error = [], ["foo"]
+    case_6_index_error = [], [0]
+
+    # Act
+    actual_result_1 = traverse_path_for_sequence_members(*case_1)
+    actual_result_2 = traverse_path_for_sequence_members(*case_2)
+    actual_result_3 = traverse_path_for_sequence_members(*case_3)
+
+    # Act/Assert
+    with pytest.raises(KeyError):
+        traverse_path_for_sequence_members(*case_4_key_error)
+    with pytest.raises(ValueError):
+        traverse_path_for_sequence_members(*case_5_value_error)
+    with pytest.raises(IndexError):
+        traverse_path_for_sequence_members(*case_6_index_error)
+
+    # Assert
+    assert result_1 == actual_result_1
+    assert result_2 == actual_result_2
+    assert result_3 == actual_result_3
+
+
+def test_traverse_path_for_sequence_members_unpack():
+    # Arrange
+    case_1 = {"foo": {"bar": [{"baz": 1, "bin": 11}, {"baz": 2, "bin": 22}]}}, (
+        "foo",
+        "bar",
+        "*",
+    )
+    result_1 = (
+        [{"baz": 1, "bin": 11}, {"baz": 2, "bin": 22}],
+        [("foo", "bar", 0), ("foo", "bar", 1)],
+    )
+    case_2 = {"foo": {"bar": [{"baz": 1, "bin": 11}, {"baz": 2, "bin": 22}]}}, (
+        "foo",
+        "bar",
+        "*",
+        "baz",
+    )
+    result_2 = (
+        [1, 2],
+        [("foo", "bar", 0, "baz"), ("foo", "bar", 1, "baz")],
+    )
+
+    # Act
+    actual_result_1 = traverse_path_for_sequence_members(*case_1)
+    actual_result_2 = traverse_path_for_sequence_members(*case_2)
+
+    # Assert
+    assert result_1 == actual_result_1
+    assert result_2 == actual_result_2
+
+
+def test_traverse_path_for_sequence_members_unpack_same_as_index():
+    # Arrange
+    case_1_a = {"foo": {"bar": [42, 43, 44]}}, ("foo", "bar", "0")
+    case_1_b = {"foo": {"bar": [42, 43, 44]}}, ("foo", "bar", "1")
+    case_1_c = {"foo": {"bar": [42, 43, 44]}}, ("foo", "bar", "2")
+    result_1_a = [42], [("foo", "bar", 0)]
+    result_1_b = [43], [("foo", "bar", 1)]
+    result_1_c = [44], [("foo", "bar", 2)]
+    case_unpack = {"foo": {"bar": [42, 43, 44]}}, ("foo", "bar", "*")
+    result_unpack = (
+        [42, 43, 44],
+        [("foo", "bar", 0), ("foo", "bar", 1), ("foo", "bar", 2)],
+    )
+
+    # Act
+    actual_result_1_a = traverse_path_for_sequence_members(*case_1_a)
+    actual_result_1_b = traverse_path_for_sequence_members(*case_1_b)
+    actual_result_1_c = traverse_path_for_sequence_members(*case_1_c)
+    actual_result_unpack = traverse_path_for_sequence_members(*case_unpack)
+
+    # Assert
+    assert result_1_a == actual_result_1_a
+    assert result_1_b == actual_result_1_b
+    assert result_1_c == actual_result_1_c
+    assert result_unpack == actual_result_unpack
+    assert (
+        actual_result_unpack[0]
+        == actual_result_1_a[0] + actual_result_1_b[0] + actual_result_1_c[0]
+    )
+    assert (
+        actual_result_unpack[1]
+        == actual_result_1_a[1] + actual_result_1_b[1] + actual_result_1_c[1]
+    )
+
+
+def test_traverse_path_for_sequence_members_multiple_unpack():
+    # Arrange
+    case = {
+        "bar": [
+            {"baz": [{"foo": 11, "faz": 111}, {"foo": 99, "faz": 999}], "bin": 1},
+            {"baz": [{"foo": 22, "faz": 222}, {"foo": 88, "faz": 888}], "bin": 2},
+        ]
+    }, ("bar", "*", "baz", "*", "foo")
+    result = (
+        [11, 99, 22, 88],
+        [
+            ("bar", 0, "baz", 0, "foo"),
+            ("bar", 0, "baz", 1, "foo"),
+            ("bar", 1, "baz", 0, "foo"),
+            ("bar", 1, "baz", 1, "foo"),
+        ],
+    )
+
+    # Act
+    actual_result = traverse_path_for_sequence_members(*case)
+
+    # Assert
+    assert result == actual_result


### PR DESCRIPTION
## Notes

Previously, contract tests could not prune an attribute from *all* sequence members, but pruning an attribute for a specific attribute was doable (by specifying a valid index in the path to prune). If supplying an asterisk (`*`) in the path for a sequence, the `traverse` method would run into a ValueError:
```
~/.virtualenvs/local_cfn/lib/python3.8/site-packages/rpdk/core/jsonutils/utils.py:114: in traverse
    part = int(part)
E   ValueError: invalid literal for int() with base 10: '*'
```

This pull request adds support for pruning attributes for all sequence members, when the index provided for the sequence is `*`.

(NOTE: it could easily be any other unpack identifier that isn't a valid property name, but asterisk felt like a good choice)

## Example

An example of a schema with readonly sequence members is `AWS::FraudDetector::EventType` ([schema json](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-frauddetector/blob/master/aws-frauddetector-eventtype/aws-frauddetector-eventtype.json#L278-L286))

## Related Issue:
https://github.com/aws-cloudformation/cloudformation-cli/issues/478

## Description of changes:

`prune_properties` was updated with a conditional that checks for `*` in the path, and uses a different version of `traverse` for those paths. This different version of traverse returns multiple resolved paths, which are then used to delete attributes from the original document.

The additional `traverse` (named `traverse_path_for_sequence_members`) uses recursion to continue to traverse multiple documents when the path "branches" for all sequence members.

## Testing:
`pre-commit run --all-files` is happy, and previously failing contract tests pass :)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
