### PR TITLE
Merge create and update model to get read only properties

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -69,6 +69,24 @@ def prune_properties_if_not_exist_in_path(output_model, input_model, paths):
     return output_document["properties"]
 
 
+def prune_properties_which_dont_exist_in_path(model, paths):
+    """Prune given properties from a model. This method removes any property
+    from the model which does not exists in the paths
+
+    This assumes properties will always have an object (dict) as a parent.
+    The function returns the model after pruning the path which exists
+    in the paths tuple but not in the input_model
+    """
+    document = {"properties": model.copy()}
+    for model_path in model.keys():
+        path_tuple = ("properties", model_path)
+        if path_tuple not in paths:
+            _prop, resolved_path, parent = traverse(document, path_tuple)
+            key = resolved_path[-1]
+            del parent[key]
+    return document["properties"]
+
+
 def path_exists(document, path):
     try:
         _prop, _resolved_path, _parent = traverse(document, path)
@@ -426,7 +444,12 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             if self.create_only_paths:
                 self.validate_update_example_keys(unique_identifiers, update_example)
             update_example.update(unique_identifiers)
-            return {**create_model, **update_example}
+            create_model_with_read_only_properties = (
+                prune_properties_which_dont_exist_in_path(
+                    create_model, self.read_only_paths
+                )
+            )
+            return {**create_model_with_read_only_properties, **update_example}
         overrides = self._overrides.get("UPDATE", self._overrides.get("CREATE", {}))
         example = override_properties(self.update_strategy.example(), overrides)
         return {**create_model, **example}

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -70,7 +70,7 @@ def prune_properties_if_not_exist_in_path(output_model, input_model, paths):
 
 
 def prune_properties_which_dont_exist_in_path(model, paths):
-    """Prune given properties from a model. This method removes any property
+    """Prunes model to properties present in path. This method removes any property
     from the model which does not exists in the paths
 
     This assumes properties will always have an object (dict) as a parent.

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -74,8 +74,8 @@ def prune_properties_which_dont_exist_in_path(model, paths):
     from the model which does not exists in the paths
 
     This assumes properties will always have an object (dict) as a parent.
-    The function returns the model after pruning the path which exists
-    in the paths tuple but not in the input_model
+    The function returns the model after pruning all but the path which exists
+    in the paths tuple from the input_model
     """
     document = {"properties": model.copy()}
     for model_path in model.keys():

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -426,7 +426,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             if self.create_only_paths:
                 self.validate_update_example_keys(unique_identifiers, update_example)
             update_example.update(unique_identifiers)
-            return update_example
+            return {**create_model, **update_example}
         overrides = self._overrides.get("UPDATE", self._overrides.get("CREATE", {}))
         example = override_properties(self.update_strategy.example(), overrides)
         return {**create_model, **example}

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -1213,7 +1213,7 @@ def test_generate_update_example_with_primary_identifier(resource_client_inputs_
     updated_resource = resource_client_inputs_schema.generate_update_example(
         created_resource
     )
-    assert updated_resource == {"a": 1, "c": 2}
+    assert updated_resource == {"a": 1, "c": 2, "d": 3}
 
 
 def test_generate_update_example_with_composite_key(

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -15,6 +15,7 @@ from rpdk.core.contract.resource_client import (
     prune_properties,
     prune_properties_from_model,
     prune_properties_if_not_exist_in_path,
+    prune_properties_which_dont_exist_in_path,
 )
 from rpdk.core.exceptions import InvalidProjectError
 from rpdk.core.test import (
@@ -327,6 +328,21 @@ def test_prune_properties_if_not_exist_in_path():
         ],
     )
     assert model == previous_model
+
+
+def test_prune_properties_which_dont_exist_in_path():
+    model = {
+        "spam": "eggs",
+        "one": "two",
+        "array": ["first", "second"],
+    }
+    model1 = prune_properties_which_dont_exist_in_path(
+        model,
+        [
+            ("properties", "one"),
+        ],
+    )
+    assert model1 == {"one": "two"}
 
 
 def test_init_sam_cli_client():
@@ -1210,10 +1226,12 @@ def test_generate_invalid_update_example_with_inputs(resource_client_inputs):
 
 def test_generate_update_example_with_primary_identifier(resource_client_inputs_schema):
     created_resource = resource_client_inputs_schema.generate_create_example()
+    # adding read only property to denote a realistic scenario
+    created_resource["b"] = 2
     updated_resource = resource_client_inputs_schema.generate_update_example(
         created_resource
     )
-    assert updated_resource == {"a": 1, "c": 2, "d": 3}
+    assert updated_resource == {"a": 1, "c": 2, "b": 2}
 
 
 def test_generate_update_example_with_composite_key(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Merging create model with update model to make sure we are fetching the read only properties.

*Test:*
```
(env) anshikg@3c22fbb25c23 aws-cloudwatch-alarm % cfn test --enforce-timeout 120                             
[Warning] Resource spec validation would fail from next major version. Provider should mark additionalProperties as false if the property is of object type and has properties or patternProperties defined in it. Please fix the warnings: 'additionalProperties' is a required property

Failed validating 'required' in schema['properties']['properties']['patternProperties']['^[A-Za-z0-9]{1,64}$']['allOf'][0]['dependencies']['patternProperties']:
    {'$comment': 'An object cannot have both defined and undefined '
                 'properties; therefore, properties is not allowed when '
                 'patternProperties is specified. Provider should mark '
                 'additionalProperties as false if the property is of '
                 'object type and has patternProperties defined in it.',
     'not': {'required': ['properties']},
     'required': ['additionalProperties']}

On instance['properties']['ExtendedStatistic']:
    {'description': 'The percentile statistic for the metric associated '
                    'with the alarm. Specify a value between p0.0 and '
                    'p100.',
     'patternProperties': {'^p(\\d{1,2}(\\.\\d{0,2})?|100)$': {'type': 'string'}},
     'type': 'string'}
Resource schema is valid.
=================================================================================================================== test session starts ====================================================================================================================
platform darwin -- Python 3.9.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm, configfile: ../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_nl27pxob.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.11.1, hypothesis-6.8.1
collected 16 items                                                                                                                                                                                                                                         

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                     [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                                    [ 12%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                                                  [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                               [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                               [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                       [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                                       [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                                     [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                     [ 56%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                                                     [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                  [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                 [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                               [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                               [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                                                                                                               [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED         
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
