### PR TITLE
Adding conditionalCreateOnlyProperties to metaschema

### DIFF
--- a/src/rpdk/core/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.v1.json
@@ -387,8 +387,8 @@
             "description": "A list of JSON pointers to properties (typically sensitive) that are able to be specified by the customer but unable to be returned in a Read request",
             "$ref": "#/definitions/jsonPointerArray"
         },
-        "conditionallyCreateOnlyProperties": {
-            "description": "A list of JSON pointers to properties that are only able to cause replacement during the Update request.",
+        "conditionalCreateOnlyProperties": {
+            "description": "A list of JSON pointers for properties that can only be updated under certain conditions. For example, you can upgrade the engine version of an RDS DBInstance but you cannot downgrade it.  When updating this property for a resource in a CloudFormation stack, the resource will be replaced if it cannot be updated.",
             "$ref": "#/definitions/jsonPointerArray"
         },
         "createOnlyProperties": {

--- a/src/rpdk/core/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.v1.json
@@ -387,6 +387,10 @@
             "description": "A list of JSON pointers to properties (typically sensitive) that are able to be specified by the customer but unable to be returned in a Read request",
             "$ref": "#/definitions/jsonPointerArray"
         },
+        "conditionallyCreateOnlyProperties": {
+            "description": "A list of JSON pointers to properties that are only able to cause replacement during the Update request.",
+            "$ref": "#/definitions/jsonPointerArray"
+        },
         "createOnlyProperties": {
             "description": "A list of JSON pointers to properties that are only able to be specified by the customer when creating a resource. Conversely, any property *not* in this list can be applied to an Update request.",
             "$ref": "#/definitions/jsonPointerArray"

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -264,9 +264,7 @@ instance types, lambda runtimes, partitions, regions, availability zones, etc. t
         resource_spec.get("conditionallyCreateOnlyProperties", [])
     )
 
-    read_only_properties_intersection = set(
-        resource_spec.get("readOnlyProperties", [])
-    ) & (
+    read_only_properties_intersection = read_only_properties & (
         create_only_properties
         | set(resource_spec.get("writeOnlyProperties", []))
         | {"/properties/" + s for s in resource_spec.get("required", [])}
@@ -310,6 +308,11 @@ as either readOnly or createOnly",
     if conditionally_create_only_properties & create_only_properties:
         raise SpecValidationError(
             "createOnlyProperties and conditionallyCreateOnlyProperties MUST NOT have common properties"
+        )
+
+    if conditionally_create_only_properties & read_only_properties:
+        raise SpecValidationError(
+            "readOnlyProperties and conditionallyCreateOnlyProperties MUST NOT have common properties"
         )
 
     # TODO: more general validation framework

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -258,10 +258,16 @@ instance types, lambda runtimes, partitions, regions, availability zones, etc. t
             list_options,
         )
 
+    read_only_properties = set(resource_spec.get("readOnlyProperties", []))
+    create_only_properties = set(resource_spec.get("createOnlyProperties", []))
+    conditionally_create_only_properties = set(
+        resource_spec.get("conditionallyCreateOnlyProperties", [])
+    )
+
     read_only_properties_intersection = set(
         resource_spec.get("readOnlyProperties", [])
     ) & (
-        set(resource_spec.get("createOnlyProperties", []))
+        create_only_properties
         | set(resource_spec.get("writeOnlyProperties", []))
         | {"/properties/" + s for s in resource_spec.get("required", [])}
     )
@@ -291,14 +297,20 @@ in it. Please fix the warnings: %s",
         )
 
     for primary_id in resource_spec["primaryIdentifier"]:
-        if primary_id not in resource_spec.get(
-            "readOnlyProperties", []
-        ) and primary_id not in resource_spec.get("createOnlyProperties", []):
+        if (
+            primary_id not in read_only_properties
+            and primary_id not in create_only_properties
+        ):
             LOG.warning(
                 "Property 'primaryIdentifier' - %s must be specified \
 as either readOnly or createOnly",
                 primary_id,
             )
+
+    if conditionally_create_only_properties & create_only_properties:
+        raise SpecValidationError(
+            "createOnlyProperties and conditionallyCreateOnlyProperties MUST NOT have common properties"
+        )
 
     # TODO: more general validation framework
     if "remote" in resource_spec:

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -260,8 +260,8 @@ instance types, lambda runtimes, partitions, regions, availability zones, etc. t
 
     read_only_properties = set(resource_spec.get("readOnlyProperties", []))
     create_only_properties = set(resource_spec.get("createOnlyProperties", []))
-    conditionally_create_only_properties = set(
-        resource_spec.get("conditionallyCreateOnlyProperties", [])
+    conditional_create_only_properties = set(
+        resource_spec.get("conditionalCreateOnlyProperties", [])
     )
 
     read_only_properties_intersection = read_only_properties & (
@@ -305,14 +305,14 @@ as either readOnly or createOnly",
                 primary_id,
             )
 
-    if conditionally_create_only_properties & create_only_properties:
+    if conditional_create_only_properties & create_only_properties:
         raise SpecValidationError(
-            "createOnlyProperties and conditionallyCreateOnlyProperties MUST NOT have common properties"
+            "createOnlyProperties and conditionalCreateOnlyProperties MUST NOT have common properties"
         )
 
-    if conditionally_create_only_properties & read_only_properties:
+    if conditional_create_only_properties & read_only_properties:
         raise SpecValidationError(
-            "readOnlyProperties and conditionallyCreateOnlyProperties MUST NOT have common properties"
+            "readOnlyProperties and conditionalCreateOnlyProperties MUST NOT have common properties"
         )
 
     # TODO: more general validation framework

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -125,6 +125,25 @@ def test_load_resource_spec_unmodeled_object_property_missing_additional_propert
     )
 
 
+def test_load_resource_spec_conditionally_create_only_match_create_only():
+    schema = {
+        "typeName": "AWS::FOO::BAR",
+        "description": "test schema",
+        "additionalProperties": False,
+        "properties": {"foo": {"type": "string"}, "bar": {"type": "string"}},
+        "primaryIdentifier": ["/properties/foo"],
+        "readOnlyProperties": ["/properties/foo"],
+        "createOnlyProperties": ["/properties/bar"],
+        "conditionallyCreateOnlyProperties": ["/properties/bar"],
+    }
+    with pytest.raises(SpecValidationError) as excinfo:
+        load_resource_spec(json_s(schema))
+    assert (
+        str(excinfo.value)
+        == "createOnlyProperties and conditionallyCreateOnlyProperties MUST NOT have common properties"
+    )
+
+
 @pytest.mark.parametrize(
     "schema",
     [

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -134,13 +134,13 @@ def test_load_resource_spec_conditionally_create_only_match_create_only():
         "primaryIdentifier": ["/properties/foo"],
         "readOnlyProperties": ["/properties/foo"],
         "createOnlyProperties": ["/properties/bar"],
-        "conditionallyCreateOnlyProperties": ["/properties/bar"],
+        "conditionalCreateOnlyProperties": ["/properties/bar"],
     }
     with pytest.raises(SpecValidationError) as excinfo:
         load_resource_spec(json_s(schema))
     assert (
         str(excinfo.value)
-        == "createOnlyProperties and conditionallyCreateOnlyProperties MUST NOT have common properties"
+        == "createOnlyProperties and conditionalCreateOnlyProperties MUST NOT have common properties"
     )
 
 
@@ -152,13 +152,13 @@ def test_load_resource_spec_conditionally_create_only_match_read_only():
         "properties": {"foo": {"type": "string"}},
         "primaryIdentifier": ["/properties/foo"],
         "readOnlyProperties": ["/properties/foo"],
-        "conditionallyCreateOnlyProperties": ["/properties/foo"],
+        "conditionalCreateOnlyProperties": ["/properties/foo"],
     }
     with pytest.raises(SpecValidationError) as excinfo:
         load_resource_spec(json_s(schema))
     assert (
         str(excinfo.value)
-        == "readOnlyProperties and conditionallyCreateOnlyProperties MUST NOT have common properties"
+        == "readOnlyProperties and conditionalCreateOnlyProperties MUST NOT have common properties"
     )
 
 

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -144,6 +144,24 @@ def test_load_resource_spec_conditionally_create_only_match_create_only():
     )
 
 
+def test_load_resource_spec_conditionally_create_only_match_read_only():
+    schema = {
+        "typeName": "AWS::FOO::BAR",
+        "description": "test schema",
+        "additionalProperties": False,
+        "properties": {"foo": {"type": "string"}},
+        "primaryIdentifier": ["/properties/foo"],
+        "readOnlyProperties": ["/properties/foo"],
+        "conditionallyCreateOnlyProperties": ["/properties/foo"],
+    }
+    with pytest.raises(SpecValidationError) as excinfo:
+        load_resource_spec(json_s(schema))
+    assert (
+        str(excinfo.value)
+        == "readOnlyProperties and conditionallyCreateOnlyProperties MUST NOT have common properties"
+    )
+
+
 @pytest.mark.parametrize(
     "schema",
     [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding `conditionalCreateOnlyProperties` to meta schema, so that resource providers could model properties that could not deterministically predict replacement/inline update.

Adding validation, as `conditionalCreateOnlyProperties` and `createOnlyProperties` must not overlap. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
