### PR TITLE
support regex comparison for transformed values

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -268,17 +268,17 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
     def compare(document_input, document_output):
         try:
             if isinstance(document_input, str):
-                return re.match(f"^{document_input}$", document_output)
+                return bool(re.match(f"^{document_input}$", document_output))
             return document_input == document_output
         except re.error:
             return document_input == document_output
 
     def transform(self, property_transform_value, input_model):
-        LOG.warning("This is the transform %s", property_transform_value)
+        LOG.debug("This is the transform %s", property_transform_value)
         content = self.transformation_template.render(
             input_model=input_model, jsonata_expression=property_transform_value
         )
-        LOG.warning("This is the content %s", content)
+        LOG.debug("This is the content %s", content)
         file = tempfile.NamedTemporaryFile(
             mode="w+b",
             buffering=-1,

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -180,8 +180,8 @@ def test_input_equals_output(resource_client, input_model, output_model):
                     pruned_input_model[key], pruned_output_model[key]
                 )
             else:
-                assert (
-                    pruned_input_model[key] == pruned_output_model[key]
+                assert resource_client.compare(
+                    pruned_input_model[key], pruned_output_model[key]
                 ), assertion_error_message
     except KeyError as e:
         raise AssertionError(assertion_error_message) from e


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* property Transform allows users to compare regex with live state from read handler. Regex comparison fails in input_equals_output method as  we were equating regex to live state rather than checking for regex match. This CR adds a check to compare regex rather than equating strings.

Lets say a customer adds the name of a property when creating the resource. This property name is updated to an ARN. propertyTransform property in the schema will allow one to define the arn regex to ensure this property is not falsely drifted.
```
document_input: {
  "propertyName": "Name"
}
```
```
document_output: {
  "propertyName": "arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:ecs:[a-z]{2}[-]{1}[a-z]{4,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}cluster/Name"
}
```
where the propertyTransform in the schema is:
```
"propertyTransform": {
    "/properties/propertyName": "$join([\"arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:ecs:[a-z]{2}[-]{1}[a-z]{4,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}cluster\\/\", PropertyName])"
  }
```


*Test:* 
Added a property transform which compares a string against a regex and this check seems to pass now. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
