### PR TITLE
Limit docker dependency to <5. Fixes #727

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "requests>=2.22",
         "hypothesis>=4.32",
         "colorama>=0.4.1",
-        "docker>=4.3.1",
+        "docker>=4.3.1,<5",
         "ordered-set>=4.0.2",
         "cfn-lint>=0.43.0",
         "cfn_flip>=1.2.3",


### PR DESCRIPTION
cloudformation-cli-typescript-plugin and cloudformation-cli-python-plugin use `docker>=3.7,<5`, cloudformation-cli-java-plugin and cloudformation-cli-go-plugin don't use docker

Docker 5.0 was released to pypi on 2021-04-06

*Issue #, if available:* #727

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
