### PR TITLE
catch common resource schema issues in cfn validate

### DIFF
--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -145,24 +145,6 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
         LOG.debug("Resource spec validation failed", exc_info=True)
         raise SpecValidationError(str(e)) from e
 
-    type_specific_keywords = {
-        "minimum",
-        "maximum",
-        "minLength",
-        "maxLength",
-        "minProperties",
-        "maxProperties",
-        "minItems",
-        "maxItems",
-        "exclusiveMinimum",
-        "exclusiveMaximum",
-        "additionalItems",
-        "additionalProperties",
-        "uniqueItems",
-        "pattern",
-        "patternProperties",
-        "multipleOf",
-    }
     try:  # pylint: disable=R
         for _key, schema in JsonSchemaFlattener(resource_spec).flatten_schema().items():
             for property_name, property_details in schema.get("properties", {}).items():
@@ -174,7 +156,7 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
                 try:
                     property_type = property_details["type"]
                     property_keywords = property_details.keys()
-                    for types, allowed_keywords in [
+                    keyword_mappings = [
                         (
                             {"integer", "number"},
                             {
@@ -211,7 +193,11 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
                                 "uniqueItems",
                             },
                         ),
-                    ]:
+                    ]
+                    type_specific_keywords = set().union(
+                        *(mapping[1] for mapping in keyword_mappings)
+                    )
+                    for types, allowed_keywords in keyword_mappings:
                         if (
                             property_type in types
                             and type_specific_keywords - allowed_keywords

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -214,11 +214,13 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
                     ]:
                         if (
                             property_type in types
-                            and type_specific_keywords - allowed_keywords & property_keywords
+                            and type_specific_keywords - allowed_keywords
+                            & property_keywords
                         ):
                             LOG.warning(
                                 "Incorrect JSON schema keyword(s) %s for type: %s for property: %s",
-                                type_specific_keywords - allowed_keywords & property_keywords,
+                                type_specific_keywords - allowed_keywords
+                                & property_keywords,
                                 property_type,
                                 property_name,
                             )

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -145,7 +145,7 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
         LOG.debug("Resource spec validation failed", exc_info=True)
         raise SpecValidationError(str(e)) from e
 
-    min_max_keywords = {
+    type_specific_keywords = {
         "minimum",
         "maximum",
         "minLength",
@@ -156,6 +156,8 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
         "maxItems",
         "exclusiveMinimum",
         "exclusiveMaximum",
+        "additionalItems",
+        "additionalProperties",
     }
     try:  # pylint: disable=R
         for _key, schema in JsonSchemaFlattener(resource_spec).flatten_schema().items():
@@ -190,6 +192,7 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
                             {
                                 "minProperties",
                                 "maxProperties",
+                                "additionalProperties",
                             },
                         ),
                         (
@@ -197,15 +200,17 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
                             {
                                 "minItems",
                                 "maxItems",
+                                "additionalItems",
                             },
                         ),
                     ]:
                         if (
                             property_type in types
-                            and min_max_keywords - allowed_keywords & property_keywords
+                            and type_specific_keywords - allowed_keywords & property_keywords
                         ):
                             LOG.warning(
-                                "Incorrect min/max JSON schema keywords for type: %s for property: %s",
+                                "Incorrect JSON schema keyword(s) %s for type: %s for property: %s",
+                                type_specific_keywords - allowed_keywords & property_keywords,
                                 property_type,
                                 property_name,
                             )

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -158,6 +158,10 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
         "exclusiveMaximum",
         "additionalItems",
         "additionalProperties",
+        "uniqueItems",
+        "pattern",
+        "patternProperties",
+        "multipleOf",
     }
     try:  # pylint: disable=R
         for _key, schema in JsonSchemaFlattener(resource_spec).flatten_schema().items():
@@ -178,6 +182,7 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
                                 "maximum",
                                 "exclusiveMinimum",
                                 "exclusiveMaximum",
+                                "multipleOf",
                             },
                         ),
                         (
@@ -185,6 +190,7 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
                             {
                                 "minLength",
                                 "maxLength",
+                                "pattern",
                             },
                         ),
                         (
@@ -193,6 +199,7 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
                                 "minProperties",
                                 "maxProperties",
                                 "additionalProperties",
+                                "patternProperties",
                             },
                         ),
                         (
@@ -201,6 +208,7 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
                                 "minItems",
                                 "maxItems",
                                 "additionalItems",
+                                "uniqueItems",
                             },
                         ),
                     ]:


### PR DESCRIPTION
continuing https://github.com/aws-cloudformation/cloudformation-cli/pull/663, https://github.com/aws-cloudformation/cloudformation-cli/pull/668, https://github.com/aws-cloudformation/cloudformation-cli/pull/675

**more incorrect type-specific JSON schema keywords** similar to https://github.com/aws-cloudformation/cloudformation-cli/issues/414

---

**[how to run new validations on all existing resource provider schemas](https://github.com/aws-cloudformation/cloudformation-cli/pull/604#issuecomment-756521889)**:

```
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: array for property: EC2InboundPermissions
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: array for property: InstanceDefinitions
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: array for property: LogPaths
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: array for property: MetricGroups
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: array for property: MonitoringInputs
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: array for property: ServerProcesses
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: array for property: Tags
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: array for property: TaskProperties
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: array for property: VpcSubnets
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: integer for property: ConcurrentExecutions
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: integer for property: DesiredEC2Instances
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: integer for property: FromPort
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: integer for property: GameSessionActivationTimeoutSeconds
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: integer for property: MaxConcurrentGameSessionActivations
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: integer for property: MaxSize
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: integer for property: MinSize
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: integer for property: NewGameSessionsPerCreator
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: integer for property: PolicyPeriodInMinutes
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: integer for property: ToPort
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: number for property: EstimatedInstanceWarmup
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: number for property: MaxSize
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: number for property: MinSize
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: number for property: TargetValue
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: AutoScalingGroupArn
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: BalancingStrategy
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: BuildId
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: CertificateType
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: DeleteOption
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: Description
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: EC2InstanceType
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: FleetId
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: FleetType
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: GameServerGroupArn
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: GameServerGroupName
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: GameServerProtectionPolicy
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: InstanceRoleARN
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: InstanceType
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: IpRange
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: LaunchPath
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: LaunchTemplateId
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: LaunchTemplateName
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: Name
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: NewGameSessionProtectionPolicy
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: Parameters
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: PeerVpcAwsAccountId
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: PeerVpcId
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: Protocol
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: RoleArn
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: ScriptId
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: ServerLaunchParameters
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: ServerLaunchPath
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: Version
Incorrect JSON schema keyword(s) {'additionalProperties'} for type: string for property: WeightedCapacity
```

---

[`format` seems intentionally used for other types?](https://github.com/aws-cloudformation/cloudformation-cli/pull/621), so I guess I'll leave that out of the new validation, even though it looks [`string`-specific in JSON schema proper](https://json-schema.org/understanding-json-schema/reference/string.html#format)