### PR TITLE
Fix update generation with additionalIdentifiers

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -290,7 +290,14 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             k: v
             for k, v in create_model.items()
             if self.is_property_in_path(k, self.primary_identifier_paths)
-            or self.is_property_in_path(k, self._additional_identifiers_paths)
+            or any(
+                map(
+                    lambda additional_identifier_paths, key=k: self.is_property_in_path(
+                        key, additional_identifier_paths
+                    ),
+                    self._additional_identifiers_paths,
+                )
+            )
         }
 
     @staticmethod

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -514,6 +514,8 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # if it's a dry run, keep the file; otherwise can delete after upload
         if dry_run:
             return self._get_zip_file_path().open("wb")
+
+        # pylint: disable=consider-using-with
         return TemporaryFile("w+b")
 
     def _get_zip_file_path(self):

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -80,6 +80,19 @@ SCHEMA_WITH_COMPOSITE_KEY = {
     "primaryIdentifier": ["/properties/c", "/properties/d"],
 }
 
+SCHEMA_WITH_ADDITIONAL_IDENTIFIERS = {
+    "properties": {
+        "a": {"type": "number"},
+        "b": {"type": "number"},
+        "c": {"type": "number"},
+        "d": {"type": "number"},
+    },
+    "readOnlyProperties": ["/properties/b"],
+    "createOnlyProperties": ["/properties/c"],
+    "primaryIdentifier": ["/properties/c"],
+    "additionalIdentifiers": [["/properties/b"]],
+}
+
 
 @pytest.fixture
 def resource_client():
@@ -157,8 +170,8 @@ def resource_client_inputs():
     return client
 
 
-@pytest.fixture
-def resource_client_inputs_schema():
+@pytest.fixture(params=[SCHEMA_, SCHEMA_WITH_ADDITIONAL_IDENTIFIERS])
+def resource_client_inputs_schema(request):
     endpoint = "https://"
     patch_sesh = patch(
         "rpdk.core.contract.resource_client.create_sdk_session", autospec=True
@@ -181,7 +194,7 @@ def resource_client_inputs_schema():
                 DEFAULT_FUNCTION,
                 endpoint,
                 DEFAULT_REGION,
-                SCHEMA_,
+                request.param,
                 EMPTY_OVERRIDE,
                 {
                     "CREATE": {"a": 111, "c": 2, "d": 3},
@@ -195,7 +208,7 @@ def resource_client_inputs_schema():
     mock_account.assert_called_once_with(mock_sesh, {})
 
     assert client._function_name == DEFAULT_FUNCTION
-    assert client._schema == SCHEMA_
+    assert client._schema == request.param
     assert client._overrides == EMPTY_OVERRIDE
     assert client.account == ACCOUNT
 


### PR DESCRIPTION
If the `additionalIdentifiers` property is present in a resource schema
the `generate_update_example` method in `resource_client` will not work,
because it checks for unique keys from the create_model and passes
`self._additional_identifiers_paths` to a method that expects a list of
tuples of string, whereas it receives a list of sets of tuples of
string and will fail with

```
AttributeError: 'tuple' object has no attribute 'split'
```

Instead, check if the key is in any of the additional identifiers.

Related issue
-------------

https://github.com/aws-cloudformation/cloudformation-cli/issues/731

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
