### PR TITLE
Remove contract_invalid_create contract test

### DIFF
--- a/src/rpdk/core/contract/suite/handler_create.py
+++ b/src/rpdk/core/contract/suite/handler_create.py
@@ -6,11 +6,8 @@ import pytest
 
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
-from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
-from rpdk.core.contract.suite.contract_asserts import (
-    failed_event,
-    skip_not_writable_identifier,
-)
+from rpdk.core.contract.interface import Action, OperationStatus
+from rpdk.core.contract.suite.contract_asserts import skip_not_writable_identifier
 from rpdk.core.contract.suite.handler_commons import (
     test_create_failure_if_repeat_writeable_id,
     test_create_success,
@@ -50,27 +47,6 @@ def contract_create_delete(resource_client):
         test_input_equals_output(resource_client, input_model, delete_model)
     finally:
         test_delete_success(resource_client, delete_model)
-
-
-@pytest.mark.create
-def contract_invalid_create(resource_client):
-    if resource_client.read_only_paths:
-        _create_with_invalid_model(resource_client)
-    else:
-        pytest.skip("No readOnly Properties. Skipping test.")
-
-
-@failed_event(error_code=HandlerErrorCode.InvalidRequest)
-def _create_with_invalid_model(resource_client):
-    try:
-        requested_model = resource_client.generate_invalid_create_example()
-        _status, response, _error_code = resource_client.call_and_assert(
-            Action.CREATE, OperationStatus.FAILED, requested_model
-        )
-        assert response["message"]
-        return _error_code
-    finally:
-        resource_client.call(Action.DELETE, requested_model)
 
 
 @pytest.mark.create


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
Remove the contract test ```contract_invalid_create``` which tries to create an invalid resource and expects the handler to fail. 
If an invalid request is made, the platform should throw an exception vs expected the handlers to throw the exception. In my opinion it is a redundant and error prone contract test which might cause more pain and failing contract test than usage. Therefore, removing this test from the contract test suite.

**Test**:
Ran the contract test for log::loggroup resource
```
(env) anshikg@3c22fbb25c23 aws-logs-loggroup % cfn test
Consider not manually maintaining large constantly evolving enums like instance types, lambda runtimes, partitions, regions, availability zones, etc. that get outdated quickly: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
Resource schema is valid.
==================================================================================================================== test session starts =====================================================================================================================
platform darwin -- Python 3.9.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/aws-cloudformation-resource-providers-logs/aws-logs-loggroup/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/aws-cloudformation-resource-providers-logs/aws-logs-loggroup, configfile: ../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_yxf7h_s4.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.11.1, hypothesis-6.8.1
collected 14 items                                                                                                                                                                                                                                           

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                       [  7%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                                                    [ 14%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                                 [ 21%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                                 [ 28%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                         [ 35%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                                         [ 42%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                                       [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                       [ 57%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                                                       [ 64%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                    [ 71%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                   [ 78%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                                 [ 85%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                                 [ 92%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                                [100%]

=============================================================================================================== 14 passed in 482.98s (0:08:02) ===============================================================================================================
(env) anshikg@3c22fbb25c23 aws-logs-loggroup % 

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
