### PR TITLE
Add support for nested comparison

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -334,6 +334,29 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
         example = override_properties(self.invalid_strategy.example(), overrides)
         return {**create_model, **example}
 
+    def compare(self, inputs, outputs):
+        assertion_error_message = (
+            "All properties specified in the request MUST "
+            "be present in the model returned, and they MUST"
+            " match exactly, with the exception of properties"
+            " defined as writeOnlyProperties in the resource schema"
+        )
+        try:
+            for key in inputs:
+                if isinstance(inputs[key], dict):
+                    self.compare(inputs[key], outputs[key])
+                elif isinstance(inputs[key], list):
+                    assert len(inputs[key]) == len(outputs[key])
+                    self.compare_list(inputs[key], outputs[key])
+                else:
+                    assert inputs[key] == outputs[key], assertion_error_message
+        except KeyError as e:
+            raise AssertionError(assertion_error_message) from e
+
+    def compare_list(self, inputs, outputs):
+        for index in range(len(inputs)):  # pylint: disable=C0200
+            self.compare(inputs[index], outputs[index])
+
     @staticmethod
     def key_error_safe_traverse(resource_model, write_only_property):
         try:

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -163,32 +163,7 @@ def test_input_equals_output(resource_client, input_model, output_model):
     pruned_output_model = prune_properties_if_not_exist_in_path(
         pruned_output_model, pruned_input_model, resource_client.create_only_paths
     )
-
-    assertion_error_message = (
-        "All properties specified in the request MUST "
-        "be present in the model returned, and they MUST"
-        " match exactly, with the exception of properties"
-        " defined as writeOnlyProperties in the resource schema"
+    resource_client.compare(
+        pruned_input_model,
+        pruned_output_model,
     )
-    # only comparing properties in input model to those in output model and
-    # ignoring extraneous properties that maybe present in output model.
-    try:
-        for key in pruned_input_model:
-            if key in resource_client.properties_without_insertion_order:
-                assert test_unordered_list_match(
-                    pruned_input_model[key], pruned_output_model[key]
-                )
-            else:
-                assert (
-                    pruned_input_model[key] == pruned_output_model[key]
-                ), assertion_error_message
-    except KeyError as e:
-        raise AssertionError(assertion_error_message) from e
-
-
-def test_unordered_list_match(inputs, outputs):
-    assert len(inputs) == len(outputs)
-    try:
-        assert all(input in outputs for input in inputs)
-    except KeyError as exception:
-        raise AssertionError("lists do not match") from exception

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -68,6 +68,32 @@ SCHEMA_ = {
     "writeOnlyProperties": ["/properties/d"],
 }
 
+SCHEMA_WITH_NESTED_PROPERTIES = {
+    "properties": {
+        "a": {"type": "string"},
+        "g": {"type": "number"},
+        "b": {"$ref": "#/definitions/c"},
+        "f": {
+            "type": "array",
+            "items": {"$ref": "#/definitions/c"},
+        },
+        "h": {
+            "type": "array",
+            "insertionOrder": "false",
+            "items": {"$ref": "#/definitions/c"},
+        },
+    },
+    "definitions": {
+        "c": {
+            "type": "object",
+            "properties": {"d": {"type": "integer"}, "e": {"type": "integer"}},
+        }
+    },
+    "readOnlyProperties": ["/properties/a"],
+    "primaryIdentifier": ["/properties/a"],
+    "writeOnlyProperties": ["/properties/g"],
+}
+
 SCHEMA_WITH_COMPOSITE_KEY = {
     "properties": {
         "a": {"type": "number"},
@@ -1210,3 +1236,52 @@ def test_generate_update_example_with_composite_key(
         created_resource
     )
     assert updated_resource == {"a": 1, "c": 2, "d": 3}
+
+
+def test_compare_should_pass(resource_client):
+    resource_client._update_schema(SCHEMA_WITH_NESTED_PROPERTIES)
+    inputs = {"b": {"d": 1}, "f": [{"d": 1}], "h": [{"d": 1}, {"d": 2}]}
+
+    outputs = {
+        "b": {"d": 1, "e": 3},
+        "f": [{"d": 1, "e": 2}],
+        "h": [{"d": 1, "e": 3}, {"d": 2}],
+    }
+    resource_client.compare(inputs, outputs)
+
+
+def test_compare_should_throw_exception(resource_client):
+    resource_client._update_schema(SCHEMA_WITH_NESTED_PROPERTIES)
+    inputs = {"b": {"d": 1}, "f": [{"d": 1}], "h": [{"d": 1}], "z": 1}
+
+    outputs = {
+        "b": {"d": 1, "e": 2},
+        "f": [{"d": 1}],
+        "h": [{"d": 1}],
+    }
+    try:
+        resource_client.compare(inputs, outputs)
+    except AssertionError:
+        logging.debug("Expected")
+
+
+def test_compare_should_throw_key_error(resource_client):
+    resource_client._update_schema(SCHEMA_WITH_NESTED_PROPERTIES)
+    inputs = {"b": {"d": 1}, "f": [{"d": 1}], "h": [{"d": 1}]}
+
+    outputs = {"b": {"d": 1, "e": 2}, "f": [{"d": 1, "e": 2}, {"d": 2, "e": 3}]}
+    try:
+        resource_client.compare(inputs, outputs)
+    except AssertionError:
+        logging.debug("Expected")
+
+
+def test_compare_ordered_list_throws_assertion_exception(resource_client):
+    resource_client._update_schema(SCHEMA_WITH_NESTED_PROPERTIES)
+    inputs = {"b": {"d": 1}, "f": [{"d": 1}], "h": [{"d": 1}]}
+
+    outputs = {"b": {"d": 1, "e": 2}, "f": [{"e": 2}, {"d": 2, "e": 3}]}
+    try:
+        resource_client.compare(inputs, outputs)
+    except AssertionError:
+        logging.debug("Expected")

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -1262,7 +1262,7 @@ def test_compare_should_throw_exception(resource_client):
     try:
         resource_client.compare(inputs, outputs)
     except AssertionError:
-        logging.debug("Expected")
+        logging.debug("This test expects Assertion Exception to be thrown")
 
 
 def test_compare_should_throw_key_error(resource_client):
@@ -1273,7 +1273,7 @@ def test_compare_should_throw_key_error(resource_client):
     try:
         resource_client.compare(inputs, outputs)
     except AssertionError:
-        logging.debug("Expected")
+        logging.debug("This test expects Assertion Exception to be thrown")
 
 
 def test_compare_ordered_list_throws_assertion_exception(resource_client):
@@ -1284,4 +1284,4 @@ def test_compare_ordered_list_throws_assertion_exception(resource_client):
     try:
         resource_client.compare(inputs, outputs)
     except AssertionError:
-        logging.debug("Expected")
+        logging.debug("This test expects Assertion Exception to be thrown")


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* This CR avoids comparing nested properties which were not present in the input model provided to the handler. This is done to mimic the drift functionality and avoid failing contract test for expected behavior.
In the below CR I am recursively checking the model of the input and output and comparing the properties present in input with output model and asserting only if a property present in input model is not present/changed in the output model.
For now, the functionality for un order types has been removed as this not supported in the back end service.

*Test:* Ran contract test for resources which failed this condition
```
========================================================================================================================================================================================================================================= test session starts =========================================================================================================================================================================================================================================
platform darwin -- Python 3.8.9, pytest-6.2.3, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/aws-cloudformation-resource-providers-kinesisfirehose/deliverystream/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/aws-cloudformation-resource-providers-kinesisfirehose/deliverystream, configfile: ../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_952xexz8.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3, black-0.3.10
collected 14 items                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                                                                                                                                                                                                                                                                
handler_create.py::contract_create_duplicate 	PASSED                                                                                                                                                                                                                                                                                                                                                                                                                                             
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                                                                                                                                                                                                                                                                          
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                                                                                                                                                                                                                                                                          
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                                                                                                                                                                                                                                                                  
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                                                                                                                                                                                                                                                                                  
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                                                                                                                                                                                                                                                                
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                                                                                                                                                                                                                                                                                                
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                                                                                                                                                                                                                                                             
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                                                                                                                                                                                                                                                            

===========================================================================================
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
