### PR TITLE
Use deep copy for model compare

### DIFF
--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -1,5 +1,5 @@
-import logging
 import copy
+import logging
 
 from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
 from rpdk.core.contract.resource_client import (

--- a/src/rpdk/core/contract/suite/handler_commons.py
+++ b/src/rpdk/core/contract/suite/handler_commons.py
@@ -1,4 +1,5 @@
 import logging
+import copy
 
 from rpdk.core.contract.interface import Action, HandlerErrorCode, OperationStatus
 from rpdk.core.contract.resource_client import (
@@ -149,7 +150,7 @@ def test_delete_failure_not_found(resource_client, current_resource_model):
 
 def test_input_equals_output(resource_client, input_model, output_model):
     pruned_input_model = prune_properties_from_model(
-        input_model.copy(),
+        copy.deepcopy(input_model),
         set(
             list(resource_client.read_only_paths)
             + list(resource_client.write_only_paths)
@@ -157,7 +158,7 @@ def test_input_equals_output(resource_client, input_model, output_model):
     )
 
     pruned_output_model = prune_properties_from_model(
-        output_model.copy(), resource_client.read_only_paths
+        copy.deepcopy(output_model), resource_client.read_only_paths
     )
 
     pruned_output_model = prune_properties_if_not_exist_in_path(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*.   Currently it uses shallow copy for model comparison. However,  for any read only property is nested, it will modify the actual model during the comparison.  For example, if a primary ID is nested property,  the contract test will break as the primary id will be pruned in this method.

### Testing
Verified using a nested primary ID, now the primary Id can pass to delete handler correctly.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
