### PR TITLE
Add comparison for primitive type

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -355,16 +355,19 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             " defined as writeOnlyProperties in the resource schema"
         )
         try:
-            for key in inputs:
-                if isinstance(inputs[key], dict):
-                    self.compare(inputs[key], outputs[key])
-                elif isinstance(inputs[key], list):
-                    assert len(inputs[key]) == len(outputs[key])
-                    self.compare_list(inputs[key], outputs[key])
-                else:
-                    assert inputs[key] == outputs[key], assertion_error_message
-        except KeyError as e:
-            raise AssertionError(assertion_error_message) from e
+            if isinstance(inputs, dict):
+                for key in inputs:
+                    if isinstance(inputs[key], dict):
+                        self.compare(inputs[key], outputs[key])
+                    elif isinstance(inputs[key], list):
+                        assert len(inputs[key]) == len(outputs[key])
+                        self.compare_list(inputs[key], outputs[key])
+                    else:
+                        assert inputs[key] == outputs[key], assertion_error_message
+            else:
+                assert inputs == outputs, assertion_error_message
+        except Exception as exception:
+            raise AssertionError(assertion_error_message) from exception
 
     def compare_list(self, inputs, outputs):
         for index in range(len(inputs)):  # pylint: disable=C0200

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -82,6 +82,11 @@ SCHEMA_WITH_NESTED_PROPERTIES = {
             "insertionOrder": "false",
             "items": {"$ref": "#/definitions/c"},
         },
+        "i": {
+            "type": "array",
+            "insertionOrder": "false",
+            "items": "string",
+        },
     },
     "definitions": {
         "c": {
@@ -1275,12 +1280,18 @@ def test_generate_update_example_with_composite_key(
 
 def test_compare_should_pass(resource_client):
     resource_client._update_schema(SCHEMA_WITH_NESTED_PROPERTIES)
-    inputs = {"b": {"d": 1}, "f": [{"d": 1}], "h": [{"d": 1}, {"d": 2}]}
+    inputs = {
+        "b": {"d": 1},
+        "f": [{"d": 1}],
+        "h": [{"d": 1}, {"d": 2}],
+        "i": ["abc", "ghi"],
+    }
 
     outputs = {
         "b": {"d": 1, "e": 3},
         "f": [{"d": 1, "e": 2}],
         "h": [{"d": 1, "e": 3}, {"d": 2}],
+        "i": ["abc", "ghi"],
     }
     resource_client.compare(inputs, outputs)
 
@@ -1313,9 +1324,13 @@ def test_compare_should_throw_key_error(resource_client):
 
 def test_compare_ordered_list_throws_assertion_exception(resource_client):
     resource_client._update_schema(SCHEMA_WITH_NESTED_PROPERTIES)
-    inputs = {"b": {"d": 1}, "f": [{"d": 1}], "h": [{"d": 1}]}
+    inputs = {"b": {"d": 1}, "f": [{"d": 1}], "h": [{"d": 1}], "i": ["abc", "ghi"]}
 
-    outputs = {"b": {"d": 1, "e": 2}, "f": [{"e": 2}, {"d": 2, "e": 3}]}
+    outputs = {
+        "b": {"d": 1, "e": 2},
+        "f": [{"e": 2}, {"d": 2, "e": 3}],
+        "i": ["abc", "ghi", "tt"],
+    }
     try:
         resource_client.compare(inputs, outputs)
     except AssertionError:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change ensure we compare a list of primitive types correctly. If a list exists, compare_list method is called which in turn calls the compare method of each index. This value doe snot have a key, just has a value which needs to compared using the else block mentioned below 

*Test:*
```
============================================================================================================= 1 passed, 13 deselected in 31.56s ==============================================================================================================
(env) anshikg@3c22fbb25c23 aws-cloudwatch-alarm % cfn test --enforce-timeout 120                             
Incorrect JSON schema keyword(s) {'patternProperties'} for type: string for property: ExtendedStatistic
Incorrect JSON schema keyword(s) {'patternProperties'} for type: string for property: Namespace
Incorrect JSON schema keyword(s) {'patternProperties'} for type: string for property: Namespace
[Warning] Resource spec validation would fail from next major version. Provider should mark additionalProperties as false if the property is of object type and has properties or patternProperties defined in it. Please fix the warnings: 'additionalProperties' is a required property

Failed validating 'required' in schema['properties']['properties']['patternProperties']['^[A-Za-z0-9]{1,64}$']['allOf'][0]['dependencies']['patternProperties']:
    {'$comment': 'An object cannot have both defined and undefined '
                 'properties; therefore, properties is not allowed when '
                 'patternProperties is specified. Provider should mark '
                 'additionalProperties as false if the property is of '
                 'object type and has patternProperties defined in it.',
     'not': {'required': ['properties']},
     'required': ['additionalProperties']}

On instance['properties']['ExtendedStatistic']:
    {'description': 'The percentile statistic for the metric associated '
                    'with the alarm. Specify a value between p0.0 and '
                    'p100.',
     'patternProperties': {'^p(\\d{1,2}(\\.\\d{0,2})?|100)$': {'type': 'string'}},
     'type': 'string'}
Resource schema is valid.
==================================================================================================================== test session starts =====================================================================================================================
platform darwin -- Python 3.8.9, pytest-6.2.3, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm, configfile: ../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_6daa6q1w.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3, black-0.3.10
collected 14 items                                                                                                                                                                                                                                           

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                       [  7%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                                                    [ 14%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                                 [ 21%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                                 [ 28%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                         [ 35%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                                         [ 42%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                                       [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                       [ 57%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                                                       [ 64%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                    [ 71%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                   [ 78%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                                 [ 85%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                                 [ 92%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                                [100%]

============================================================================================================== 14 passed in 1093.37s (0:18:13) ===============================================================================================================
==================================================================================================================== test session starts =====================================================================================================================
platform darwin -- Python 3.8.9, pytest-6.2.3, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm, configfile: ../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_8qjqmv3s.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3, black-0.3.10
collected 14 items                                                                                                                                                                                                                                           

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                       [  7%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                                                    [ 14%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                                 [ 21%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                                 [ 28%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                         [ 35%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                                         [ 42%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                                       [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                       [ 57%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                                                       [ 64%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                    [ 71%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                   [ 78%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                                 [ 85%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                                 [ 92%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                                [100%]

============================================================================================================== 14 passed in 1215.34s (0:20:15) ===============================================================================================================
==================================================================================================================== test session starts =====================================================================================================================
platform darwin -- Python 3.8.9, pytest-6.2.3, py-1.9.0, pluggy-0.13.1 -- /Users/anshikg/workspace/cloudformation-cli/env/bin/python3
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm/.hypothesis/examples')
rootdir: /Users/anshikg/workspace/aws-cloudformation-resource-providers-cloudwatch/aws-cloudwatch-alarm, configfile: ../../../../../private/var/folders/zh/rhw_046j7bq4d88hjn671hqjy323j8/T/pytest_brai535r.ini
plugins: random-order-1.0.4, localserver-0.5.0, cov-2.10.0, hypothesis-5.19.3, black-0.3.10
collected 14 items                                                                                                                                                                                                                                           

handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                       [  7%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                                                    [ 14%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                                 [ 21%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                                 [ 28%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                         [ 35%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                                         [ 42%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                                       [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                       [ 57%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                                                       [ 64%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                    [ 71%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                   [ 78%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                                 [ 85%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                                 [ 92%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                                [100%]

============================================================================================================== 14 passed in 1288.48s (0:21:28) ===============================================================================================================
(env) anshikg@3c22fbb25c23 aws-cloudwatch-alarm % 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
