### PR TITLE
Update HandlerErrorCode with new InvalidTypeConfiguration value

### DIFF
--- a/src/rpdk/core/contract/interface.py
+++ b/src/rpdk/core/contract/interface.py
@@ -38,3 +38,4 @@ class HandlerErrorCode(AutoName):
     ServiceInternalError = auto()
     NetworkFailure = auto()
     InternalFailure = auto()
+    InvalidTypeConfiguration = auto()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A new error of type `INVALID_TYPE_CONFIGURATION ` is added to aws sdk which seems to fail test_handler_error_code_enum_matches_sdk test. Adding the new error type to the enum so that the test passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
