### PR TITLE
Remove CloudFormation access to S3 via ArtifactCopyPolicy and KMS access

### DIFF
--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -41,34 +41,6 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
 
-  ArtifactCopyPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref ArtifactBucket
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Sid: Allow CloudFormation to copy artifacts from the bucket
-            Effect: Allow
-            Principal:
-              Service: cloudformation.amazonaws.com
-            Action:
-              - s3:ListBucket
-              - s3:GetObject
-            Resource:
-              - !Sub "arn:${AWS::Partition}:s3:::${ArtifactBucket}"
-              - !Sub "arn:${AWS::Partition}:s3:::${ArtifactBucket}/*"
-          - Sid: Require Secure Transport
-            Action: "s3:*"
-            Effect: Deny
-            Resource:
-              - !Sub "arn:${AWS::Partition}:s3:::${ArtifactBucket}"
-              - !Sub "arn:${AWS::Partition}:s3:::${ArtifactBucket}/*"
-            Condition:
-              Bool:
-                "aws:SecureTransport": "false"
-            Principal: "*"
-
   EncryptionKey:
     Type: AWS::KMS::Key
     DeletionPolicy: Retain
@@ -83,17 +55,6 @@ Resources:
           Principal:
             AWS: !Ref AWS::AccountId
           Action: kms:*
-          Resource: "*"
-        - Sid: Enable access for cloudformation to copy encrypted objects
-          Effect: Allow
-          Principal:
-            Service: cloudformation.amazonaws.com
-          Action:
-            - "kms:Encrypt"
-            - "kms:Decrypt"
-            - "kms:ReEncrypt*"
-            - "kms:GenerateDataKey*"
-            - "kms:DescribeKey"
           Resource: "*"
 
   LogAndMetricsDeliveryRole:

--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -41,6 +41,24 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
 
+  ArtifactCopyPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ArtifactBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: Require Secure Transport
+            Action: "s3:*"
+            Effect: Deny
+            Resource:
+              - !Sub "arn:${AWS::Partition}:s3:::${ArtifactBucket}"
+              - !Sub "arn:${AWS::Partition}:s3:::${ArtifactBucket}/*"
+            Condition:
+              Bool:
+                "aws:SecureTransport": "false"
+            Principal: "*"
+
   EncryptionKey:
     Type: AWS::KMS::Key
     DeletionPolicy: Retain


### PR DESCRIPTION
Remove CloudFormation access to S3 via ArtifactCopyPolicy and KMS secret access since it is not used anymore

Tested by installing local changes in cloudformation cli and using cloudwatch-alarm resource to register in private account and test creating a stack -

![Screen Shot 2021-06-28 at 2 32 44 PM](https://user-images.githubusercontent.com/69654230/123707336-6597d580-d81e-11eb-86c5-717770351764.png)

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
