### PR TITLE
[BugFix] Collection Comparison for Contract Tests

### DIFF
--- a/src/rpdk/core/jsonutils/utils.py
+++ b/src/rpdk/core/jsonutils/utils.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -12,6 +14,14 @@ REF = "$ref"
 
 class FlatteningError(Exception):
     pass
+
+
+def item_hash(item):
+    """MD5 hash for an item (Dictionary/Scalar)"""
+    dhash = hashlib.md5()  # nosec
+    encoded = json.dumps(item, sort_keys=True).encode()
+    dhash.update(encoded)
+    return dhash.hexdigest()
 
 
 def to_set(value: Any) -> OrderedSet:

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -1373,6 +1373,30 @@ def test_compare_should_throw_exception(resource_client):
         logging.debug("This test expects Assertion Exception to be thrown")
 
 
+@pytest.mark.parametrize(
+    "inputs,outputs,schema_fragment",
+    [
+        (
+            {"CollectionToCompare": ["item1", "item2", "item3"]},
+            {"CollectionToCompare": ["item3", "item2", "item1"]},
+            {"properties": {"CollectionToCompare": {"insetionOrder": False}}},
+        ),
+        (
+            {"CollectionToCompare": ["item1", "item2", "item3"]},
+            {"CollectionToCompare": ["item1", "item2", "item3"]},
+            {"properties": {"CollectionToCompare": {"insetionOrder": True}}},
+        ),
+    ],
+)
+def test_compare_collection(resource_client, inputs, outputs, schema_fragment):
+    resource_client._update_schema(schema_fragment)
+
+    try:
+        resource_client.compare(inputs, outputs)
+    except AssertionError:
+        logging.debug("This test expects Assertion Exception to be thrown")
+
+
 def test_compare_should_throw_key_error(resource_client):
     resource_client._update_schema(SCHEMA_WITH_NESTED_PROPERTIES)
     inputs = {"b": {"d": 1}, "f": [{"d": 1}], "h": [{"d": 1}]}

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -1379,22 +1379,19 @@ def test_compare_should_throw_exception(resource_client):
         (
             {"CollectionToCompare": ["item1", "item2", "item3"]},
             {"CollectionToCompare": ["item3", "item2", "item1"]},
-            {"properties": {"CollectionToCompare": {"insetionOrder": False}}},
+            {"properties": {"CollectionToCompare": {"insertionOrder": False}}},
         ),
         (
             {"CollectionToCompare": ["item1", "item2", "item3"]},
             {"CollectionToCompare": ["item1", "item2", "item3"]},
-            {"properties": {"CollectionToCompare": {"insetionOrder": True}}},
+            {"properties": {"CollectionToCompare": {"insertionOrder": True}}},
         ),
     ],
 )
 def test_compare_collection(resource_client, inputs, outputs, schema_fragment):
     resource_client._update_schema(schema_fragment)
 
-    try:
-        resource_client.compare(inputs, outputs)
-    except AssertionError:
-        logging.debug("This test expects Assertion Exception to be thrown")
+    resource_client.compare(inputs, outputs)
 
 
 def test_compare_should_throw_key_error(resource_client):


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/cloudformation-cli/issues/811

*Description of changes:*

Collection Comparison for contract tests. Method `test_input_equals_output` contains a naive comparison of the collections, which generates a false positive for unordered sets.

Change: instead of comparing lists by values, added `compare_collection`. If `insertionOrder` is `False` then transform list items (since it's json each item is scalar/array/json) into a set of hash values, which does naive comparison after that. For hashing I'm using MD5, which is not secure hashing but provides a good hashing for contract test purpose.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
