### PR TITLE
Add contract test for tagging metadata enforcement

### DIFF
--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -661,6 +661,37 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
     def has_update_handler(self):
         return "update" in self._schema["handlers"]
 
+    def is_taggable(self):
+        try:
+            return self._schema["tagging"]["taggable"]
+        except KeyError:
+            try:
+                return self._schema["taggable"]
+            except KeyError:
+                return True
+
+    def metadata_contains_tag_property(self):
+        try:
+            return "tagProperty" in self._schema["tagging"]
+        except KeyError:
+            return False
+
+    def validate_model_contain_tags(self, inputs):
+        assertion_error_message = "Contract test inputs does not contain tags property."
+        tag_property_path = self._schema["tagging"]["tagProperty"]
+        tag_property_name = tag_property_path.split("/")[-1]
+        LOG.debug("Defined tag property name is: %s\n", tag_property_name)
+        try:
+            if isinstance(inputs, dict):
+                for key in inputs:
+                    if key == tag_property_name:
+                        return True
+            else:
+                raise assertion_error_message
+        except Exception as exception:
+            raise AssertionError(assertion_error_message) from exception
+        return False
+
     def has_required_handlers(self):
         try:
             has_delete = "delete" in self._schema["handlers"]

--- a/src/rpdk/core/contract/suite/contract_asserts.py
+++ b/src/rpdk/core/contract/suite/contract_asserts.py
@@ -114,6 +114,12 @@ def skip_not_writable_identifier(resource_client):
         pytest.skip("No writable identifiers. Skipping test.")
 
 
+@decorate(after=False)
+def skip_not_taggable(resource_client):
+    if not resource_client.is_taggable():
+        pytest.skip("Resource is not taggable. Skipping test.")
+
+
 def failed_event(error_code, msg=""):
     def decorator_wrapper(func: object):
         @wraps(func)

--- a/src/rpdk/core/contract/suite/handler_create.py
+++ b/src/rpdk/core/contract/suite/handler_create.py
@@ -7,7 +7,10 @@ import pytest
 # WARNING: contract tests should use fully qualified imports to avoid issues
 # when being loaded by pytest
 from rpdk.core.contract.interface import Action, OperationStatus
-from rpdk.core.contract.suite.contract_asserts import skip_not_writable_identifier
+from rpdk.core.contract.suite.contract_asserts import (
+    skip_not_taggable,
+    skip_not_writable_identifier,
+)
 from rpdk.core.contract.suite.handler_commons import (
     test_create_failure_if_repeat_writeable_id,
     test_create_success,
@@ -73,3 +76,15 @@ def contract_create_list(created_resource, resource_client):
     _input_model, created_model, _request = created_resource
     assert test_model_in_list(resource_client, created_model)
     test_read_success(resource_client, created_model)
+
+
+@pytest.mark.create
+@skip_not_taggable
+def contract_create_taggable(resource_client):
+    assert (
+        resource_client.metadata_contains_tag_property()
+    ), "Resource marked taggable but tagProperty attribute missing in tagging metadata."
+    input_model = resource_client.generate_create_example()
+    assert resource_client.validate_model_contain_tags(
+        input_model
+    ), "Contract test inputs does not contain tags property."

--- a/src/rpdk/core/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.v1.json
@@ -118,9 +118,42 @@
             "$ref": "#/definitions/replacementStrategy"
         },
         "taggable": {
-            "$comment": "A boolean flag indicating whether this resource type supports updatable tagging.",
+            "$comment": "(deprecated) A boolean flag indicating whether this resource type supports tagging.",
             "type": "boolean",
             "default": true
+        },
+        "tagging": {
+            "type": "object",
+            "properties": {
+                "taggable": {
+                    "description": "A boolean flag indicating whether this resource type supports tagging.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "tagOnCreate": {
+                    "description": "A boolean flag indicating whether this resource type supports tagging resources upon creation.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "tagUpdatable": {
+                    "description": "A boolean flag indicating whether this resource type supports updatable tagging.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "cloudFormationSystemTags": {
+                    "description": "A boolean flag indicating whether this resource type supports CloudFormation system tags.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "tagProperty": {
+                    "description": "A reference to the Tags property in the schema.",
+                    "$ref": "http://json-schema.org/draft-07/schema#/properties/$ref"
+                }
+            },
+            "required": [
+                "taggable"
+            ],
+            "additionalProperties": false
         },
         "additionalProperties": {
             "$comment": "All properties of a resource must be expressed in the schema - arbitrary inputs are not allowed",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Customers migrated to new version of tagging metadata will need to go through some new contract tests. However, If "taggable" is marked false, they will be able to skip them.
```
"tagging": {
            "type": "object",
            "properties": {
                "taggable": {
                    "description": "A boolean flag indicating whether this resource type supports tagging.",
                    "type": "boolean",
                    "default": true
                },
                "tagOnCreate": {
                    "description": "A boolean flag indicating whether this resource type supports tagging resources upon creation.",
                    "type": "boolean",
                    "default": true
                },
                "tagUpdatable": {
                    "description": "A boolean flag indicating whether this resource type supports updatable tagging.",
                    "type": "boolean",
                    "default": true
                },
                "cloudFormationSystemTags": {
                    "description": "A boolean flag indicating whether this resource type supports CloudFormation system tags.",
                    "type": "boolean",
                    "default": true
                },
                "tagProperty": {
                    "description": "A reference to the Tags property in the schema.",
                    "$ref": "http://json-schema.org/draft-07/schema#/properties/$ref"
                }
            },
            "required": [
                "taggable"
            ],
            "additionalProperties": false
 }
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
