### PR TITLE
Add nonPublicProperties and nonPublicDefinitions lists of JSONPointers

### DIFF
--- a/src/rpdk/core/data/schema/provider.definition.schema.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.v1.json
@@ -173,6 +173,14 @@
             "description": "A list of JSON pointers for properties that can only be updated under certain conditions. For example, you can upgrade the engine version of an RDS DBInstance but you cannot downgrade it.  When updating this property for a resource in a CloudFormation stack, the resource will be replaced if it cannot be updated.",
             "$ref": "base.definition.schema.v1.json#/definitions/jsonPointerArray"
         },
+        "nonPublicProperties": {
+            "description": "A list of JSON pointers for properties that are hidden. These properties will still be used but will not be visible",
+            "$ref": "base.definition.schema.v1.json#/definitions/jsonPointerArray"
+        },
+        "nonPublicDefinitions": {
+            "description": "A list of JSON pointers for definitions that are hidden. These definitions will still be used but will not be visible",
+            "$ref": "base.definition.schema.v1.json#/definitions/jsonPointerArray"
+        },
         "createOnlyProperties": {
             "description": "A list of JSON pointers to properties that are only able to be specified by the customer when creating a resource. Conversely, any property *not* in this list can be applied to an Update request.",
             "$ref": "base.definition.schema.v1.json#/definitions/jsonPointerArray"

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -154,6 +154,21 @@ def test_load_resource_spec_conditionally_create_only_match_read_only():
     )
 
 
+def test_load_resource_spec_non_public_properties_and_definitions():
+    schema = {
+        "typeName": "AWS::FOO::BAR",
+        "description": "test schema",
+        "additionalProperties": False,
+        "definitions": {"bar": {"type": "string"}},
+        "properties": {"foo": {"type": "string"}},
+        "primaryIdentifier": ["/properties/foo"],
+        "readOnlyProperties": ["/properties/foo"],
+        "nonPublicProperties": ["/properties/foo"],
+        "nonPublicDefinitions": ["/definitions/bar"],
+    }
+    load_resource_spec(json_s(schema))
+
+
 @pytest.mark.parametrize(
     "schema",
     [


### PR DESCRIPTION
*Description of changes:*

Add nonPublicProperties and nonPublicDefinitions lists of JSONPointers in metaschema. Adding top level lists to allow hidden property and definition paths to be accepted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
