### PR TITLE
fix: breaking change in jsonschema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     install_requires=[
         "boto3>=1.10.20",
         "Jinja2>=2.10,<3",
-        "jsonschema>=3.0.1",
+        "jsonschema>=3.0.1,<4.0",
         "pytest>=4.5.0",
         "pytest-random-order>=1.0.4",
         "pytest-localserver>=0.5.0",


### PR DESCRIPTION
jsonschema 4.0 introduced a breaking change that we were depending on. I have pinned the json schema to any version before 4.0 (and after the existing 3.0.1

```(.venv) Feder08:~/environment $ cfn init
Traceback (most recent call last):
  File "/home/ec2-user/environment/.venv/bin/cfn", line 5, in <module>
    from rpdk.core.cli import main
  File "/home/ec2-user/environment/.venv/lib64/python3.7/site-packages/rpdk/core/cli.py", line 12, in <module>
    from .build_image import setup_subparser as build_image_setup_subparser
  File "/home/ec2-user/environment/.venv/lib64/python3.7/site-packages/rpdk/core/build_image.py", line 11, in <module>
    from .project import Project
  File "/home/ec2-user/environment/.venv/lib64/python3.7/site-packages/rpdk/core/project.py", line 15, in <module>
    from rpdk.core.fragment.generator import TemplateFragment
  File "/home/ec2-user/environment/.venv/lib64/python3.7/site-packages/rpdk/core/fragment/generator.py", line 14, in <module>
    from rpdk.core.data_loaders import resource_json
  File "/home/ec2-user/environment/.venv/lib64/python3.7/site-packages/rpdk/core/data_loaders.py", line 17, in <module>
    from .jsonutils.inliner import RefInliner
  File "/home/ec2-user/environment/.venv/lib64/python3.7/site-packages/rpdk/core/jsonutils/inliner.py", line 6, in <module>
    from .renamer import RefRenamer
  File "/home/ec2-user/environment/.venv/lib64/python3.7/site-packages/rpdk/core/jsonutils/renamer.py", line 3, in <module>
    from jsonschema.compat import urldefrag
ModuleNotFoundError: No module named 'jsonschema.compat'
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
