### PR TITLE
Add .template to allowed extensions and fix typo in error message

### DIFF
--- a/src/rpdk/core/fragment/module_fragment_reader.py
+++ b/src/rpdk/core/fragment/module_fragment_reader.py
@@ -7,7 +7,7 @@ from cfn_tools import load_yaml
 from rpdk.core.exceptions import FragmentValidationError
 
 LOG = logging.getLogger(__name__)
-ALLOWED_EXTENSIONS = {".json", ".yaml", ".yml"}
+ALLOWED_EXTENSIONS = {".json", ".yaml", ".yml", ".template"}
 
 
 def read_raw_fragments(fragment_dir):
@@ -37,7 +37,7 @@ def _get_fragment_file(fragment_dir):
                 all_fragment_files.append(os.path.join(root, f))
     if len(all_fragment_files) == 0:
         raise FragmentValidationError(
-            f"No module fragment files found in the fragments folder ending on one of {ALLOWED_EXTENSIONS}"
+            f"No module fragment files found in the fragments folder ending in one of {ALLOWED_EXTENSIONS}"
         )
     if len(all_fragment_files) > 1:
         raise FragmentValidationError(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add `.template` to allowed fragment extentions.

`.template` is a pretty common extension for CloudFormation templates. In fact, AWS publishes several templates with that extension in various GitHub repositories. It therefore ought to be allowable as a fragment filename extension.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
