### PR TITLE
Add upperbound for PyYAML dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "pytest-random-order>=1.0.4",
         "pytest-localserver>=0.5.0",
         "Werkzeug>=0.15",
-        "PyYAML>=5.1",
+        "PyYAML>=5.1,<6.0",
         "requests>=2.22",
         "hypothesis>=4.32",
         "colorama>=0.4.1",


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
I noticed the tests encounter this failure in codebuild:
```
Container] 2021/12/06 19:53:04 Running command pip3 install --upgrade pip setuptools wheel > /dev/null
 
[Container] 2021/12/06 19:53:08 Running command pip3 install cloudformation-cli cloudformation-cli-java-plugin cloudformation-cli-go-plugin cloudformation-cli-python-plugin cloudformation-cli-typescript-plugin > /dev/null
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
serverlessrepo 0.1.9 requires pyyaml~=5.1, but you have pyyaml 6.0 which is incompatible.
awscli 1.18.49 requires PyYAML<5.4,>=3.10; python_version != "3.4", but you have pyyaml 6.0 which is incompatible.
aws-sam-cli 0.48.0 requires aws-sam-translator==1.22.0, but you have aws-sam-translator 1.42.0 which is incompatible.
aws-sam-cli 0.48.0 requires PyYAML~=5.1, but you have pyyaml 6.0 which is incompatible.

```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
