### PR TITLE
Enforce SecureTransport policy on AccessLogsBucket

### DIFF
--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -59,6 +59,24 @@ Resources:
                 "aws:SecureTransport": "false"
             Principal: "*"
 
+  AccessLogsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref AccessLogsBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: Require Secure Transport
+            Action: "s3:*"
+            Effect: Deny
+            Resource:
+              - !Sub "arn:${AWS::Partition}:s3:::${AccessLogsBucket}"
+              - !Sub "arn:${AWS::Partition}:s3:::${AccessLogsBucket}/*"
+            Condition:
+              Bool:
+                "aws:SecureTransport": "false"
+            Principal: "*"
+
   EncryptionKey:
     Type: AWS::KMS::Key
     DeletionPolicy: Retain


### PR DESCRIPTION
Policy was enforced in https://github.com/aws-cloudformation/cloudformation-cli/pull/389, but another bucket was added later in https://github.com/aws-cloudformation/cloudformation-cli/pull/396. Enforcing SecureTransport for that bucket as well

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
