### PR TITLE
Updated hook contract tests to prune target schema properties

### DIFF
--- a/src/rpdk/core/contract/hook_client.py
+++ b/src/rpdk/core/contract/hook_client.py
@@ -112,7 +112,8 @@ class HookClient:  # pylint: disable=too-many-instance-attributes
         from .resource_generator import ResourceGenerator
 
         target_info = dict(hook_target_info)
-        for _target, info in target_info.items():
+        for target, info in target_info.items():
+            LOG.debug("Setting up target info for '%s'", target)
 
             # make a copy so the original schema is never modified
             target_schema = json.loads(json.dumps(info["Schema"]))

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -1173,13 +1173,13 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         target_info = {}
         for target_name in target_names:
+            type_info = provided_target_info.get(target_name) or {}
             if target_name in loaded_schemas:
                 target_schema = loaded_schemas[target_name]
                 target_type = "RESOURCE"
-                provisioning_type = provided_target_info.get(target_name, {}).get(
-                    "ProvisioningType",
-                    loader.get_provision_type(target_name, "RESOURCE"),
-                )
+                provisioning_type = type_info.get(
+                    "ProvisioningType"
+                ) or loader.get_provision_type(target_name, "RESOURCE")
             else:
                 (
                     target_schema,


### PR DESCRIPTION
Fixed some `cfn test` bugs for `HOOK`  type projects:
* Prune `createOnlyProperties` and `readOnlyProperties` from target schema when generating schema strategy for target
* Fix bug where CFN DescribeType API would still be called even if local target info was provided
* Log exact target type name that failed contract tests to help debug process

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
