### PR TITLE
Setup Hook target schema strategy only if no input is provided for contract tests

### DIFF
--- a/tests/contract/test_hook_client.py
+++ b/tests/contract/test_hook_client.py
@@ -239,8 +239,6 @@ def test_setup_target_info():
     assert target_info["AWS::Example::Target"]["createOnlyProperties"] == {
         ("properties", "c")
     }
-    assert target_info["AWS::Example::Target"]["SchemaStrategy"]
-    assert target_info["AWS::Example::Target"]["UpdateSchemaStrategy"]
 
 
 @pytest.mark.parametrize("hook_type", [None, "Org::Srv::Type"])
@@ -330,8 +328,11 @@ def test_generate_example(hook_client):
         }
     }
     hook_client._target_info = HookClient._setup_target_info(hook_target_info)
+    assert not hook_client._target_info["AWS::Example::Target"].get("SchemaStrategy")
+
     example = hook_client._generate_target_example("AWS::Example::Target")
     assert example == {"a": 1}
+    assert hook_client._target_info["AWS::Example::Target"]["SchemaStrategy"]
 
 
 def test_generate_update_example(hook_client):
@@ -351,9 +352,14 @@ def test_generate_update_example(hook_client):
     }
     hook_client._target_info = HookClient._setup_target_info(hook_target_info)
     hook_client._overrides = {}
+    assert not hook_client._target_info["AWS::Example::Target"].get(
+        "UpdateSchemaStrategy"
+    )
+
     model = {"b": 2, "a": 4}
     example = hook_client._generate_target_update_example("AWS::Example::Target", model)
     assert example == {"a": 1, "b": 2}
+    assert hook_client._target_info["AWS::Example::Target"]["UpdateSchemaStrategy"]
 
 
 def test_make_payload(hook_client):


### PR DESCRIPTION
Updating hook contract test client to only setup a schema strategy for the hook's target if no input is given


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
