### PR TITLE
add deletionPolicy and replacepolicy for managedUploadinfra stack

### DIFF
--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -6,6 +6,8 @@ Description: >
 Resources:
   ArtifactBucket:
     Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       AccessControl: BucketOwnerFullControl
       BucketEncryption:
@@ -27,6 +29,8 @@ Resources:
 
   AccessLogsBucket:
     Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       AccessControl: LogDeliveryWrite
       BucketEncryption:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change added DeletionPolicy and UpdateReplacePolicy as part of the Deployment Safety Campaign

S3 buckets are Stateful resources therefore require DeletionPolicy and UpdateReplacePolicy. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
