### PR TITLE
Update example hook schema to target real resource types

### DIFF
--- a/src/rpdk/core/data/examples/hook/sse.verification.v1.json
+++ b/src/rpdk/core/data/examples/hook/sse.verification.v1.json
@@ -17,19 +17,19 @@
     "handlers": {
         "preCreate": {
             "targetNames": [
-                "My::Example::Resource"
+                "AWS::S3::Bucket"
             ],
             "permissions": []
         },
         "preUpdate": {
             "targetNames": [
-                "My::Example::Resource"
+                "AWS::S3::Bucket"
             ],
             "permissions": []
         },
         "preDelete": {
             "targetNames": [
-                "Other::Example::Resource"
+                "AWS::S3::Bucket"
             ],
             "permissions": []
         }


### PR DESCRIPTION
Updated the example hook schema to target an `AWS::S3::Bucket` to provide a real world example after initiating a hook project

Related PRs:
* https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/pull/398
* https://github.com/aws-cloudformation/cloudformation-cli-python-plugin/pull/188

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
