### PR TITLE
Specify that numbers are "Length" in documentation

### DIFF
--- a/src/rpdk/core/templates/docs-readme.md
+++ b/src/rpdk/core/templates/docs-readme.md
@@ -63,11 +63,11 @@ _Allowed Values_: {% for allowedvalue in prop.allowedvalues %}<code>{{ allowedva
 {% endif %}
 {% if prop.minLength %}
 
-_Minimum_: <code>{{ prop.minLength }}</code>
+_Minimum Length_: <code>{{ prop.minLength }}</code>
 {% endif %}
 {% if prop.maxLength %}
 
-_Maximum_: <code>{{ prop.maxLength }}</code>
+_Maximum Length_: <code>{{ prop.maxLength }}</code>
 {% endif %}
 {% if prop.pattern %}
 


### PR DESCRIPTION
People might otherwise read this as a check on the string value


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
