### PR TITLE
add pre-commit hook for modules

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: cfn-module-generate
+    name: CloudFormation Module generate
+    entry: cfn generate
+    language: python
+    files: ^fragments\/.*\.(json|yaml|yml)$
+    pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,5 +2,5 @@
     name: AWS CloudFormation module generate command
     entry: cfn generate
     language: python
-    files: ^fragments\/.*\.(json|yaml|yml)$
+    files: ^.*fragments\/.*\.(json|yaml|yml)$
     pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,5 @@
 -   id: cfn-module-generate
-    name: CloudFormation Module generate
+    name: AWS CloudFormation module generate command
     entry: cfn generate
     language: python
     files: ^fragments\/.*\.(json|yaml|yml)$


### PR DESCRIPTION
*Description of changes:* 

As a CFN module developer I want to prevent commits to my module repo that have drift between the schema and template fragment.

This PR makes the cfn cli available as a [pre-commit hook](https://pre-commit.com/#new-hooks) that can be used in module projects by adding a `.pre-commit-config.yaml` as follows:

```
repos:
- repo: https://github.com/aws-cloudformation/cloudformation-cli
  rev: v0.2.26
  hooks:
    - id: cfn-module-generate
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
