### PR TITLE
Add custom property arrayType

### DIFF
--- a/src/rpdk/core/data/schema/base.definition.schema.v1.json
+++ b/src/rpdk/core/data/schema/base.definition.schema.v1.json
@@ -61,6 +61,15 @@
                             "type": "boolean",
                             "default": true
                         },
+                        "arrayType": {
+                            "description": "When set to AttributeList, it indicates that the array is of nested type objects, and when set to Standard it indicates that the array consists of primitive types",
+                            "type": "string",
+                            "default": "Standard",
+                            "enum": [
+                                "Standard",
+                                "AttributeList"
+                            ]
+                        },
                         "$ref": {
                             "$ref": "http://json-schema.org/draft-07/schema#/properties/$ref"
                         },

--- a/src/rpdk/core/data/schema/provider.definition.schema.modules.v1.json
+++ b/src/rpdk/core/data/schema/provider.definition.schema.modules.v1.json
@@ -96,6 +96,15 @@
                             "type": "boolean",
                             "default": true
                         },
+                        "arrayType": {
+                            "description": "When set to AttributeList, it indicates that the array is of nested type objects, and when set to Standard it indicates that the array consists of primitive types",
+                            "type": "string",
+                            "default": "Standard",
+                            "enum": [
+                                "Standard",
+                                "AttributeList"
+                            ]
+                        },
                         "$ref": {
                             "$ref": "https://json-schema.org/draft-07/schema#/properties/$ref"
                         },

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -179,6 +179,10 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
                             "Explicitly specify value for insertionOrder for array: %s",
                             property_name,
                         )
+                    if property_type != "array" and "arrayType" in property_keywords:
+                        raise SpecValidationError(
+                            "arrayType is only applicable for properties of type array"
+                        )
                     keyword_mappings = [
                         (
                             {"integer", "number"},

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -267,6 +267,101 @@ def test_load_hook_spec_hook_permissions_valid():
     assert result == schema
 
 
+def test_load_resource_spec_array_type_invalid():
+    schema = {
+        "typeName": "AWS::FOO::BAR",
+        "description": "test schema",
+        "additionalProperties": False,
+        "properties": {
+            "Foo": {
+                "type": "array",
+                "uniqueItems": False,
+                "insertionOrder": False,
+                "items": {"$ref": "#/definitions/XYZ"},
+            },
+            "Bar": {"type": "string", "arrayType": "Standard"},
+        },
+        "definitions": {
+            "XYZ": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {"Value": {"type": "string"}, "Key": {"type": "string"}},
+            }
+        },
+        "primaryIdentifier": ["/properties/Foo"],
+        "readOnlyProperties": ["/properties/Foo"],
+        "createOnlyProperties": ["/properties/Foo"],
+        "conditionalCreateOnlyProperties": ["/properties/Bar"],
+    }
+    with pytest.raises(SpecValidationError) as excinfo:
+        load_resource_spec(json_s(schema))
+    assert (
+        str(excinfo.value)
+        == "arrayType is only applicable for properties of type array"
+    )
+
+
+def test_load_resource_spec_array_type_valid():
+    schema = {
+        "typeName": "AWS::FOO::BAR",
+        "description": "test schema",
+        "additionalProperties": False,
+        "properties": {
+            "Foo": {
+                "type": "array",
+                "uniqueItems": False,
+                "insertionOrder": False,
+                "arrayType": "Standard",
+                "items": {"$ref": "#/definitions/XYZ"},
+            },
+            "Bar": {"type": "string"},
+        },
+        "definitions": {
+            "XYZ": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {"Value": {"type": "string"}, "Key": {"type": "string"}},
+            }
+        },
+        "primaryIdentifier": ["/properties/Foo"],
+        "readOnlyProperties": ["/properties/Foo"],
+        "createOnlyProperties": ["/properties/Foo"],
+        "conditionalCreateOnlyProperties": ["/properties/Bar"],
+    }
+    result = load_resource_spec(json_s(schema))
+    assert result == schema
+
+
+def test_load_resource_spec_without_array_type_valid():
+    schema = {
+        "typeName": "AWS::FOO::BAR",
+        "description": "test schema",
+        "additionalProperties": False,
+        "properties": {
+            "foo": {
+                "type": "array",
+                "uniqueItems": False,
+                "insertionOrder": False,
+                "items": {"$ref": "#/definitions/XYZ"},
+            },
+            "bar": {"type": "string"},
+        },
+        "definitions": {
+            "XYZ": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {"Value": {"type": "string"}, "Key": {"type": "string"}},
+            }
+        },
+        "primaryIdentifier": ["/properties/foo"],
+        "readOnlyProperties": ["/properties/foo"],
+        "createOnlyProperties": ["/properties/foo"],
+        "conditionalCreateOnlyProperties": ["/properties/bar"],
+    }
+    result = load_resource_spec(json_s(schema))
+    assert result == schema
+
+
 def test_argparse_stdin_name():
     """By default, pytest messes with stdin and stdout, which prevents me from
     writing a test to check we have the right magic name that argparse uses


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add custom tag arrayType

arrayType is only applicable for property of type array. When set to AttributeList, it indicates that the array is of nested type objects, and when set to Standard it indicates that the array consists of primitive types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
