### PR TITLE
chore(ci): set fail fast to false in pr-ci github action

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -13,6 +13,7 @@ jobs:
     env:
       AWS_DEFAULT_REGION: us-east-1
     strategy:
+      fail-fast: false
       matrix:
         python: [3.6, 3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
Closes #917 

By default github actions fail fast is set to true, where if one build fails it cancels all other in progress builds. Current build process is somewhat inconsistent and until that is resolved disabling fail-fast so we can just rerun failed builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
