### PR TITLE
fix(tests) - clean up docker random hook failures

### DIFF
--- a/tests/contract/test_hook_client.py
+++ b/tests/contract/test_hook_client.py
@@ -714,7 +714,7 @@ def test_call_docker():
         '{"hookStatus": "SUCCESS"}__CFN_HOOK_END_RESPONSE__'
     )
     mock_client.containers.run.return_value = str.encode(response_str)
-    with patch_creds:
+    with patch_creds, patch_config:
         status, response = hook_client.call(
             "CREATE_PRE_PROVISION", HOOK_TARGET_TYPE_NAME, {"foo": "bar"}
         )

--- a/tests/contract/test_type_configuration.py
+++ b/tests/contract/test_type_configuration.py
@@ -21,13 +21,15 @@ def setup_function():
     TypeConfiguration.TYPE_CONFIGURATION = None
 
 
+def teardown_function():
+    # Rest after to clean TypeConfiguration before the next test
+    TypeConfiguration.TYPE_CONFIGURATION = None
+
+
 def test_get_type_configuration_with_not_exist_file():
     with patch("builtins.open", mock_open()) as f:
         f.side_effect = FileNotFoundError()
-        try:
-            TypeConfiguration.get_type_configuration()
-        except FileNotFoundError:
-            pass
+        assert TypeConfiguration.get_type_configuration() is None
 
 
 @patch("builtins.open", mock_open(read_data=TYPE_CONFIGURATION_TEST_SETTING))
@@ -73,7 +75,4 @@ def test_get_hook_configuration_with_invalid_json():
 def test_get_hook_configuration_with_not_exist_file():
     with patch("builtins.open", mock_open()) as f:
         f.side_effect = FileNotFoundError()
-        try:
-            TypeConfiguration.get_hook_configuration()
-        except FileNotFoundError:
-            pass
+        assert TypeConfiguration.get_hook_configuration() is None


### PR DESCRIPTION
*Issue #, if available:*
#912 

*Description of changes:*
- Trying to fix the below error that happens randomly

```
=================================== FAILURES ===================================
_______________________________ test_call_docker _______________________________

    @staticmethod
    def get_hook_configuration():
        type_configuration = TypeConfiguration.get_type_configuration()
        if type_configuration:
            try:
                return type_configuration.get("CloudFormationConfiguration", {})[
>                   "HookConfiguration"
                ]["Properties"]
E               KeyError: 'HookConfiguration'

/opt/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/site-packages/rpdk/core/contract/type_configuration.py:48: KeyError

The above exception was the direct cause of the following exception:

    def test_call_docker():
        patch_sesh = patch(
            "rpdk.core.contract.hook_client.create_sdk_session", autospec=True
        )
        patch_creds = patch(
            "rpdk.core.contract.hook_client.get_temporary_credentials",
            autospec=True,
            return_value={},
        )
        patch_config = patch(
            "rpdk.core.contract.hook_client.TypeConfiguration.get_hook_configuration",
            return_value={},
        )
        patch_account = patch(
            "rpdk.core.contract.hook_client.get_account",
            autospec=True,
            return_value=ACCOUNT,
        )
        patch_docker = patch("rpdk.core.contract.hook_client.docker", autospec=True)
        with patch_sesh as mock_create_sesh, patch_docker as mock_docker, patch_creds, patch_config:
            with patch_account:
                mock_client = mock_docker.from_env.return_value
                mock_sesh = mock_create_sesh.return_value
                mock_sesh.region_name = DEFAULT_REGION
                hook_client = HookClient(
                    DEFAULT_FUNCTION,
                    "url",
                    DEFAULT_REGION,
                    {},
                    EMPTY_OVERRIDE,
                    docker_image="docker_image",
                    executable_entrypoint="entrypoint",
                )
                hook_client._type_name = HOOK_TYPE_NAME
        response_str = (
            "__CFN_HOOK_START_RESPONSE__"
            '{"hookStatus": "SUCCESS"}__CFN_HOOK_END_RESPONSE__'
        )
        mock_client.containers.run.return_value = str.encode(response_str)
        with patch_creds:
            status, response = hook_client.call(
>               "CREATE_PRE_PROVISION", HOOK_TARGET_TYPE_NAME, {"foo": "bar"}
            )

tests/contract/test_hook_client.py:719: 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
