### PR TITLE
fix(core) - Ignore timestamp issues when creating a ZipFile on py3.8 and greater

### DIFF
--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 import zipfile
 from pathlib import Path
 from tempfile import TemporaryFile
@@ -611,7 +612,10 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         with context_mgr as f:
             # the default compression is ZIP_STORED, which helps with the
             # file-size check on upload
-            with zipfile.ZipFile(f, mode="w") as zip_file:
+            args = {}
+            if sys.version_info >= (3, 8):
+                args = {"strict_timestamps": False}
+            with zipfile.ZipFile(f, mode="w", **args) as zip_file:
                 if self.configuration_schema:
                     with zip_file.open(
                         CONFIGURATION_SCHEMA_UPLOAD_FILENAME, "w"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -6,6 +6,7 @@ import logging
 import os
 import random
 import string
+import sys
 import zipfile
 from contextlib import contextmanager
 from io import StringIO
@@ -1189,6 +1190,8 @@ def test_submit_dry_run(project, is_type_configuration_available):
 
     with project.schema_path.open("w", encoding="utf-8") as f:
         f.write(CONTENTS_UTF8)
+    if sys.version_info >= (3, 8):
+        os.utime(project.schema_path, (1602179630, 10000))
 
     if is_type_configuration_available:
         project.configuration_schema = {"properties": {}}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add `strict_timestamps` to False when creating a ZipFile on python 3.8 and greater


replaces pr #600 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
