### PR TITLE
fix(schema) - Use ASCII characters for \w in pattern regex

### DIFF
--- a/src/rpdk/core/contract/resource_generator.py
+++ b/src/rpdk/core/contract/resource_generator.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from collections.abc import Sequence
 
 from hypothesis.strategies import (
@@ -247,7 +248,7 @@ class ResourceGenerator:
             if "maxLength" in schema:  # pragma: no cover
                 LOG.warning("found maxLength used with pattern")
 
-            return from_regex(terminate_regex(regex))
+            return from_regex(re.compile(terminate_regex(regex), re.ASCII))
 
         if "pattern" in schema:  # pragma: no cover
             LOG.warning("found pattern used with format")
@@ -257,4 +258,4 @@ class ResourceGenerator:
             LOG.warning("found maxLength used with format")
 
         regex = STRING_FORMATS[string_format]
-        return from_regex(regex)
+        return from_regex(re.compile(regex, re.ASCII))

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -249,7 +249,10 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
                 pattern,
             )
         try:
-            re.compile(pattern)
+            # http://json-schema.org/understanding-json-schema/reference/regular_expressions.html
+            # ECMA-262 has \w, \W, \b, \B, \d, \D, \s and \S perform ASCII-only matching
+            # instead of full Unicode matching. Unicode matching is the default in Python
+            re.compile(pattern, re.ASCII)
         except re.error:
             LOG.warning("Could not validate regular expression: %s", pattern)
 

--- a/tests/contract/test_resource_generator.py
+++ b/tests/contract/test_resource_generator.py
@@ -68,6 +68,13 @@ def test_generate_string_strategy_regex():
     assert re.fullmatch(schema["pattern"], regex_strategy.example())
 
 
+def test_generate_string_strategy_ascii():
+    schema = {"type": "string", "pattern": "^\\w{1,6}$"}
+    strategy = ResourceGenerator(schema).generate_schema_strategy(schema)
+    for _ in range(100):
+        assert re.match("^[A-Za-z0-9_]{1,6}$", strategy.example())
+
+
 def test_generate_string_strategy_format():
     schema = {"type": "string", "format": "arn"}
     strategy = ResourceGenerator(schema).generate_schema_strategy(schema)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- \w, \W, \b, \B, \d, \D, \s and \S flags in regex should be ASCII based not unicode
- Unicode is the default in python so this switches it to be ascii based

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
