### PR TITLE
chore(CD): Update pypi GHA to new syntax

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -22,6 +22,6 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
     - name: Publish distribution 📦 to PyPI (If triggered from release)
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_KEY_CLOUDFORMATION_CLI }}


### PR DESCRIPTION
Closes #936 

Pypi has deprecated "master" and now uses pypa/gh-action-pypi-publish@release/v1 syntax.  Updated github action to reflect this change


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
