### PR TITLE
fix(jinja2): upgrade jinja2 and markupsafe

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text eol=lf

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "boto3>=1.10.20",
-        "Jinja2==2.11.3",
-        "markupsafe==2.0.1",
+        "Jinja2>=2.11.3",
+        "markupsafe>=2.0.1",
         "jsonschema>=3.0.1,<4.0",
         "pytest>=4.5.0",
         "pytest-random-order>=1.0.4",

--- a/src/rpdk/core/contract/hook_client.py
+++ b/src/rpdk/core/contract/hook_client.py
@@ -130,7 +130,8 @@ class HookClient:  # pylint: disable=too-many-instance-attributes
             trim_blocks=True,
             lstrip_blocks=True,
             keep_trailing_newline=True,
-            loader=PackageLoader(__name__, "templates/"),
+            # Unable to use __name__ anymore after Jinja2 3.x change
+            loader=PackageLoader("rpdk.core", "templates/"),
             autoescape=select_autoescape(["html", "htm", "xml", "md"]),
         )
         self._schema = schema

--- a/src/rpdk/core/templates/docs-readme.md
+++ b/src/rpdk/core/templates/docs-readme.md
@@ -52,8 +52,11 @@ Properties:
 {{ prop.description }}
 {% endif %}
 
-_Required_: {% if propname in schema.required %}Yes{% else %}No{% endif %}
-
+{% if schema.required is defined and propname in schema.required %}
+_Required_: Yes
+{% else %}
+_Required_: No
+{% endif %}
 
 _Type_: {{ prop.longformtype }}
 {% if prop.allowedvalues %}

--- a/src/rpdk/core/templates/docs-subproperty.md
+++ b/src/rpdk/core/templates/docs-subproperty.md
@@ -47,8 +47,11 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 {{ prop.description }}
 {% endif %}
 
-_Required_: {% if propname in schema.required %}Yes{% else %}No{% endif %}
-
+{% if schema.required is defined and propname in schema.required %}
+_Required_: Yes
+{% else %}
+_Required_: No
+{% endif %}
 
 _Type_: {{ prop.longformtype }}
 {% if prop.allowedvalues %}

--- a/src/rpdk/core/templates/hook-docs-readme.md
+++ b/src/rpdk/core/templates/hook-docs-readme.md
@@ -43,8 +43,11 @@ To activate a hook in your account, use the following JSON as the `Configuration
 {{ prop.description }}
 {% endif %}
 
-_Required_: {% if propname in schema.required %}Yes{% else %}No{% endif %}
-
+{% if schema.required is defined and propname in schema.required %}
+_Required_: Yes
+{% else %}
+_Required_: No
+{% endif %}
 
 _Type_: {{ prop.longformtype }}
 {% if prop.allowedvalues %}


### PR DESCRIPTION
Closes #940 
Closes #938 
Closes #899 
Closes #864 

Jinja2 upgraded away from setuptools and pkg_resources, this caused a slight change in PackageLoader.  Updated Jinja2 template syntax and PackageLoader in contract/hooks_client to compensate and unpin Jinja2 and MarkupSafe.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
