### PR TITLE
Add support for Wildcard Hook Targets

### DIFF
--- a/src/rpdk/core/contract/interface.py
+++ b/src/rpdk/core/contract/interface.py
@@ -53,4 +53,5 @@ class HandlerErrorCode(AutoName):
     InvalidTypeConfiguration = auto()
     HandlerInternalFailure = auto()
     NonCompliant = auto()
+    UnsupportedTarget = auto()
     Unknown = auto()

--- a/src/rpdk/core/contract/suite/hook/handler_pre_create.py
+++ b/src/rpdk/core/contract/suite/hook/handler_pre_create.py
@@ -6,6 +6,7 @@ from rpdk.core.contract.interface import HookInvocationPoint
 from rpdk.core.contract.suite.hook.hook_handler_commons import (
     test_hook_handlers_failed,
     test_hook_handlers_success,
+    test_hook_unsupported_target,
 )
 
 LOG = logging.getLogger(__name__)
@@ -21,3 +22,8 @@ def contract_pre_create_success(hook_client):
 @pytest.mark.create_pre_provision
 def contract_pre_create_failed(hook_client):
     test_hook_handlers_failed(hook_client, INVOCATION_POINT)
+
+
+@pytest.mark.create_pre_provision
+def contract_pre_create_failed_unsupported_target(hook_client):
+    test_hook_unsupported_target(hook_client, INVOCATION_POINT)

--- a/src/rpdk/core/contract/suite/hook/handler_pre_delete.py
+++ b/src/rpdk/core/contract/suite/hook/handler_pre_delete.py
@@ -6,6 +6,7 @@ from rpdk.core.contract.interface import HookInvocationPoint
 from rpdk.core.contract.suite.hook.hook_handler_commons import (
     test_hook_handlers_failed,
     test_hook_handlers_success,
+    test_hook_unsupported_target,
 )
 
 LOG = logging.getLogger(__name__)
@@ -21,3 +22,8 @@ def contract_pre_delete_success(hook_client):
 @pytest.mark.delete_pre_provision
 def contract_pre_delete_failed(hook_client):
     test_hook_handlers_failed(hook_client, INVOCATION_POINT)
+
+
+@pytest.mark.delete_pre_provision
+def contract_pre_delete_failed_unsupported_target(hook_client):
+    test_hook_unsupported_target(hook_client, INVOCATION_POINT)

--- a/src/rpdk/core/contract/suite/hook/handler_pre_update.py
+++ b/src/rpdk/core/contract/suite/hook/handler_pre_update.py
@@ -6,6 +6,7 @@ from rpdk.core.contract.interface import HookInvocationPoint
 from rpdk.core.contract.suite.hook.hook_handler_commons import (
     test_hook_handlers_failed,
     test_hook_handlers_success,
+    test_hook_unsupported_target,
 )
 
 LOG = logging.getLogger(__name__)
@@ -21,3 +22,8 @@ def contract_pre_update_success(hook_client):
 @pytest.mark.update_pre_provision
 def contract_pre_update_failed(hook_client):
     test_hook_handlers_failed(hook_client, INVOCATION_POINT)
+
+
+@pytest.mark.update_pre_provision
+def contract_pre_update_failed_unsupported_target(hook_client):
+    test_hook_unsupported_target(hook_client, INVOCATION_POINT)

--- a/src/rpdk/core/contract/suite/hook/hook_handler_commons.py
+++ b/src/rpdk/core/contract/suite/hook/hook_handler_commons.py
@@ -1,9 +1,24 @@
+# pylint: disable=import-outside-toplevel
 import logging
 
+import pytest
+
 from rpdk.core.contract.hook_client import HookClient
-from rpdk.core.contract.interface import HookStatus
+from rpdk.core.contract.interface import HandlerErrorCode, HookStatus
+from rpdk.core.contract.suite.contract_asserts_commons import failed_event
 
 LOG = logging.getLogger(__name__)
+
+TARGET_NAME_REGEX = "^[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}$"
+
+UNSUPPORTED_TARGET_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "id": {"type": "string", "format": "arn"},
+        "property1": {"type": "string", "pattern": "^[a-zA-Z0-9]{2,26}$"},
+        "property2": {"type": "integer", "minimum": 1, "maximum": 100},
+    },
+}
 
 
 def test_hook_success(hook_client, invocation_point, target, target_model):
@@ -66,3 +81,37 @@ def test_hook_handlers_failed(hook_client, invocation_point):
         target_model,
     ) in hook_client.generate_invalid_request_examples(invocation_point):
         test_hook_failed(hook_client, invocation_point, target, target_model)
+
+
+@failed_event(
+    error_code=HandlerErrorCode.UnsupportedTarget,
+    msg="A hook handler MUST return FAILED with a UnsupportedTarget error code if the target is not supported",
+)
+def test_hook_unsupported_target(hook_client, invocation_point):
+    if not hook_client.handler_has_wildcard_targets(invocation_point):
+        pytest.skip("No wildcard hook targets. Skipping test.")
+
+    # imported here to avoid hypothesis being loaded before pytest is loaded
+    from ...resource_generator import ResourceGenerator
+
+    unsupported_target = ResourceGenerator(
+        UNSUPPORTED_TARGET_SCHEMA
+    ).generate_schema_strategy(UNSUPPORTED_TARGET_SCHEMA)
+
+    target_model = {"resourceProperties": unsupported_target.example()}
+    if HookClient.is_update_invocation_point(invocation_point):
+        target_model["previousResourceProperties"] = unsupported_target.example()
+        target_model["previousResourceProperties"]["id"] = target_model[
+            "resourceProperties"
+        ]["id"]
+
+    _response, error_code = test_hook_failed(
+        hook_client,
+        invocation_point,
+        ResourceGenerator.generate_string_strategy(
+            {"pattern": TARGET_NAME_REGEX}
+        ).example(),
+        target_model,
+    )
+
+    return error_code

--- a/src/rpdk/core/contract/type_configuration.py
+++ b/src/rpdk/core/contract/type_configuration.py
@@ -41,12 +41,13 @@ class TypeConfiguration:
 
     @staticmethod
     def get_hook_configuration():
+        # pylint: disable=unsubscriptable-object
         type_configuration = TypeConfiguration.get_type_configuration()
         if type_configuration:
             try:
-                return type_configuration.get("CloudFormationConfiguration", {})[
+                return type_configuration["CloudFormationConfiguration"][
                     "HookConfiguration"
-                ]["Properties"]
+                ].get("Properties")
             except KeyError as e:
                 LOG.warning("Hook configuration is invalid")
                 raise InvalidProjectError("Hook configuration is invalid") from e

--- a/src/rpdk/core/data/pytest-contract.ini
+++ b/src/rpdk/core/data/pytest-contract.ini
@@ -19,4 +19,4 @@ markers =
     delete_pre_provision: preDelete handler related tests.
 
 filterwarnings =
-    ignore::hypothesis.errors.NonInteractiveExampleWarning:hypothesis
+    ignore::hypothesis.errors.NonInteractiveExampleWarning

--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -399,16 +399,21 @@ def load_hook_spec(hook_spec_file):  # pylint: disable=R # noqa: C901
         raise SpecValidationError(str(e)) from e
 
     blocked_handler_permissions = {"cloudformation:RegisterType"}
-    for handler in hook_spec.get("handlers", []):
-        for permission in hook_spec.get("handlers", [])[handler]["permissions"]:
+    for handler in hook_spec.get("handlers", {}).values():
+        for permission in handler["permissions"]:
             if "cloudformation:*" in permission:
                 raise SpecValidationError(
                     f"Wildcards for cloudformation are not allowed for hook handler permissions: '{permission}'"
                 )
-
             if permission in blocked_handler_permissions:
                 raise SpecValidationError(
                     f"Permission is not allowed for hook handler permissions: '{permission}'"
+                )
+
+        for target_name in handler["targetNames"]:
+            if "*?" in target_name:
+                raise SpecValidationError(
+                    f"Wildcard pattern '*?' is not allowed in target name: '{target_name}'"
                 )
 
     try:

--- a/src/rpdk/core/exceptions.py
+++ b/src/rpdk/core/exceptions.py
@@ -60,3 +60,7 @@ class ModelResolverError(RPDKBaseException):
 
 class InvalidFragmentFileError(RPDKBaseException):
     pass
+
+
+class InvalidTypeSchemaError(RPDKBaseException):
+    pass

--- a/src/rpdk/core/generate.py
+++ b/src/rpdk/core/generate.py
@@ -12,7 +12,9 @@ LOG = logging.getLogger(__name__)
 def generate(args):
     project = Project()
     project.load()
-    project.generate(args.endpoint_url, args.region, args.target_schemas)
+    project.generate(
+        args.endpoint_url, args.region, args.local_only, args.target_schemas
+    )
     project.generate_docs()
 
     LOG.warning("Generated files for %s", project.type_name)
@@ -25,6 +27,9 @@ def setup_subparser(subparsers, parents):
 
     parser.add_argument("--endpoint-url", help="CloudFormation endpoint to use.")
     parser.add_argument("--region", help="AWS Region to submit the type.")
+    parser.add_argument(
+        "--local-only", action="store_true", help="Only load local target info"
+    )
     parser.add_argument(
         "--target-schemas", help="Path to target schemas.", nargs="*", default=[]
     )

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -16,27 +16,24 @@ from jsonschema.exceptions import ValidationError
 
 from rpdk.core.fragment.generator import TemplateFragment
 from rpdk.core.jsonutils.flattener import JsonSchemaFlattener
-from rpdk.core.type_schema_loader import TypeSchemaLoader
 
 from . import __version__
 from .boto_helpers import create_sdk_session
-from .data_loaders import (
-    load_hook_spec,
-    load_resource_spec,
-    make_resource_validator,
-    resource_json,
-)
+from .data_loaders import load_hook_spec, load_resource_spec, resource_json
 from .exceptions import (
     DownstreamError,
     FragmentValidationError,
     InternalError,
     InvalidProjectError,
+    RPDKBaseException,
     SpecValidationError,
 )
 from .fragment.module_fragment_reader import _get_fragment_file
 from .jsonutils.pointer import fragment_decode, fragment_encode
 from .jsonutils.utils import traverse
 from .plugin_registry import load_plugin
+from .type_name_resolver import TypeNameResolver
+from .type_schema_loader import TypeSchemaLoader
 from .upload import Uploader
 
 LOG = logging.getLogger(__name__)
@@ -480,7 +477,9 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             except FileExistsError:
                 LOG.info("File already exists, not overwriting '%s'", path)
 
-    def generate(self, endpoint_url=None, region_name=None, target_schemas=None):
+    def generate(
+        self, endpoint_url=None, region_name=None, local_only=False, target_schemas=None
+    ):
         if self.artifact_type == ARTIFACT_TYPE_MODULE:
             return  # for Modules, the schema is already generated in cfn validate
 
@@ -533,7 +532,10 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             )
             self.overwrite(path, contents)
             self.target_info = self._load_target_info(
-                endpoint_url, region_name, target_schemas
+                endpoint_url,
+                region_name,
+                type_schemas=target_schemas,
+                local_only=local_only,
             )
 
         self._plugin.generate(self)
@@ -680,12 +682,22 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         else:
             LOG.debug("%s not found. Not writing to package.", INPUTS_FOLDER)
 
-        target_info = (
-            self.target_info
-            if self.target_info
-            else self._load_target_info(endpoint_url, region_name)
-        )
-        zip_file.writestr(TARGET_INFO_FILENAME, json.dumps(target_info, indent=4))
+        target_info = {}
+        try:
+            target_info = (
+                self.target_info
+                if self.target_info
+                else self._load_target_info(endpoint_url, region_name)
+            )
+        except RPDKBaseException as e:
+            LOG.warning("Failed to load target info, attempting local...", exc_info=e)
+            try:
+                target_info = self._load_target_info(None, None, local_only=True)
+            except RPDKBaseException as ex:
+                LOG.warning("Failed to load target info, ignoring...", exc_info=ex)
+
+        if target_info:
+            zip_file.writestr(TARGET_INFO_FILENAME, json.dumps(target_info, indent=4))
         for target_name, info in target_info.items():
             filename = "{}.json".format(
                 "-".join(s.lower() for s in target_name.split("::"))
@@ -738,6 +750,18 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             )
             return
 
+        target_names = (
+            self.target_info.keys()
+            if self.target_info
+            else {
+                target_name
+                for handler in self.schema.get("handlers", {}).values()
+                for target_name in handler.get("targetNames", [])
+            }
+            if self.artifact_type == ARTIFACT_TYPE_HOOK
+            else []
+        )
+
         LOG.debug("Removing generated docs: %s", docs_path)
         shutil.rmtree(docs_path, ignore_errors=True)
         docs_path.mkdir(exist_ok=True)
@@ -769,7 +793,11 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         )
         template = self.env.get_template(readme_template)
         contents = template.render(
-            type_name=self.type_name, schema=docs_schema, ref=ref, getatt=getatt
+            type_name=self.type_name,
+            schema=docs_schema,
+            ref=ref,
+            getatt=getatt,
+            target_names=sorted(target_names),
         )
         self.safewrite(readme_path, contents)
 
@@ -1106,105 +1134,65 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 raise DownstreamError("Error setting default version") from e
             LOG.warning("Set default version to '%s", arn)
 
-    # pylint: disable=R0912,R0914,R0915
     # flake8: noqa: C901
-    def _load_target_info(self, endpoint_url, region_name, provided_schemas=None):
+    # pylint: disable=R0914
+    def _load_target_info(
+        self, endpoint_url, region_name, type_schemas=None, local_only=False
+    ):
         if self.artifact_type != ARTIFACT_TYPE_HOOK or not self.schema:
             return {}
 
-        if provided_schemas is None:
-            provided_schemas = []
-
-        target_names = set()
-        for handler in self.schema.get("handlers", []).values():
-            for target_name in handler.get("targetNames", []):
-                target_names.add(target_name)
-
-        loader = TypeSchemaLoader.get_type_schema_loader(endpoint_url, region_name)
-
-        provided_target_info = {}
-
-        if os.path.isfile(self.target_info_path):
-            try:
-                with self.target_info_path.open("r", encoding="utf-8") as f:
-                    provided_target_info = json.load(f)
-            except json.JSONDecodeError as e:  # pragma: no cover
-                self._raise_invalid_project(
-                    f"Target info file '{self.target_info_path}' is invalid", e
-                )
+        if type_schemas is None:
+            type_schemas = []
 
         if os.path.isdir(self.target_schemas_path):
             for filename in os.listdir(self.target_schemas_path):
                 absolute_path = self.target_schemas_path / filename
-                if absolute_path.is_file() and absolute_path.match(
-                    "*.json"
-                ):  # pragma: no cover
-                    provided_schemas.append(str(absolute_path))
+                if absolute_path.is_file() and absolute_path.match("*.json"):
+                    type_schemas.append(str(absolute_path))
 
-        loaded_schemas = {}
-        for provided_schema in provided_schemas:
-            loaded_schema = loader.load_type_schema(provided_schema)
-            if not loaded_schema:
-                continue
+        local_info = {}
+        if os.path.isfile(self.target_info_path):
+            try:
+                with self.target_info_path.open("r", encoding="utf-8") as f:
+                    local_info = json.load(f)
+            except json.JSONDecodeError as e:
+                self._raise_invalid_project(
+                    f"Target info file '{self.target_info_path}' is invalid", e
+                )
 
-            if isinstance(loaded_schema, dict):
-                type_schemas = (loaded_schema,)
-            else:
-                type_schemas = loaded_schema
+        target_names = {
+            target_name
+            for handler in self.schema.get("handlers", {}).values()
+            for target_name in handler.get("targetNames", [])
+        }
 
-            for type_schema in type_schemas:
-                try:
-                    type_name = type_schema["typeName"]
-                    if type_name in loaded_schemas:
-                        raise InvalidProjectError(
-                            "Duplicate schemas for '{}' target type.".format(type_name)
-                        )
+        LOG.debug("Hook schema target names: %s", str(target_names))
 
-                    loaded_schemas[type_name] = type_schema
-                except (KeyError, TypeError) as e:
-                    LOG.warning(
-                        "Error while loading a provided schema: %s",
-                        provided_schema,
-                        exc_info=e,
-                    )
+        if local_only:
+            targets = TypeNameResolver.resolve_type_names_locally(
+                target_names, local_info
+            )
+            loader = TypeSchemaLoader(None, None, local_only=local_only)
+        else:
+            session = create_sdk_session(region_name)
+            cfn_client = session.client("cloudformation", endpoint_url=endpoint_url)
+            s3_client = session.client("s3")
 
-        validator = make_resource_validator()
+            targets = TypeNameResolver(cfn_client).resolve_type_names(target_names)
+            loader = TypeSchemaLoader(cfn_client, s3_client, local_only=local_only)
 
-        target_info = {}
-        for target_name in target_names:
-            type_info = provided_target_info.get(target_name) or {}
-            if target_name in loaded_schemas:
-                target_schema = loaded_schemas[target_name]
-                target_type = "RESOURCE"
-                provisioning_type = type_info.get(
-                    "ProvisioningType"
-                ) or loader.get_provision_type(target_name, "RESOURCE")
-            else:
-                (
-                    target_schema,
-                    target_type,
-                    provisioning_type,
-                ) = loader.load_schema_from_cfn_registry(target_name, "RESOURCE")
+        LOG.debug("Retrieving info for following target names: %s", str(targets))
 
-            is_registry_type = bool(
-                provisioning_type and provisioning_type != "NON_PROVISIONABLE"
+        type_info = loader.load_type_info(
+            targets, local_schemas=type_schemas, local_info=local_info
+        )
+
+        missing_targets = {target for target in targets if target not in type_info}
+
+        if missing_targets:
+            raise InvalidProjectError(
+                f"Type info missing for the following targets: {missing_targets}"
             )
 
-            if is_registry_type:  # pragma: no cover
-                try:
-                    validator.validate(target_schema)
-                except (SpecValidationError, ValidationError) as e:
-                    self._raise_invalid_project(
-                        f"Target schema for '{target_name}' is invalid: " + str(e), e
-                    )
-
-            target_info[target_name] = {
-                "TargetName": target_name,
-                "TargetType": target_type,
-                "Schema": target_schema,
-                "ProvisioningType": provisioning_type,
-                "IsCfnRegistrySupportedType": is_registry_type,
-                "SchemaFileAvailable": bool(target_schema),
-            }
-
-        return target_info
+        return type_info

--- a/src/rpdk/core/templates/hook-docs-readme.md
+++ b/src/rpdk/core/templates/hook-docs-readme.md
@@ -66,6 +66,15 @@ _Maximum Length_: <code>{{ prop.maxLength }}</code>
 {% endif %}
 
 ---
+
+## Targets
+
+{% for target_name in target_names %}
+* `{{ target_name }}`
+{% endfor %}
+
+---
+
 <p id="footnote-1"><i> Please note that the enum values for <a href="https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/hooks-structure.html#hooks-targetstacks" title="TargetStacks">
 TargetStacks</a> and <a href="https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/hooks-structure.html#hooks-failuremode" title="FailureMode">FailureMode</a>
 might go out of date, please refer to their official documentation page for up-to-date values. </i></p>

--- a/src/rpdk/core/type_name_resolver.py
+++ b/src/rpdk/core/type_name_resolver.py
@@ -1,0 +1,136 @@
+import fnmatch
+import logging
+import os
+
+from botocore.exceptions import ClientError
+
+from .exceptions import DownstreamError, InvalidTypeSchemaError
+
+LOG = logging.getLogger(__name__)
+
+REGISTRY_RESOURCE_TYPE = "RESOURCE"
+REGISTRY_DEPRECATED_STATUS_LIVE = "LIVE"
+REGISTRY_VISIBILITY_PRIVATE = "PRIVATE"
+REGISTRY_VISIBILITY_PUBLIC = "PUBLIC"
+REGISTRY_RESULTS_PAGE_SIZE = 100
+
+
+def contains_wildcard(pattern):
+    return pattern and ("*" in pattern or "?" in pattern)
+
+
+class TypeNameResolver:
+    def __init__(self, cfn_client):
+        self.cfn_client = cfn_client
+
+    def resolve_type_names(self, type_names):
+        LOG.debug("Resolving the following type names: %s", str(type_names))
+
+        if not any(contains_wildcard(tn) for tn in type_names):
+            return type_names
+
+        req = self._create_list_types_request(type_names)
+
+        return self._resolve_types(type_names, self.list_applicable_types(**req).keys())
+
+    @staticmethod
+    def resolve_type_names_locally(type_names, local_info):
+        LOG.debug("Resolving the following type names: %s", str(type_names))
+
+        if not local_info:
+            raise InvalidTypeSchemaError(
+                "Type info must be provided for local resolving"
+            )
+
+        return TypeNameResolver._resolve_types(type_names, local_info.keys())
+
+    @staticmethod
+    def _resolve_types(type_names, applicable_types):
+        types = set()
+        for type_name in type_names:
+            if type_name == "*":
+                resolved_type_names = applicable_types
+            elif contains_wildcard(type_name):
+                resolved_type_names = fnmatch.filter(applicable_types, type_name)
+            else:
+                resolved_type_names = [type_name]
+
+            LOG.debug(
+                "'%s' resolved to the following types: %s",
+                type_name,
+                str(resolved_type_names),
+            )
+            types.update(resolved_type_names)
+
+        return sorted(types)
+
+    def list_applicable_types(self, **kwargs):
+        kwargs["Type"] = REGISTRY_RESOURCE_TYPE
+        kwargs["DeprecatedStatus"] = REGISTRY_DEPRECATED_STATUS_LIVE
+        kwargs["MaxResults"] = REGISTRY_RESULTS_PAGE_SIZE
+
+        return {
+            **self._list_public_types(**kwargs),
+            **self._list_private_types(**kwargs),
+        }
+
+    def _list_private_types(self, **kwargs):
+        kwargs["Visibility"] = REGISTRY_VISIBILITY_PRIVATE
+
+        return self.list_types(**kwargs)
+
+    def _list_public_types(self, **kwargs):
+        kwargs["Visibility"] = REGISTRY_VISIBILITY_PUBLIC
+
+        return self.list_types(**kwargs)
+
+    def list_types(self, **kwargs):
+        kwargs["PaginationConfig"] = {"PageSize": REGISTRY_RESULTS_PAGE_SIZE}
+
+        try:
+            paginator = self.cfn_client.get_paginator("list_types")
+
+            types = {}
+            for page in paginator.paginate(**kwargs):
+                types.update(
+                    {
+                        type_summary["TypeName"]: type_summary
+                        for type_summary in page["TypeSummaries"]
+                        if self._type_enabled(type_summary, kwargs)
+                    }
+                )
+
+            return types
+        except ClientError as e:
+            LOG.debug("Listing types resulted in unknown ClientError", exc_info=e)
+            raise DownstreamError("Unknown CloudFormation error") from e
+
+    @staticmethod
+    def _create_list_types_request(type_names):
+        prefix = os.path.commonprefix(list(type_names))
+        if not prefix:
+            return {}
+
+        if contains_wildcard(prefix):
+            index = len(prefix)
+            if "*" in prefix:
+                index = min(index, prefix.index("*"))
+            if "?" in prefix:
+                index = min(index, prefix.index("?"))
+            prefix = prefix[:index]
+
+        req = {}
+        if prefix:
+            req["Filters"] = {"TypeNamePrefix": prefix}
+
+        return req
+
+    @staticmethod
+    def _type_enabled(type_summary, request):
+        if (
+            request["Visibility"] == REGISTRY_VISIBILITY_PRIVATE
+            or "PublisherId" not in type_summary
+        ):
+            return True
+
+        return type_summary.get("IsActivated")

--- a/src/rpdk/core/type_schema_loader.py
+++ b/src/rpdk/core/type_schema_loader.py
@@ -1,3 +1,4 @@
+import collections.abc
 import json
 import logging
 import os
@@ -6,12 +7,17 @@ from urllib.parse import urlparse
 
 import requests
 from botocore.exceptions import ClientError
+from requests.exceptions import RequestException
 
-from .boto_helpers import create_sdk_session
-from .exceptions import RPDKBaseException
+from .exceptions import DownstreamError, InvalidTypeSchemaError
 
 LOG = logging.getLogger(__name__)
 
+REGISTRY_RESOURCE_TYPE = "RESOURCE"
+REGISTRY_DEPRECATED_STATUS_LIVE = "LIVE"
+REGISTRY_VISIBILITY_PRIVATE = "PRIVATE"
+REGISTRY_VISIBILITY_PUBLIC = "PUBLIC"
+REGISTRY_RESULTS_PAGE_SIZE = 100
 VALID_TYPE_SCHEMA_URI_REGEX = "^(https?|file|s3)://.+$"
 
 
@@ -33,122 +39,211 @@ class TypeSchemaLoader:
         * Calls CFN DescribeType API to retrieve the schema
     """
 
-    @staticmethod
-    def get_type_schema_loader(endpoint_url=None, region_name=None):
-        cfn_client = None
-        s3_client = None
-        try:
-            session = create_sdk_session(region_name)
-            cfn_client = session.client("cloudformation", endpoint_url=endpoint_url)
-            s3_client = session.client("s3", endpoint_url=endpoint_url)
-        except RPDKBaseException as err:  # pragma: no cover
-            LOG.debug("Type schema loader setup resulted in error", exc_info=err)
-
-        return TypeSchemaLoader(cfn_client, s3_client)
-
-    def __init__(self, cfn_client, s3_client):
+    def __init__(self, cfn_client, s3_client, local_only=False):
         self.cfn_client = cfn_client
         self.s3_client = s3_client
+        self.local_only = local_only
 
-    def load_type_schema(self, provided_schema, default_schema=None):
-        if not provided_schema:
-            return default_schema
+    def load_type_info(self, type_names, local_schemas=None, local_info=None):
+        if local_info is None:
+            local_info = {}
 
-        if provided_schema.startswith("{") and provided_schema.endswith("}"):
-            type_schema = self.load_type_schema_from_json(
-                provided_schema, default_schema
-            )
-        elif provided_schema.startswith("[") and provided_schema.endswith("]"):
-            type_schema = self.load_type_schema_from_json(
-                provided_schema, default_schema
-            )
-        elif os.path.isfile(provided_schema):
-            type_schema = self.load_type_schema_from_file(
-                provided_schema, default_schema
-            )
-        elif is_valid_type_schema_uri(provided_schema):
-            type_schema = self.load_type_schema_from_uri(
-                provided_schema, default_schema
-            )
+        schemas = self._validate_and_load_local_schemas(local_schemas)
+
+        type_info = {}
+        for type_name in type_names:
+            LOG.debug("Retrieving info for type: %s", type_name)
+
+            target_info = {
+                "TypeName": type_name,
+                "TargetName": type_name,
+                "TargetType": REGISTRY_RESOURCE_TYPE,
+            }
+
+            if type_name in schemas or type_name in local_info:
+                LOG.warning(
+                    "Loading type info for %s from provided local info", type_name
+                )
+                if type_name in schemas and type_name in local_info:
+                    target_info.update(local_info[type_name])
+                    if "Schema" in target_info:
+                        if target_info["Schema"] != schemas[type_name]:
+                            raise InvalidTypeSchemaError(
+                                f"Duplicate conflicting schemas for '{type_name}' target type in 'target-info.json' "
+                                f"file and 'target-schemas' directory. "
+                            )
+                    else:
+                        target_info["Schema"] = schemas[type_name]
+                else:
+                    if type_name in local_info:
+                        target_info.update(local_info[type_name])
+                    else:
+                        target_info["Schema"] = schemas[type_name]
+
+                if "Schema" not in target_info or not target_info.get("Schema"):
+                    raise InvalidTypeSchemaError(
+                        f"No local schema provided for '{type_name}' target type."
+                    )
+            elif self.local_only:
+                LOG.warning(
+                    "Attempting to load local type info %s with incorrect configuration. Local target schema file or "
+                    "'target-info.json' are required to load local target info",
+                    type_name,
+                )
+                raise InvalidTypeSchemaError(
+                    "Local type schema or 'target-info.json' are required to load local type info"
+                )
+            else:
+                target_info.update(
+                    self.describe_type(TypeName=type_name, Type=REGISTRY_RESOURCE_TYPE)
+                )
+
+            target_info[
+                "IsCfnRegistrySupportedType"
+            ] = True  # For backwards compatibility
+            target_info["SchemaFileAvailable"] = bool(target_info.get("Schema"))
+
+            type_info[type_name] = target_info
+
+        return type_info
+
+    def load_type_schemas(self, schemas=None):
+        if not schemas:
+            schemas = []
+
+        type_schemas = {}
+        for schema in schemas:
+            loaded_type_schema = self.load_type_schema(schema)
+
+            if isinstance(loaded_type_schema, collections.abc.Mapping):
+                loaded_schemas = [loaded_type_schema]
+            else:
+                loaded_schemas = loaded_type_schema
+
+            for loaded_schema in loaded_schemas:
+                try:
+                    type_name = loaded_schema["typeName"]
+                    if (
+                        type_name in type_schemas
+                        and loaded_schema != type_schemas[type_name]
+                    ):
+                        raise InvalidTypeSchemaError(
+                            f"Duplicate schemas for '{type_name}' target type."
+                        )
+
+                    type_schemas[type_name] = loaded_schema
+                except (KeyError, TypeError) as e:
+                    LOG.warning(
+                        "Error while loading a provided schema: %s", schema, exc_info=e
+                    )
+                    raise InvalidTypeSchemaError(
+                        "Unknown error while loading type schema"
+                    ) from e
+
+        return type_schemas
+
+    def load_type_schema(self, type_schema):
+        if isinstance(type_schema, collections.abc.Mapping):
+            schema = type_schema
+        elif self._is_json(type_schema):
+            schema = self.load_type_schema_from_json(type_schema)
+        elif os.path.isfile(type_schema):
+            schema = self.load_type_schema_from_file(type_schema)
+        elif is_valid_type_schema_uri(type_schema):
+            schema = self.load_type_schema_from_uri(type_schema)
         else:
-            type_schema = default_schema
+            raise InvalidTypeSchemaError(
+                f"Provided schema is invalid or not supported: {type_schema}"
+            )
 
-        return type_schema
+        return schema
+
+    def _validate_and_load_local_schemas(self, local_schemas):
+        if local_schemas is None:
+            schemas = {}
+        elif isinstance(local_schemas, collections.abc.Mapping):
+            schemas = local_schemas
+        elif isinstance(local_schemas, (str, bytes, bytearray)):
+            schemas = self.load_type_schemas(
+                [
+                    local_schemas
+                    if isinstance(local_schemas, str)
+                    else str(local_schemas, "utf-8")
+                ]
+            )
+        elif isinstance(local_schemas, collections.abc.Collection):
+            schemas = self.load_type_schemas(local_schemas)
+        else:
+            raise InvalidTypeSchemaError(
+                "Local Schemas must be either list of schemas to load or mapping of type names to schemas"
+            )
+
+        return schemas
 
     @staticmethod
-    def load_type_schema_from_json(schema_json, default_schema=None):
-        if not schema_json:
-            return default_schema
-
+    def load_type_schema_from_json(schema_json):
         try:
             return json.loads(schema_json)
-        except json.JSONDecodeError:
-            LOG.debug(
-                "Provided schema is not valid JSON. Falling back to default schema."
-            )
-            return default_schema
+        except json.JSONDecodeError as e:
+            LOG.debug("Provided schema is not valid JSON", exc_info=e)
+            raise InvalidTypeSchemaError("Schema is not valid JSON") from e
 
-    def load_type_schema_from_uri(self, schema_uri, default_schema=None):
+    def load_type_schema_from_uri(self, schema_uri):
+        LOG.info("Loading schema from URI: %s", schema_uri)
         if not is_valid_type_schema_uri(schema_uri):
-            return default_schema
+            raise InvalidTypeSchemaError(
+                f"URI provided {schema_uri} is not supported or invalid."
+            )
 
         uri = urlparse(schema_uri)
+        if self.local_only and uri.scheme != "file":
+            raise InvalidTypeSchemaError(f"URI provided is not local: {schema_uri}")
+
         if uri.scheme == "file":
-            type_schema = self.load_type_schema_from_file(uri.path, default_schema)
+            type_schema = self.load_type_schema_from_file(uri.path)
         elif uri.scheme == "https":
-            type_schema = self._get_type_schema_from_url(uri.geturl(), default_schema)
+            type_schema = self._get_type_schema_from_url(uri.geturl())
         elif uri.scheme == "s3":
             bucket = uri.netloc
             key = uri.path.lstrip("/")
-            type_schema = self._get_type_schema_from_s3(bucket, key, default_schema)
-        else:
+            type_schema = self._get_type_schema_from_s3(bucket, key)
+        else:  # pragma: no cover
             LOG.debug(
-                "URI provided '%s' is not supported. Falling back to default schema",
+                "URI provided '%s' is not supported or invalid",
                 schema_uri,
             )
-            type_schema = default_schema
+            raise InvalidTypeSchemaError(
+                f"URI provided {schema_uri} is not supported or invalid."
+            )
 
         return type_schema
 
     @staticmethod
-    def load_type_schema_from_file(schema_path, default_schema=None):
-        if not schema_path:
-            return default_schema
-
+    def load_type_schema_from_file(schema_path):
         try:
             with open(schema_path, "r") as file:
                 return TypeSchemaLoader.load_type_schema_from_json(file.read())
-        except FileNotFoundError:
-            LOG.debug(
-                "Target schema file '%s' not found. Falling back to default schema.",
-                schema_path,
-            )
-            return default_schema
+        except FileNotFoundError as e:
+            LOG.debug("Target schema file '%s' not found", schema_path, exc_info=e)
+            raise InvalidTypeSchemaError(
+                f"Target schema file '{schema_path}' not found"
+            ) from e
 
     @staticmethod
-    def _get_type_schema_from_url(url, default_schema=None):
-        response = requests.get(url, timeout=60)
-        if response.status_code == 200:
-            type_schema = TypeSchemaLoader.load_type_schema_from_json(
+    def _get_type_schema_from_url(url):
+        try:
+            response = requests.get(url, timeout=60)
+            if response.status_code != 200:
+                response.raise_for_status()
+
+            return TypeSchemaLoader.load_type_schema_from_json(
                 response.content.decode("utf-8")
             )
-        else:
-            LOG.debug(
-                "Received status code of '%s' when calling url '%s.'",
-                str(response.status_code),
-                url,
-            )
-            LOG.debug("Falling back to default schema.")
-            type_schema = default_schema
+        except RequestException as e:
+            LOG.debug("Unknown error when calling url '%s'", url, exc_info=e)
+            raise DownstreamError("Unknown error while making HTTP request") from e
 
-        return type_schema
-
-    def _get_type_schema_from_s3(self, bucket, key, default_schema=None):
-        if self.s3_client is None:  # pragma: no cover
-            LOG.debug("S3 client is not set up")
-            LOG.debug("Falling back to default schema")
-            return default_schema
-
+    def _get_type_schema_from_s3(self, bucket, key):
         try:
             type_schema = (
                 self.s3_client.get_object(Bucket=bucket, Key=key)["Body"]
@@ -163,48 +258,34 @@ class TypeSchemaLoader:
                 key,
                 exc_info=err,
             )
-            LOG.debug("Falling back to default schema")
-            return default_schema
+            raise DownstreamError("Error getting S3 object from bucket") from err
 
-    def load_schema_from_cfn_registry(
-        self, type_name, extension_type, default_schema=None
-    ):
-        if self.cfn_client is None:  # pragma: no cover
-            LOG.debug("CloudFormation client is not set up")
-            LOG.debug("Falling back to default schema for type '%s'", type_name)
-            return default_schema, None, None
+    def load_schema_from_cfn_registry(self, type_name, extension_type):
+        return self.describe_type(TypeName=type_name, Type=extension_type)["Schema"]
 
+    def describe_type(self, **kwargs):
         try:
-            response = self.cfn_client.describe_type(
-                Type=extension_type, TypeName=type_name
-            )
-            return (
-                self.load_type_schema_from_json(response["Schema"]),
-                response["Type"],
-                response["ProvisioningType"],
-            )
-        except ClientError as err:
-            LOG.debug(
-                "Describing type '%s' resulted in unknown ClientError",
-                type_name,
-                exc_info=err,
-            )
-            LOG.debug("Falling back to default schema for type '%s'", type_name)
-            return default_schema, None, None
+            res = self.cfn_client.describe_type(**kwargs)
 
-    def get_provision_type(self, type_name, extension_type):
-        if self.cfn_client is None:  # pragma: no cover
-            LOG.debug("CloudFormation client is not set up")
-            return None
-
-        try:
-            return self.cfn_client.describe_type(
-                Type=extension_type, TypeName=type_name
-            )["ProvisioningType"]
-        except ClientError as err:
-            LOG.debug(
-                "Describing type '%s' resulted in unknown ClientError",
-                type_name,
-                exc_info=err,
+            res.pop("LastUpdated", None)
+            res.pop("TimeCreated", None)
+            res.pop("ResponseMetadata", None)
+            res["Schema"] = (
+                json.loads(res["Schema"])
+                if not isinstance(res["Schema"], dict)
+                else res["Schema"]
             )
-            return None
+
+            return res
+        except ClientError as e:
+            LOG.debug("Describing type resulted in unknown ClientError", exc_info=e)
+            raise DownstreamError("Unknown CloudFormation error") from e
+
+    @staticmethod
+    def _is_json(data):
+        if not isinstance(data, (str, bytes, bytearray)):
+            return False
+        data = data if isinstance(data, str) else str(data, "utf-8")
+        return (data.startswith("{") and data.endswith("}")) or (
+            data.startswith("[") and data.endswith("]")
+        )

--- a/tests/contract/test_hook_client.py
+++ b/tests/contract/test_hook_client.py
@@ -86,7 +86,7 @@ HOOK_TARGET_INFO = {
                 }
             },
         },
-        "ProvisioningType": "FULLY_MUTTABLE",
+        "ProvisioningType": "FULLY_MUTABLE",
         "IsCfnRegistrySupportedType": True,
         "SchemaFileAvailable": True,
     }
@@ -303,6 +303,46 @@ def test_get_handler_target(hook_client):
         HookInvocationPoint.CREATE_PRE_PROVISION
     )
     TestCase().assertCountEqual(target_names, targets)
+
+
+def test_get_handler_target_multiple_targets(hook_client):
+    targets = ["AWS::ExampleResource", "AWS::S3::Bucket", "AWS::S3::BucketPolicy"]
+    schema = {
+        "handlers": {
+            "preCreate": {
+                "targetNames": ["AWS::ExampleResource", "AWS::S?::Bucket*"],
+                "permissions": [],
+            },
+            "preUpdate": {"targetNames": ["AWS::S?::Bucket*"], "permissions": []},
+        }
+    }
+    hook_client._update_schema(schema)
+
+    hook_target_info = {
+        target: {
+            "Schema": {
+                "typeName": targets,
+                "description": "test schema",
+                "properties": {"foo": {"type": "string"}},
+                "primaryIdentifier": ["/properties/foo"],
+                "readOnlyProperties": ["/properties/foo"],
+                "additionalProperties": False,
+            }
+        }
+        for target in targets
+    }
+    hook_client._target_info = HookClient._setup_target_info(hook_target_info)
+
+    target_names = hook_client.get_handler_targets(
+        HookInvocationPoint.CREATE_PRE_PROVISION
+    )
+    TestCase().assertCountEqual(target_names, targets)
+    target_names = hook_client.get_handler_targets(
+        HookInvocationPoint.UPDATE_PRE_PROVISION
+    )
+    TestCase().assertCountEqual(
+        target_names, ["AWS::S3::Bucket", "AWS::S3::BucketPolicy"]
+    )
 
 
 def test_get_handler_target_no_targets(hook_client):
@@ -1075,3 +1115,24 @@ def test_generate_invalid_target_model_inputs(hook_client_inputs):
     assert hook_client_inputs._generate_target_model(
         "My::Example::Resource", "INVALID"
     ) == {"resourceProperties": {"b": 1}}
+
+
+@pytest.mark.parametrize(
+    "invoke_point,expected",
+    [
+        (HookInvocationPoint.CREATE_PRE_PROVISION, True),
+        (HookInvocationPoint.UPDATE_PRE_PROVISION, False),
+        (HookInvocationPoint.DELETE_PRE_PROVISION, True),
+    ],
+)
+def test_handler_has_wildcard(hook_client, invoke_point, expected):
+    hook_client._schema["handlers"] = {
+        "preCreate": {"targetNames": ["AWS::*::Resource"], "permissions": []},
+        "preUpdate": {
+            "targetNames": ["AWS::Service::TargetResource"],
+            "permissions": [],
+        },
+        "preDelete": {"targetNames": ["AWS::Cloud*", "AWS::S3::Bucket"]},
+    }
+
+    assert hook_client.handler_has_wildcard_targets(invoke_point) == expected

--- a/tests/contract/test_interface.py
+++ b/tests/contract/test_interface.py
@@ -1,6 +1,7 @@
 # fixture and parameter have the same name
 # pylint: disable=redefined-outer-name
 import json
+import sys
 
 import boto3
 import pytest
@@ -25,6 +26,9 @@ def test_operation_status_enum_matches_sdk(client):
 
 
 def test_handler_error_code_enum_matches_sdk(client):
+    if sys.version_info < (3, 7):
+        return
+
     sdk = set(client.meta.service_model.shape_for("HandlerErrorCode").enum)
     enum = set(HandlerErrorCode.__members__)
     assert enum == sdk

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -226,6 +226,25 @@ def test_load_resource_spec_remote_key_is_invalid():
     assert "remote" in str(excinfo.value)
 
 
+def test_load_hook_spec_invalid():
+    schema = {
+        "typeName": "AWS::FOO::BAR",
+        "description": "test schema",
+        "typeConfiguration": {
+            "properties": {"foo": {"type": "string"}},
+            "additionalProperties": False,
+        },
+        "handlers": {
+            "midCreate": {"targetNames": ["AWS::S3::Bucket"], "permissions": []}
+        },
+        "additionalProperties": False,
+    }
+    with pytest.raises(SpecValidationError) as excinfo:
+        load_hook_spec(json_s(schema))
+    assert "Additional properties are not allowed" in str(excinfo.value)
+    assert "midCreate" in str(excinfo.value)
+
+
 @pytest.mark.parametrize(
     "permission", ("cloudformation:RegisterType", "cloudformation:*")
 )
@@ -360,6 +379,40 @@ def test_load_resource_spec_without_array_type_valid():
     }
     result = load_resource_spec(json_s(schema))
     assert result == schema
+
+
+def test_load_hook_spec_properties_key_is_invalid():
+    schema = {
+        "typeName": "AWS::FOO::BAR",
+        "description": "test schema",
+        "typeConfiguration": {
+            "properties": {},
+            "additionalProperties": False,
+        },
+        "properties": {"foo": {"type": "string"}},
+        "additionalProperties": False,
+    }
+    with pytest.raises(SpecValidationError) as excinfo:
+        load_hook_spec(json_s(schema))
+    assert "properties" in str(excinfo.value)
+
+
+def test_load_hook_spec_hook_target_name_pattern_invalid():
+    schema = {
+        "typeName": "AWS::FOO::BAR",
+        "description": "test schema",
+        "typeConfiguration": {
+            "properties": {"foo": {"type": "string"}},
+            "additionalProperties": False,
+        },
+        "handlers": {
+            "preCreate": {"targetNames": ["AWS::S3::Bu*?ket"], "permissions": []}
+        },
+        "additionalProperties": False,
+    }
+    with pytest.raises(SpecValidationError) as excinfo:
+        load_hook_spec(json_s(schema))
+    assert "Wildcard pattern '*?' is not allowed in target name" in str(excinfo.value)
 
 
 def test_argparse_stdin_name():

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -12,7 +12,7 @@ def test_generate_command_generate(capsys):
         main(args_in=["generate"])
 
     mock_project.load.assert_called_once_with()
-    mock_project.generate.assert_called_once_with(None, None, [])
+    mock_project.generate.assert_called_once_with(None, None, False, [])
     mock_project.generate_docs.assert_called_once_with()
 
     out, err = capsys.readouterr()
@@ -42,6 +42,7 @@ def test_generate_command_generate_with_args(capsys):
     mock_project.generate.assert_called_once_with(
         "http://localhost/3001",
         "us-east-1",
+        False,
         ["/files/target-schema.json", "/files/other-target-schema"],
     )
     mock_project.generate_docs.assert_called_once_with()

--- a/tests/test_type_name_resolver.py
+++ b/tests/test_type_name_resolver.py
@@ -1,0 +1,251 @@
+# fixture and parameter have the same name
+# pylint: disable=redefined-outer-name,no-else-return,protected-access
+
+from unittest.mock import Mock, call, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from rpdk.core.exceptions import DownstreamError, InvalidTypeSchemaError
+from rpdk.core.type_name_resolver import TypeNameResolver
+
+
+@pytest.fixture()
+def resolver():
+    return TypeNameResolver(Mock())
+
+
+def list_types_request(visibility, filters=None):
+    req = {
+        "Type": "RESOURCE",
+        "Visibility": visibility,
+        "DeprecatedStatus": "LIVE",
+        "MaxResults": 100,
+        "PaginationConfig": {"PageSize": 100},
+    }
+    if filters:
+        req["Filters"] = filters
+
+    return req
+
+
+def list_types_result(type_names):
+    return {
+        "TypeSummaries": [
+            {
+                "Type": "RESOURCE",
+                "TypeName": type_name,
+                "TypeArn": f'arn:aws:cloudformation:us-east-1:123456789012:type/resource/{type_name.replace("::", "-")}',
+            }
+            for type_name in type_names
+        ]
+    }
+
+
+def test_resolve_type_names(resolver):
+    def list_type_return(**kwargs):
+        if kwargs["Visibility"] == "PUBLIC":
+            return [list_types_result(["AWS::S3::Bucket", "AWS::Logs::LogGroup"])]
+        else:
+            return [list_types_result(["MyCompany::Testing::Hook"])]
+
+    mock_cfn_client = Mock(spec=["get_paginator"])
+    mock_paginator = Mock(spec=["paginate"])
+    mock_cfn_client.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.side_effect = list_type_return
+
+    resolver.cfn_client = mock_cfn_client
+
+    assert [
+        "AWS::Logs::LogGroup",
+        "MyCompany::Testing::Hook",
+    ] == resolver.resolve_type_names(["AWS::*::LogGroup", "MyCompany::Testing::Hook"])
+    mock_paginator.paginate.assert_has_calls(
+        calls=[
+            call(**list_types_request("PUBLIC")),
+            call(**list_types_request("PRIVATE")),
+        ],
+        any_order=True,
+    )
+
+
+def test_resolve_type_names_multiple_wildcards(resolver):
+    def list_type_return(**kwargs):
+        if kwargs["Visibility"] == "PUBLIC":
+            return [list_types_result(["AWS::S3::Bucket", "AWS::Logs::LogGroup"])]
+        else:
+            return [list_types_result(["MyCompany::Testing::Hook"])]
+
+    mock_cfn_client = Mock(spec=["get_paginator"])
+    mock_paginator = Mock(spec=["paginate"])
+    mock_cfn_client.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.side_effect = list_type_return
+
+    resolver.cfn_client = mock_cfn_client
+
+    assert [
+        "AWS::Logs::LogGroup",
+        "AWS::S3::Bucket",
+        "MyCompany::Testing::Hook",
+    ] == resolver.resolve_type_names(["AWS::*", "MyCompany::Testing::Hook"])
+    mock_paginator.paginate.assert_has_calls(
+        calls=[
+            call(**list_types_request("PUBLIC")),
+            call(**list_types_request("PRIVATE")),
+        ],
+        any_order=True,
+    )
+
+
+def test_resolve_type_names_common_prefix(resolver):
+    def list_type_return(**kwargs):
+        if kwargs["Visibility"] == "PUBLIC":
+            return [
+                list_types_result(
+                    [
+                        "AWS::S3::Bucket",
+                        "AWS::Logs::LogGroup",
+                        "AWS::Logs::LogStream",
+                        "AWS::SQS::Queue",
+                    ]
+                )
+            ]
+        else:
+            return []
+
+    mock_cfn_client = Mock(spec=["get_paginator"])
+    mock_paginator = Mock(spec=["paginate"])
+    mock_cfn_client.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.side_effect = list_type_return
+
+    resolver.cfn_client = mock_cfn_client
+
+    assert [
+        "AWS::Logs::LogGroup",
+        "AWS::Logs::LogStream",
+        "AWS::S3::Bucket",
+    ] == resolver.resolve_type_names(["AWS::*::Log*", "AWS::S3::Bucket"])
+    mock_paginator.paginate.assert_has_calls(
+        calls=[
+            call(**list_types_request("PUBLIC", filters={"TypeNamePrefix": "AWS::"})),
+            call(**list_types_request("PRIVATE", filters={"TypeNamePrefix": "AWS::"})),
+        ],
+        any_order=True,
+    )
+
+
+def test_resolve_type_names_glob_wildcard(resolver):
+    def list_type_return(**kwargs):
+        if kwargs["Visibility"] == "PUBLIC":
+            return [list_types_result(["AWS::S3::Bucket", "AWS::Logs::LogGroup"])]
+        else:
+            return [list_types_result(["MyCompany::Testing::Hook"])]
+
+    mock_cfn_client = Mock(spec=["get_paginator"])
+    mock_paginator = Mock(spec=["paginate"])
+    mock_cfn_client.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.side_effect = list_type_return
+
+    resolver.cfn_client = mock_cfn_client
+
+    assert [
+        "AWS::Logs::LogGroup",
+        "AWS::S3::Bucket",
+        "MyCompany::Testing::Hook",
+    ] == resolver.resolve_type_names(["*"])
+    mock_paginator.paginate.assert_has_calls(
+        calls=[
+            call(**list_types_request("PUBLIC")),
+            call(**list_types_request("PRIVATE")),
+        ],
+        any_order=True,
+    )
+
+
+def test_resolve_type_names_no_wildcards(resolver):
+    mock_cfn_client = Mock(spec=["get_paginator"])
+    mock_paginator = Mock(spec=["paginate"])
+    mock_cfn_client.get_paginator.return_value = mock_paginator
+
+    # loader.cfn_client = mock_cfn_client
+
+    assert [
+        "AWS::Logs::LogGroup",
+        "MyCompany::Testing::Hook",
+    ] == resolver.resolve_type_names(
+        ["AWS::Logs::LogGroup", "MyCompany::Testing::Hook"]
+    )
+    resolver.cfn_client.get_paginator.assert_not_called()
+
+
+def test_resolve_type_names_client_error(resolver):
+    e = ClientError({"Error": {"Code": "", "Message": "Invalid request"}}, "list_types")
+
+    mock_cfn_client = Mock(spec=["get_paginator"])
+    mock_paginator = Mock(spec=["paginate"])
+    mock_cfn_client.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.side_effect = e
+
+    resolver.cfn_client = mock_cfn_client
+
+    with pytest.raises(DownstreamError) as excinfo:
+        resolver.resolve_type_names(["AWS::*::LogGroup", "MyCompany::Testing::Hook"])
+
+    assert excinfo.value.__cause__ is e
+    mock_paginator.paginate.assert_called_once()
+
+
+def test_resolve_type_names_locally(resolver):
+    local_info = {
+        "AWS::S3::Bucket": {"ProvisioningType": "FULLY_MUTABLE"},
+        "AWS::Logs::LogGroup": {"ProvisioningType": "IMMUTABLE"},
+        "AWS::Logs::LogStream": {"ProvisioningType": "NON_PROVISIONAL"},
+        "MyCompany::Test::Hook": {},
+    }
+
+    patch_list_hooks = patch.object(
+        resolver, "list_applicable_types", wraps=resolver.list_applicable_types
+    )
+
+    with patch_list_hooks as mock_list_hooks:
+        assert [
+            "AWS::Logs::LogGroup",
+            "AWS::Logs::LogStream",
+            "AWS::S3::Bucket",
+        ] == resolver.resolve_type_names_locally(
+            ["AWS::*::Log*", "AWS::S3::Bucket"], local_info
+        )
+
+    mock_list_hooks.assert_not_called()
+
+
+def test_resolve_type_names_locally_no_local_info(resolver):
+    with pytest.raises(InvalidTypeSchemaError) as excinfo:
+        resolver.resolve_type_names_locally(["AWS::*::Log*", "AWS::S3::Bucket"], None)
+
+    assert "Type info must be provided for local resolving" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "type_names,expected",
+    [
+        ([], None),
+        (["AWS::Test::Resource"], "AWS::Test::Resource"),
+        (["AWS::Test::Resource", "MyCompany::Test::Resource"], None),
+        (["AWS::S3::Bucket", "AWS::SQS::Queue"], "AWS::S"),
+        (["AWS::S3::*Bucket"], "AWS::S3::"),
+        (["AWS::S?::Bucket"], "AWS::S"),
+        (["AWS::S?::*Bucket"], "AWS::S"),
+        (["AWS::*::Log*"], "AWS::"),
+        (["A*::S?::Bucket*"], "A"),
+        (["*::S?::Bucket*"], ""),
+        (["AWS::S?::BucketPolicy", "AWS::S3::Bucket"], "AWS::S"),
+        (["AWS::S*::Queue", "AWS::DynamoDB::*"], "AWS::"),
+    ],
+)
+def test_create_list_types_request(type_names, expected):
+    req = TypeNameResolver._create_list_types_request(type_names)
+    if not expected:
+        assert not req
+    else:
+        assert req == {"Filters": {"TypeNamePrefix": expected}}

--- a/tests/test_type_schema_loader.py
+++ b/tests/test_type_schema_loader.py
@@ -3,29 +3,36 @@
 import json
 import unittest
 from io import BytesIO
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import Mock, call, mock_open, patch
 
 import pytest
 from botocore.exceptions import ClientError
+from requests import HTTPError
 
+from rpdk.core.exceptions import DownstreamError, InvalidTypeSchemaError
 from rpdk.core.type_schema_loader import TypeSchemaLoader, is_valid_type_schema_uri
 
+
+def get_test_schema(type_name):
+    return {
+        "typeName": type_name,
+        "description": "test schema",
+        "properties": {"foo": {"type": "string"}},
+        "primaryIdentifier": ["/properties/foo"],
+        "additionalProperties": False,
+    }
+
+
 TEST_TARGET_TYPE_NAME = "AWS::Test::Target"
-TEST_TARGET_SCHEMA = {
-    "typeName": TEST_TARGET_TYPE_NAME,
-    "additionalProperties": False,
-    "properties": {},
-    "required": [],
-}
+TEST_TARGET_SCHEMA = get_test_schema(TEST_TARGET_TYPE_NAME)
 TEST_TARGET_SCHEMA_JSON = json.dumps(TEST_TARGET_SCHEMA)
 TEST_TARGET_SCHEMA_JSON_ARRAY = json.dumps([TEST_TARGET_SCHEMA])
-OTHER_TEST_TARGET_FALLBACK_SCHEMA = {
-    "typeName": "AWS::Test::Backup",
-    "additionalProperties": False,
-    "properties": {},
-    "required": [],
-}
-OTHER_TEST_TARGET_FALLBACK_SCHEMA_JSON = json.dumps(OTHER_TEST_TARGET_FALLBACK_SCHEMA)
+MULTIPLE_TEST_TARGET_SCHEMAS = [
+    get_test_schema("AWS::Other::Target"),
+    get_test_schema("MyCompany::Test::Target"),
+    get_test_schema("Another::Test::Target"),
+]
+MULTIPLE_TEST_TARGET_SCHEMAS_JSON = json.dumps(MULTIPLE_TEST_TARGET_SCHEMAS)
 
 TEST_TARGET_SCHEMA_BUCKET = "TestTargetSchemaBucket"
 TEST_TARGET_SCHEMA_KEY = "test-target-schema.json"
@@ -44,10 +51,453 @@ def assert_dict_equals(d1, d2):
     unittest.TestCase().assertDictEqual(d1, d2)
 
 
+def get_test_type_info(type_name, visibility, provisioning_type):
+    return {
+        "TypeName": type_name,
+        "TargetName": type_name,
+        "TargetType": "RESOURCE",
+        "Type": "RESOURCE",
+        "Arn": f'arn:aws:cloudformation:us-east-1:12345678902:type:resource:{type_name.replace("::", "-")}',
+        "IsDefaultVersion": True,
+        "Description": "Test Schema",
+        "ProvisioningType": provisioning_type,
+        "DeprecatedStatus": "LIVE",
+        "Visibility": visibility,
+        "Schema": get_test_schema(type_name),
+    }
+
+
+def describe_type_result(type_name, visibility, provisioning_type):
+    return {
+        "Arn": f'arn:aws:cloudformation:us-east-1:12345678902:type:resource:{type_name.replace("::", "-")}',
+        "Type": "RESOURCE",
+        "TypeName": type_name,
+        "IsDefaultVersion": True,
+        "Description": "Test Schema",
+        "ProvisioningType": provisioning_type,
+        "DeprecatedStatus": "LIVE",
+        "Visibility": visibility,
+        "Schema": json.dumps(get_test_schema(type_name)),
+    }
+
+
 @pytest.fixture
 def loader():
+    return TypeSchemaLoader(Mock(), Mock())
+
+
+@pytest.fixture
+def local_loader():
+    return TypeSchemaLoader(Mock(), Mock(), local_only=True)
+
+
+def test_load_type_info(loader):
+    remote_types = {
+        t[0]: t
+        for t in [
+            ("AWS::Test::Target", "PUBLIC", "FULLY_MUTABLE"),
+            ("AWS::Other::Target", "PRIVATE", "IMMUTABLE"),
+            ("MyCompany::Test::Target", "PUBLIC", "NON_PROVISIONABLE"),
+            ("Another::Test::Target", "PUBLIC", "IMMUTABLE"),
+        ]
+    }
+    local_types = {
+        t[0]: t
+        for t in [
+            ("MyFile::Hook::Target", "PRIVATE", "NON_PROVISIONABLE"),
+            ("MyHttp::Hook::Target", "PUBLIC", "NON_PROVISIONABLE"),
+            ("MyS3::Hook::Target", "PUBLIC", "IMMUTABLE"),
+        ]
+    }
+
+    local_info = {
+        type_name: get_test_type_info(type_name, visibility, provisioning_type)
+        for type_name, visibility, provisioning_type in local_types.values()
+    }
+    loaded_schemas = {
+        target["TypeName"]: target["Schema"] for target in local_info.values()
+    }
+
+    local_info["MyFile::Hook::Target"].pop("Schema")
+
+    test_types = {**remote_types, **local_types}
+
+    def mock_describe_type(**kwargs):
+        type_name, visibility, provisioning_type = test_types[kwargs["TypeName"]]
+        return describe_type_result(type_name, visibility, provisioning_type)
+
+    loader.cfn_client.describe_type.side_effect = mock_describe_type
+
+    type_info = loader.load_type_info(test_types.keys(), loaded_schemas, local_info)
+
+    expected = {
+        type_name: {
+            **get_test_type_info(type_name, visibility, provisioning_type),
+            "IsCfnRegistrySupportedType": True,
+            "SchemaFileAvailable": True,
+        }
+        for type_name, visibility, provisioning_type in test_types.values()
+    }
+
+    assert type_info == expected
+    loader.cfn_client.describe_type.assert_has_calls(
+        calls=[
+            call(TypeName="AWS::Test::Target", Type="RESOURCE"),
+            call(TypeName="AWS::Other::Target", Type="RESOURCE"),
+            call(TypeName="MyCompany::Test::Target", Type="RESOURCE"),
+            call(TypeName="Another::Test::Target", Type="RESOURCE"),
+        ],
+        any_order=True,
+    )
+
+
+def test_load_remote_type_info(loader):
+    test_types = {
+        t[0]: t
+        for t in [
+            ("AWS::Test::Target", "PUBLIC", "FULLY_MUTABLE"),
+            ("AWS::Other::Target", "PRIVATE", "IMMUTABLE"),
+            ("MyCompany::Test::Target", "PUBLIC", "NON_PROVISIONABLE"),
+            ("Another::Test::Target", "PUBLIC", "IMMUTABLE"),
+        ]
+    }
+
+    def mock_describe_type(**kwargs):
+        type_name, visibility, provisioning_type = test_types[kwargs["TypeName"]]
+        return describe_type_result(type_name, visibility, provisioning_type)
+
+    loader.cfn_client.describe_type.side_effect = mock_describe_type
+
+    type_info = loader.load_type_info(test_types.keys())
+
+    expected = {
+        type_name: {
+            **get_test_type_info(type_name, visibility, provisioning_type),
+            "IsCfnRegistrySupportedType": True,
+            "SchemaFileAvailable": True,
+        }
+        for type_name, visibility, provisioning_type in test_types.values()
+    }
+
+    assert type_info == expected
+
+    loader.cfn_client.describe_type.assert_has_calls(
+        calls=[
+            call(TypeName="AWS::Test::Target", Type="RESOURCE"),
+            call(TypeName="AWS::Other::Target", Type="RESOURCE"),
+            call(TypeName="MyCompany::Test::Target", Type="RESOURCE"),
+            call(TypeName="Another::Test::Target", Type="RESOURCE"),
+        ],
+        any_order=True,
+    )
+
+
+def test_load_local_type_info(loader):
+    test_types = {
+        t[0]: t
+        for t in [
+            ("MyFile::Hook::Target", "PRIVATE", "NON_PROVISIONABLE"),
+            ("MyHttp::Hook::Target", "PUBLIC", "NON_PROVISIONABLE"),
+            ("MyS3::Hook::Target", "PUBLIC", "IMMUTABLE"),
+        ]
+    }
+
+    local_info = {
+        type_name: get_test_type_info(type_name, visibility, provisioning_type)
+        for type_name, visibility, provisioning_type in test_types.values()
+    }
+    loaded_schemas = {
+        target["TypeName"]: target["Schema"] for target in local_info.values()
+    }
+
+    def mock_describe_type(**kwargs):
+        type_name, visibility, provisioning_type = test_types[kwargs["TypeName"]]
+        return describe_type_result(type_name, visibility, provisioning_type)
+
+    loader.cfn_client.describe_type.side_effect = mock_describe_type
+
+    target_info = loader.load_type_info(test_types.keys(), loaded_schemas, local_info)
+
+    expected = {
+        type_name: {
+            **get_test_type_info(type_name, visibility, provisioning_type),
+            "IsCfnRegistrySupportedType": True,
+            "SchemaFileAvailable": True,
+        }
+        for type_name, visibility, provisioning_type in test_types.values()
+    }
+
+    assert target_info == expected
+
+    loader.cfn_client.describe_type.assert_not_called()
+
+
+def test_load_type_info_missing_info(loader):
+    remote_types = {
+        t[0]: t
+        for t in [
+            ("AWS::Test::Target", "PUBLIC", "FULLY_MUTABLE"),
+            ("AWS::Other::Target", "PRIVATE", "IMMUTABLE"),
+            ("MyCompany::Test::Target", "PUBLIC", "NON_PROVISIONABLE"),
+            ("Another::Test::Target", "PUBLIC", "IMMUTABLE"),
+        ]
+    }
+    local_types = {
+        t[0]: t
+        for t in [
+            ("MyFile::Hook::Target", "PRIVATE", "NON_PROVISIONABLE"),
+            ("MyHttp::Hook::Target", "PUBLIC", "NON_PROVISIONABLE"),
+            ("MyS3::Hook::Target", "PUBLIC", "IMMUTABLE"),
+        ]
+    }
+
+    local_info = {
+        type_name: get_test_type_info(type_name, visibility, provisioning_type)
+        for type_name, visibility, provisioning_type in local_types.values()
+    }
+    loaded_schemas = {
+        target["TypeName"]: target["Schema"] for target in local_info.values()
+    }
+
+    loaded_schemas.pop("MyFile::Hook::Target")
+
+    test_types = {**remote_types, **local_types}
+
+    def mock_describe_type(**kwargs):
+        type_name, visibility, provisioning_type = test_types[kwargs["TypeName"]]
+        return describe_type_result(type_name, visibility, provisioning_type)
+
+    loader.cfn_client.describe_type.side_effect = mock_describe_type
+
+    type_info = loader.load_type_info(test_types.keys(), loaded_schemas, local_info)
+
+    expecting = {
+        type_name: {
+            **get_test_type_info(type_name, visibility, provisioning_type),
+            "IsCfnRegistrySupportedType": True,
+            "SchemaFileAvailable": True,
+        }
+        for type_name, visibility, provisioning_type in test_types.values()
+    }
+    assert type_info == expecting
+
+
+def test_load_type_info_missing_schema(loader):
+    remote_types = {
+        t[0]: t
+        for t in [
+            ("AWS::Test::Target", "PUBLIC", "FULLY_MUTABLE"),
+            ("AWS::Other::Target", "PRIVATE", "IMMUTABLE"),
+            ("MyCompany::Test::Target", "PUBLIC", "NON_PROVISIONABLE"),
+            ("Another::Test::Target", "PUBLIC", "IMMUTABLE"),
+        ]
+    }
+    local_types = {
+        t[0]: t
+        for t in [
+            ("MyFile::Hook::Target", "PRIVATE", "NON_PROVISIONABLE"),
+            ("MyHttp::Hook::Target", "PUBLIC", "NON_PROVISIONABLE"),
+            ("MyS3::Hook::Target", "PUBLIC", "IMMUTABLE"),
+        ]
+    }
+
+    local_info = {
+        type_name: get_test_type_info(type_name, visibility, provisioning_type)
+        for type_name, visibility, provisioning_type in local_types.values()
+    }
+    loaded_schemas = {
+        target["TypeName"]: target["Schema"] for target in local_info.values()
+    }
+
+    local_info["MyFile::Hook::Target"].pop("Schema")
+    loaded_schemas.pop("MyFile::Hook::Target")
+
+    test_types = {**remote_types, **local_types}
+
+    def mock_describe_type(**kwargs):
+        type_name, visibility, provisioning_type = test_types[kwargs["TypeName"]]
+        return describe_type_result(type_name, visibility, provisioning_type)
+
+    loader.cfn_client.describe_type.side_effect = mock_describe_type
+
+    with pytest.raises(InvalidTypeSchemaError) as excinfo:
+        loader.load_type_info(test_types.keys(), loaded_schemas, local_info)
+
+    assert "No local schema provided for 'MyFile::Hook::Target' target type" in str(
+        excinfo.value
+    )
+
+
+def test_load_local_type_info_missing_info(local_loader):
+    remote_types = {
+        t[0]: t
+        for t in [
+            ("AWS::Test::Target", "PUBLIC", "FULLY_MUTABLE"),
+            ("AWS::Other::Target", "PRIVATE", "IMMUTABLE"),
+            ("MyCompany::Test::Target", "PUBLIC", "NON_PROVISIONABLE"),
+            ("Another::Test::Target", "PUBLIC", "IMMUTABLE"),
+        ]
+    }
+    local_types = {
+        t[0]: t
+        for t in [
+            ("MyFile::Hook::Target", "PRIVATE", "NON_PROVISIONABLE"),
+            ("MyHttp::Hook::Target", "PUBLIC", "NON_PROVISIONABLE"),
+            ("MyS3::Hook::Target", "PUBLIC", "IMMUTABLE"),
+        ]
+    }
+
+    local_info = {
+        type_name: get_test_type_info(type_name, visibility, provisioning_type)
+        for type_name, visibility, provisioning_type in local_types.values()
+    }
+    loaded_schemas = {
+        target["TypeName"]: target["Schema"] for target in local_info.values()
+    }
+
+    loaded_schemas.pop("MyFile::Hook::Target")
+
+    test_types = {**remote_types, **local_types}
+
+    with pytest.raises(InvalidTypeSchemaError) as excinfo:
+        local_loader.load_type_info(test_types.keys(), loaded_schemas, local_info)
+
+    assert (
+        "Local type schema or 'target-info.json' are required to load local type info"
+        in str(excinfo.value)
+    )
+
+
+def test_load_type_info_invalid_local_schemas(loader):
+    type_names = ["AWS::Test::Target", "AWS::Test::DifferentTarget"]
+    with pytest.raises(InvalidTypeSchemaError) as excinfo:
+        loader.load_type_info(type_names, local_schemas=0)
+
+    assert (
+        "Local Schemas must be either list of schemas to load or mapping of type names to schemas"
+        in str(excinfo.value)
+    )
+
+
+@pytest.mark.parametrize(
+    "local_schemas,expected_schemas",
+    [
+        (None, {}),
+        (
+            {schema["typeName"]: schema for schema in MULTIPLE_TEST_TARGET_SCHEMAS},
+            {schema["typeName"]: schema for schema in MULTIPLE_TEST_TARGET_SCHEMAS},
+        ),
+        (
+            MULTIPLE_TEST_TARGET_SCHEMAS,
+            {schema["typeName"]: schema for schema in MULTIPLE_TEST_TARGET_SCHEMAS},
+        ),
+        (
+            [json.dumps(ts) for ts in MULTIPLE_TEST_TARGET_SCHEMAS],
+            {schema["typeName"]: schema for schema in MULTIPLE_TEST_TARGET_SCHEMAS},
+        ),
+        (
+            MULTIPLE_TEST_TARGET_SCHEMAS_JSON,
+            {schema["typeName"]: schema for schema in MULTIPLE_TEST_TARGET_SCHEMAS},
+        ),
+    ],
+)
+def test_validate_and_load_local_schemas(local_schemas, expected_schemas):
     loader = TypeSchemaLoader(Mock(), Mock())
-    return loader
+    schemas = loader._validate_and_load_local_schemas(local_schemas)
+
+    assert schemas == expected_schemas
+
+
+# pylint: disable=too-many-locals
+def test_load_type_schemas(loader):
+    schemas_to_load = [
+        TEST_TARGET_SCHEMA_JSON,
+        MULTIPLE_TEST_TARGET_SCHEMAS_JSON,
+        TEST_TARGET_SCHEMA_FILE_PATH,
+        TEST_HTTPS_TARGET_SCHEMA_URI,
+        TEST_S3_TARGET_SCHEMA_URI,
+    ]
+
+    # Load from JSON
+    patch_load_json = patch.object(
+        loader, "load_type_schema_from_json", wraps=loader.load_type_schema_from_json
+    )
+
+    # Load from File
+    patch_file = patch(
+        "builtins.open",
+        mock_open(read_data=json.dumps(get_test_schema("MyFile::Hook::Target"))),
+    )
+    patch_path_is_file = patch(
+        "rpdk.core.type_schema_loader.os.path.isfile",
+        side_effect=lambda s: s == TEST_TARGET_SCHEMA_FILE_PATH,
+    )
+    patch_load_file = patch.object(
+        loader, "load_type_schema_from_file", wraps=loader.load_type_schema_from_file
+    )
+
+    # Load from HTTP Request
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.content = json.dumps(get_test_schema("MyHttp::Hook::Target")).encode(
+        "utf-8"
+    )
+    patch_get_request = patch(
+        "rpdk.core.type_schema_loader.requests.get", return_value=mock_response
+    )
+    patch_get_from_url = patch.object(
+        loader, "_get_type_schema_from_url", wraps=loader._get_type_schema_from_url
+    )
+
+    # Load from S3
+    loader.s3_client.get_object.return_value = {
+        "Body": BytesIO(
+            json.dumps(get_test_schema("MyS3::Hook::Target")).encode("utf-8")
+        )
+    }
+    patch_get_from_s3 = patch.object(
+        loader, "_get_type_schema_from_s3", wraps=loader._get_type_schema_from_s3
+    )
+
+    # Formatting check makes this line too long which causes pylint to fail
+    # pylint: disable=line-too-long
+    with patch_load_json as mock_load_json, patch_file as mock_file, patch_path_is_file as mock_path_is_file, patch_load_file as mock_load_file, patch_get_request as mock_get_request, patch_get_from_url as mock_get_from_url, patch_get_from_s3 as mock_get_from_s3:  # noqa: B950
+        schemas = loader.load_type_schemas(schemas_to_load)
+
+        mock_load_json.assert_has_calls(
+            calls=[
+                call(TEST_TARGET_SCHEMA_JSON),
+                call(MULTIPLE_TEST_TARGET_SCHEMAS_JSON),
+            ],
+            any_order=True,
+        )
+
+        mock_path_is_file.assert_any_call(TEST_TARGET_SCHEMA_FILE_PATH)
+        mock_load_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH)
+        mock_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH, "r")
+
+        mock_get_from_url.assert_called_with(TEST_HTTPS_TARGET_SCHEMA_URI)
+        mock_get_request.assert_called_with(TEST_HTTPS_TARGET_SCHEMA_URI, timeout=60)
+
+        mock_get_from_s3.assert_called_with(
+            TEST_TARGET_SCHEMA_BUCKET, TEST_TARGET_SCHEMA_KEY
+        )
+        loader.s3_client.get_object.assert_called_once_with(
+            Bucket=TEST_TARGET_SCHEMA_BUCKET, Key=TEST_TARGET_SCHEMA_KEY
+        )
+
+        assert schemas == {
+            type_name: get_test_schema(type_name)
+            for type_name in [
+                "AWS::Test::Target",
+                "AWS::Other::Target",
+                "MyCompany::Test::Target",
+                "Another::Test::Target",
+                "MyFile::Hook::Target",
+                "MyHttp::Hook::Target",
+                "MyS3::Hook::Target",
+            ]
+        }
 
 
 def test_load_type_schema_from_json(loader):
@@ -57,34 +507,17 @@ def test_load_type_schema_from_json(loader):
         type_schema = loader.load_type_schema(TEST_TARGET_SCHEMA_JSON)
 
     assert_dict_equals(TEST_TARGET_SCHEMA, type_schema)
-    mock_load_json.assert_called_with(TEST_TARGET_SCHEMA_JSON, None)
+    mock_load_json.assert_called_with(TEST_TARGET_SCHEMA_JSON)
 
 
 def test_load_type_schema_from_invalid_json(loader):
     with patch.object(
         loader, "load_type_schema_from_json", wraps=loader.load_type_schema_from_json
     ) as mock_load_json:
-        type_schema = loader.load_type_schema(
-            '{"Credentials" :{"ApiKey": "123", xxxx}}'
-        )
+        with pytest.raises(InvalidTypeSchemaError):
+            loader.load_type_schema('{"Credentials" :{"ApiKey": "123", xxxx}}')
 
-    assert not type_schema
-    mock_load_json.assert_called_with('{"Credentials" :{"ApiKey": "123", xxxx}}', None)
-
-
-def test_load_type_schema_from_invalid_json_fallback_to_default(loader):
-    with patch.object(
-        loader, "load_type_schema_from_json", wraps=loader.load_type_schema_from_json
-    ) as mock_load_json:
-        type_schema = loader.load_type_schema(
-            '{"Credentials" :{"ApiKey": "123", xxxx}}',
-            OTHER_TEST_TARGET_FALLBACK_SCHEMA,
-        )
-
-    assert_dict_equals(OTHER_TEST_TARGET_FALLBACK_SCHEMA, type_schema)
-    mock_load_json.assert_called_with(
-        '{"Credentials" :{"ApiKey": "123", xxxx}}', OTHER_TEST_TARGET_FALLBACK_SCHEMA
-    )
+    mock_load_json.assert_called_with('{"Credentials" :{"ApiKey": "123", xxxx}}')
 
 
 def test_load_type_schema_from_json_array(loader):
@@ -94,32 +527,17 @@ def test_load_type_schema_from_json_array(loader):
         type_schema = loader.load_type_schema(TEST_TARGET_SCHEMA_JSON_ARRAY)
 
     assert [TEST_TARGET_SCHEMA] == type_schema
-    mock_load_json.assert_called_with(TEST_TARGET_SCHEMA_JSON_ARRAY, None)
+    mock_load_json.assert_called_with(TEST_TARGET_SCHEMA_JSON_ARRAY)
 
 
 def test_load_type_schema_from_invalid_json_array(loader):
     with patch.object(
         loader, "load_type_schema_from_json", wraps=loader.load_type_schema_from_json
     ) as mock_load_json:
-        type_schema = loader.load_type_schema('[{"Credentials" :{"ApiKey": "123"}}]]')
+        with pytest.raises(InvalidTypeSchemaError):
+            loader.load_type_schema('[{"Credentials" :{"ApiKey": "123"}}]]')
 
-    assert not type_schema
-    mock_load_json.assert_called_with('[{"Credentials" :{"ApiKey": "123"}}]]', None)
-
-
-def test_load_type_schema_from_invalid_json_array_fallback_to_default(loader):
-    with patch.object(
-        loader, "load_type_schema_from_json", wraps=loader.load_type_schema_from_json
-    ) as mock_load_json:
-        type_schema = loader.load_type_schema(
-            '[{"Credentials" :{"ApiKey": "123"}}]]',
-            OTHER_TEST_TARGET_FALLBACK_SCHEMA,
-        )
-
-    assert_dict_equals(OTHER_TEST_TARGET_FALLBACK_SCHEMA, type_schema)
-    mock_load_json.assert_called_with(
-        '[{"Credentials" :{"ApiKey": "123"}}]]', OTHER_TEST_TARGET_FALLBACK_SCHEMA
-    )
+    mock_load_json.assert_called_with('[{"Credentials" :{"ApiKey": "123"}}]]')
 
 
 def test_load_type_schema_from_file(loader):
@@ -135,12 +553,13 @@ def test_load_type_schema_from_file(loader):
         type_schema = loader.load_type_schema(TEST_TARGET_SCHEMA_FILE_PATH)
 
     assert_dict_equals(TEST_TARGET_SCHEMA, type_schema)
-    mock_path_is_file.assert_any_call(TEST_TARGET_SCHEMA_FILE_PATH)
-    mock_load_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH, None)
+    mock_path_is_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH)
+    mock_load_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH)
     mock_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH, "r")
 
 
 def test_load_type_schema_from_file_file_not_found(loader):
+    e = FileNotFoundError("File not found")
     patch_file = patch("builtins.open", mock_open())
     patch_path_is_file = patch(
         "rpdk.core.type_schema_loader.os.path.isfile", return_value=True
@@ -148,38 +567,15 @@ def test_load_type_schema_from_file_file_not_found(loader):
     patch_load_file = patch.object(
         loader, "load_type_schema_from_file", wraps=loader.load_type_schema_from_file
     )
-
     with patch_file as mock_file, patch_path_is_file as mock_path_is_file, patch_load_file as mock_load_file:
-        mock_file.side_effect = FileNotFoundError()
-        type_schema = loader.load_type_schema(TEST_TARGET_SCHEMA_FILE_PATH)
+        mock_file.side_effect = e
+        with pytest.raises(InvalidTypeSchemaError) as excinfo:
+            loader.load_type_schema(TEST_TARGET_SCHEMA_FILE_PATH)
 
-    assert not type_schema
-    mock_path_is_file.assert_any_call(TEST_TARGET_SCHEMA_FILE_PATH)
-    mock_load_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH, None)
+    mock_path_is_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH)
+    mock_load_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH)
     mock_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH, "r")
-
-
-def test_load_type_schema_from_file_error_fallback_to_default(loader):
-    patch_file = patch("builtins.open", mock_open())
-    patch_path_is_file = patch(
-        "rpdk.core.type_schema_loader.os.path.isfile", return_value=True
-    )
-    patch_load_file = patch.object(
-        loader, "load_type_schema_from_file", wraps=loader.load_type_schema_from_file
-    )
-
-    with patch_file as mock_file, patch_path_is_file as mock_path_is_file, patch_load_file as mock_load_file:
-        mock_file.side_effect = FileNotFoundError()
-        type_schema = loader.load_type_schema(
-            TEST_TARGET_SCHEMA_FILE_PATH, OTHER_TEST_TARGET_FALLBACK_SCHEMA
-        )
-
-    assert_dict_equals(OTHER_TEST_TARGET_FALLBACK_SCHEMA, type_schema)
-    mock_path_is_file.assert_any_call(TEST_TARGET_SCHEMA_FILE_PATH)
-    mock_load_file.assert_called_with(
-        TEST_TARGET_SCHEMA_FILE_PATH, OTHER_TEST_TARGET_FALLBACK_SCHEMA
-    )
-    mock_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH, "r")
+    assert excinfo.value.__cause__ is e
 
 
 def test_load_type_schema_from_file_uri(loader):
@@ -195,12 +591,13 @@ def test_load_type_schema_from_file_uri(loader):
         type_schema = loader.load_type_schema(TEST_TARGET_SCHEMA_FILE_URI)
 
     assert_dict_equals(TEST_TARGET_SCHEMA, type_schema)
-    mock_load_from_uri.assert_called_with(TEST_TARGET_SCHEMA_FILE_URI, None)
-    mock_load_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH, None)
+    mock_load_from_uri.assert_called_with(TEST_TARGET_SCHEMA_FILE_URI)
+    mock_load_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH)
     mock_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH, "r")
 
 
 def test_load_type_schema_from_file_uri_file_not_found(loader):
+    e = FileNotFoundError("File Not Found")
     patch_file = patch("builtins.open", mock_open())
     patch_load_from_uri = patch.object(
         loader, "load_type_schema_from_uri", wraps=loader.load_type_schema_from_uri
@@ -210,47 +607,23 @@ def test_load_type_schema_from_file_uri_file_not_found(loader):
     )
 
     with patch_file as mock_file, patch_load_from_uri as mock_load_from_uri, patch_load_file as mock_load_file:
-        mock_file.side_effect = FileNotFoundError()
-        type_schema = loader.load_type_schema(TEST_TARGET_SCHEMA_FILE_URI)
+        mock_file.side_effect = e
+        with pytest.raises(InvalidTypeSchemaError) as excinfo:
+            loader.load_type_schema(TEST_TARGET_SCHEMA_FILE_URI)
 
-    assert not type_schema
-    mock_load_from_uri.assert_called_with(TEST_TARGET_SCHEMA_FILE_URI, None)
-    mock_load_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH, None)
+    mock_load_from_uri.assert_called_with(TEST_TARGET_SCHEMA_FILE_URI)
+    mock_load_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH)
     mock_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH, "r")
-
-
-def test_load_type_schema_from_file_uri_error_fallback_to_default(loader):
-    patch_file = patch("builtins.open", mock_open())
-    patch_load_from_uri = patch.object(
-        loader, "load_type_schema_from_uri", wraps=loader.load_type_schema_from_uri
-    )
-    patch_load_file = patch.object(
-        loader, "load_type_schema_from_file", wraps=loader.load_type_schema_from_file
-    )
-
-    with patch_file as mock_file, patch_load_from_uri as mock_load_from_uri, patch_load_file as mock_load_file:
-        mock_file.side_effect = FileNotFoundError()
-        type_schema = loader.load_type_schema(
-            TEST_TARGET_SCHEMA_FILE_URI, OTHER_TEST_TARGET_FALLBACK_SCHEMA
-        )
-
-    assert_dict_equals(OTHER_TEST_TARGET_FALLBACK_SCHEMA, type_schema)
-    mock_load_from_uri.assert_called_with(
-        TEST_TARGET_SCHEMA_FILE_URI, OTHER_TEST_TARGET_FALLBACK_SCHEMA
-    )
-    mock_load_file.assert_called_with(
-        TEST_TARGET_SCHEMA_FILE_PATH, OTHER_TEST_TARGET_FALLBACK_SCHEMA
-    )
-    mock_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH, "r")
+    assert excinfo.value.__cause__ is e
 
 
 def test_load_type_schema_from_https_url(loader):
-    mock_request = Mock()
-    mock_request.status_code = 200
-    mock_request.content = TEST_TARGET_SCHEMA_JSON.encode("utf-8")
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.content = TEST_TARGET_SCHEMA_JSON.encode("utf-8")
 
     patch_get_request = patch(
-        "rpdk.core.type_schema_loader.requests.get", return_value=mock_request
+        "rpdk.core.type_schema_loader.requests.get", return_value=mock_response
     )
     patch_load_from_uri = patch.object(
         loader, "load_type_schema_from_uri", wraps=loader.load_type_schema_from_uri
@@ -263,17 +636,18 @@ def test_load_type_schema_from_https_url(loader):
         type_schema = loader.load_type_schema(TEST_HTTPS_TARGET_SCHEMA_URI)
 
     assert_dict_equals(TEST_TARGET_SCHEMA, type_schema)
-    mock_load_from_uri.assert_called_with(TEST_HTTPS_TARGET_SCHEMA_URI, None)
-    mock_get_from_url.assert_called_with(TEST_HTTPS_TARGET_SCHEMA_URI, None)
+    mock_load_from_uri.assert_called_with(TEST_HTTPS_TARGET_SCHEMA_URI)
+    mock_get_from_url.assert_called_with(TEST_HTTPS_TARGET_SCHEMA_URI)
     mock_get_request.assert_called_with(TEST_HTTPS_TARGET_SCHEMA_URI, timeout=60)
 
 
 def test_load_type_schema_from_https_url_unsuccessful(loader):
-    mock_request = Mock()
-    mock_request.status_code = 404
-
+    e = HTTPError()
+    mock_response = Mock()
+    mock_response.status_code = 404
+    mock_response.raise_for_status.side_effect = e
     patch_get_request = patch(
-        "rpdk.core.type_schema_loader.requests.get", return_value=mock_request
+        "rpdk.core.type_schema_loader.requests.get", return_value=mock_response
     )
     patch_load_from_uri = patch.object(
         loader, "load_type_schema_from_uri", wraps=loader.load_type_schema_from_uri
@@ -283,41 +657,13 @@ def test_load_type_schema_from_https_url_unsuccessful(loader):
     )
 
     with patch_get_request as mock_get_request, patch_load_from_uri as mock_load_from_uri, patch_get_from_url as mock_get_from_url:
-        type_schema = loader.load_type_schema(TEST_HTTPS_TARGET_SCHEMA_URI)
+        with pytest.raises(DownstreamError) as excinfo:
+            loader.load_type_schema(TEST_HTTPS_TARGET_SCHEMA_URI)
 
-    assert not type_schema
-    mock_load_from_uri.assert_called_with(TEST_HTTPS_TARGET_SCHEMA_URI, None)
-    mock_get_from_url.assert_called_with(TEST_HTTPS_TARGET_SCHEMA_URI, None)
+    mock_load_from_uri.assert_called_with(TEST_HTTPS_TARGET_SCHEMA_URI)
+    mock_get_from_url.assert_called_with(TEST_HTTPS_TARGET_SCHEMA_URI)
     mock_get_request.assert_called_with(TEST_HTTPS_TARGET_SCHEMA_URI, timeout=60)
-
-
-def test_load_type_schema_from_https_url_unsuccessful_fallback_to_default(loader):
-    mock_request = Mock()
-    mock_request.status_code = 404
-
-    patch_get_request = patch(
-        "rpdk.core.type_schema_loader.requests.get", return_value=mock_request
-    )
-    patch_load_from_uri = patch.object(
-        loader, "load_type_schema_from_uri", wraps=loader.load_type_schema_from_uri
-    )
-    patch_get_from_url = patch.object(
-        loader, "_get_type_schema_from_url", wraps=loader._get_type_schema_from_url
-    )
-
-    with patch_get_request as mock_get_request, patch_load_from_uri as mock_load_from_uri, patch_get_from_url as mock_get_from_url:
-        type_schema = loader.load_type_schema(
-            TEST_HTTPS_TARGET_SCHEMA_URI, OTHER_TEST_TARGET_FALLBACK_SCHEMA
-        )
-
-    assert_dict_equals(OTHER_TEST_TARGET_FALLBACK_SCHEMA, type_schema)
-    mock_load_from_uri.assert_called_with(
-        TEST_HTTPS_TARGET_SCHEMA_URI, OTHER_TEST_TARGET_FALLBACK_SCHEMA
-    )
-    mock_get_from_url.assert_called_with(
-        TEST_HTTPS_TARGET_SCHEMA_URI, OTHER_TEST_TARGET_FALLBACK_SCHEMA
-    )
-    mock_get_request.assert_called_with(TEST_HTTPS_TARGET_SCHEMA_URI, timeout=60)
+    assert excinfo.value.__cause__ is e
 
 
 def test_load_type_schema_from_s3(loader):
@@ -336,9 +682,9 @@ def test_load_type_schema_from_s3(loader):
         type_schema = loader.load_type_schema(TEST_S3_TARGET_SCHEMA_URI)
 
     assert_dict_equals(TEST_TARGET_SCHEMA, type_schema)
-    mock_load_from_uri.assert_called_with(TEST_S3_TARGET_SCHEMA_URI, None)
+    mock_load_from_uri.assert_called_with(TEST_S3_TARGET_SCHEMA_URI)
     mock_get_from_s3.assert_called_with(
-        TEST_TARGET_SCHEMA_BUCKET, TEST_TARGET_SCHEMA_KEY, None
+        TEST_TARGET_SCHEMA_BUCKET, TEST_TARGET_SCHEMA_KEY
     )
     loader.s3_client.get_object.assert_called_once_with(
         Bucket=TEST_TARGET_SCHEMA_BUCKET, Key=TEST_TARGET_SCHEMA_KEY
@@ -346,10 +692,12 @@ def test_load_type_schema_from_s3(loader):
 
 
 def test_load_type_schema_from_s3_client_error(loader):
-    loader.s3_client.get_object.side_effect = ClientError(
+    e = ClientError(
         {"Error": {"Code": "", "Message": "Bucket does not exist"}},
         "get_object",
     )
+    mock_s3_client = loader.s3_client
+    mock_s3_client.get_object.side_effect = e
 
     patch_load_from_uri = patch.object(
         loader, "load_type_schema_from_uri", wraps=loader.load_type_schema_from_uri
@@ -359,168 +707,98 @@ def test_load_type_schema_from_s3_client_error(loader):
     )
 
     with patch_load_from_uri as mock_load_from_uri, patch_get_from_s3 as mock_get_from_s3:
-        type_schema = loader.load_type_schema(TEST_S3_TARGET_SCHEMA_URI)
+        with pytest.raises(DownstreamError) as excinfo:
+            loader.load_type_schema(TEST_S3_TARGET_SCHEMA_URI)
 
-    assert not type_schema
-    mock_load_from_uri.assert_called_with(TEST_S3_TARGET_SCHEMA_URI, None)
+    mock_load_from_uri.assert_called_with(TEST_S3_TARGET_SCHEMA_URI)
     mock_get_from_s3.assert_called_with(
-        TEST_TARGET_SCHEMA_BUCKET, TEST_TARGET_SCHEMA_KEY, None
+        TEST_TARGET_SCHEMA_BUCKET, TEST_TARGET_SCHEMA_KEY
     )
-    loader.s3_client.get_object.assert_called_once_with(
+    mock_s3_client.get_object.assert_called_once_with(
         Bucket=TEST_TARGET_SCHEMA_BUCKET, Key=TEST_TARGET_SCHEMA_KEY
     )
-
-
-def test_load_type_schema_from_s3_error_fallback_to_default(loader):
-    loader.s3_client.get_object.side_effect = ClientError(
-        {"Error": {"Code": "", "Message": "Bucket does not exist"}},
-        "get_object",
-    )
-
-    patch_load_from_uri = patch.object(
-        loader, "load_type_schema_from_uri", wraps=loader.load_type_schema_from_uri
-    )
-    patch_get_from_s3 = patch.object(
-        loader, "_get_type_schema_from_s3", wraps=loader._get_type_schema_from_s3
-    )
-
-    with patch_load_from_uri as mock_load_from_uri, patch_get_from_s3 as mock_get_from_s3:
-        type_schema = loader.load_type_schema(
-            TEST_S3_TARGET_SCHEMA_URI, OTHER_TEST_TARGET_FALLBACK_SCHEMA
-        )
-
-    assert_dict_equals(OTHER_TEST_TARGET_FALLBACK_SCHEMA, type_schema)
-    mock_load_from_uri.assert_called_with(
-        TEST_S3_TARGET_SCHEMA_URI, OTHER_TEST_TARGET_FALLBACK_SCHEMA
-    )
-    mock_get_from_s3.assert_called_with(
-        TEST_TARGET_SCHEMA_BUCKET,
-        TEST_TARGET_SCHEMA_KEY,
-        OTHER_TEST_TARGET_FALLBACK_SCHEMA,
-    )
-    loader.s3_client.get_object.assert_called_once_with(
-        Bucket=TEST_TARGET_SCHEMA_BUCKET, Key=TEST_TARGET_SCHEMA_KEY
-    )
+    assert excinfo.value.__cause__ is e
 
 
 def test_load_type_schema_from_cfn_registry(loader):
-    loader.cfn_client.describe_type.return_value = {
+    mock_cfn = loader.cfn_client
+    mock_cfn.describe_type.return_value = {
         "Schema": TEST_TARGET_SCHEMA_JSON,
         "Type": "RESOURCE",
-        "ProvisioningType": "FULLY_MUTABLE",
     }
 
-    type_schema, target_type, provisioning_type = loader.load_schema_from_cfn_registry(
+    type_schema = loader.load_schema_from_cfn_registry(
         TEST_TARGET_TYPE_NAME, "RESOURCE"
     )
-
     assert_dict_equals(TEST_TARGET_SCHEMA, type_schema)
-    assert target_type == "RESOURCE"
-    assert provisioning_type == "FULLY_MUTABLE"
-    loader.cfn_client.describe_type.assert_called_once_with(
+    mock_cfn.describe_type.assert_called_once_with(
         Type="RESOURCE", TypeName=TEST_TARGET_TYPE_NAME
     )
 
 
 def test_load_type_schema_from_cfn_registry_client_error(loader):
-    loader.cfn_client.describe_type.side_effect = ClientError(
+    e = ClientError(
         {"Error": {"Code": "", "Message": "Type does not exist"}},
-        "get_object",
+        "describe_type",
     )
+    loader.cfn_client.describe_type.side_effect = e
 
-    type_schema, target_type, provisioning_type = loader.load_schema_from_cfn_registry(
-        TEST_TARGET_TYPE_NAME, "RESOURCE"
-    )
+    with pytest.raises(DownstreamError) as excinfo:
+        loader.load_schema_from_cfn_registry(TEST_TARGET_TYPE_NAME, "RESOURCE")
 
-    assert not type_schema
-    assert not target_type
-    assert not provisioning_type
     loader.cfn_client.describe_type.assert_called_once_with(
         Type="RESOURCE", TypeName=TEST_TARGET_TYPE_NAME
     )
+    assert excinfo.value.__cause__ is e
 
 
-def test_load_type_schema_from_cfn_registry_error_fallback_to_default(loader):
-    loader.cfn_client.describe_type.side_effect = ClientError(
-        {"Error": {"Code": "", "Message": "Type does not exist"}},
-        "get_object",
+def test_load_type_schemas_duplicates(loader):
+    duplicate_schema = dict(
+        TEST_TARGET_SCHEMA,
+        properties={"bar": {"type": "string"}},
+        primaryIdentifier=["/properties/bar"],
     )
+    schemas_to_load = [TEST_TARGET_SCHEMA_JSON, f"[{json.dumps(duplicate_schema)}]"]
 
-    type_schema, target_type, provisioning_type = loader.load_schema_from_cfn_registry(
-        TEST_TARGET_TYPE_NAME, "RESOURCE", OTHER_TEST_TARGET_FALLBACK_SCHEMA
-    )
+    with pytest.raises(InvalidTypeSchemaError) as excinfo:
+        loader.load_type_schemas(schemas_to_load)
 
-    assert_dict_equals(OTHER_TEST_TARGET_FALLBACK_SCHEMA, type_schema)
-    assert not target_type
-    assert not provisioning_type
-    loader.cfn_client.describe_type.assert_called_once_with(
-        Type="RESOURCE", TypeName=TEST_TARGET_TYPE_NAME
-    )
-
-
-def test_get_provision_type(loader):
-    loader.cfn_client.describe_type.return_value = {
-        "Schema": TEST_TARGET_SCHEMA_JSON,
-        "Type": "RESOURCE",
-        "ProvisioningType": "IMMUTABLE",
-    }
-
-    provisioning_type = loader.get_provision_type(TEST_TARGET_TYPE_NAME, "RESOURCE")
-
-    assert provisioning_type == "IMMUTABLE"
-    loader.cfn_client.describe_type.assert_called_once_with(
-        Type="RESOURCE", TypeName=TEST_TARGET_TYPE_NAME
+    assert f"Duplicate schemas for '{TEST_TARGET_TYPE_NAME}' target type" in str(
+        excinfo.value
     )
 
 
-def test_get_provision_type_client_error(loader):
-    loader.cfn_client.describe_type.side_effect = ClientError(
-        {"Error": {"Code": "", "Message": "Type does not exist"}},
-        "get_object",
+def test_load_type_schemas_unknown_error(loader):
+    patch_load_schema = patch.object(
+        loader, "load_type_schema", wraps=loader.load_type_schema, return_value={}
     )
 
-    provisioning_type = loader.get_provision_type(TEST_TARGET_TYPE_NAME, "RESOURCE")
+    with patch_load_schema as mock_load_schema, pytest.raises(
+        InvalidTypeSchemaError
+    ) as excinfo:
+        loader.load_type_schemas([TEST_TARGET_SCHEMA_JSON])
 
-    assert not provisioning_type
-    loader.cfn_client.describe_type.assert_called_once_with(
-        Type="RESOURCE", TypeName=TEST_TARGET_TYPE_NAME
+    mock_load_schema.assert_called_once_with(TEST_TARGET_SCHEMA_JSON)
+    assert "Unknown error while loading type schema" in str(excinfo.value)
+
+
+def test_load_type_schemas_invalid_schema_format(loader):
+    patch_load_schema = patch.object(
+        loader, "load_type_schema", wraps=loader.load_type_schema
     )
 
+    with patch_load_schema as mock_load_schema, pytest.raises(
+        InvalidTypeSchemaError
+    ) as excinfo:
+        loader.load_type_schemas(["ftp://unsupportedurlschema.com/test-schema.json"])
 
-def test_load_type_schema_null_input(loader):
-    type_schema = loader.load_type_schema(None, OTHER_TEST_TARGET_FALLBACK_SCHEMA)
-    assert_dict_equals(OTHER_TEST_TARGET_FALLBACK_SCHEMA, type_schema)
-
-    type_schema = loader.load_type_schema_from_json(
-        None, OTHER_TEST_TARGET_FALLBACK_SCHEMA
+    mock_load_schema.assert_called_once_with(
+        "ftp://unsupportedurlschema.com/test-schema.json"
     )
-    assert_dict_equals(OTHER_TEST_TARGET_FALLBACK_SCHEMA, type_schema)
-
-    type_schema = loader.load_type_schema_from_uri(
-        None, OTHER_TEST_TARGET_FALLBACK_SCHEMA
+    assert (
+        "Provided schema is invalid or not supported: ftp://unsupportedurlschema.com/test-schema.json"
+        in str(excinfo.value)
     )
-    assert_dict_equals(OTHER_TEST_TARGET_FALLBACK_SCHEMA, type_schema)
-
-    type_schema = loader.load_type_schema_from_file(
-        None, OTHER_TEST_TARGET_FALLBACK_SCHEMA
-    )
-    assert_dict_equals(OTHER_TEST_TARGET_FALLBACK_SCHEMA, type_schema)
-
-
-def test_load_type_schema_invalid_input(loader):
-    type_schema = loader.load_type_schema(
-        "This is invalid input", OTHER_TEST_TARGET_FALLBACK_SCHEMA
-    )
-    assert_dict_equals(OTHER_TEST_TARGET_FALLBACK_SCHEMA, type_schema)
-
-    with patch(
-        "rpdk.core.type_schema_loader.is_valid_type_schema_uri", return_value=True
-    ):
-        type_schema = loader.load_type_schema_from_uri(
-            "ftp://unsupportedurlschema.com/test-schema.json",
-            OTHER_TEST_TARGET_FALLBACK_SCHEMA,
-        )
-    assert_dict_equals(OTHER_TEST_TARGET_FALLBACK_SCHEMA, type_schema)
 
 
 @pytest.mark.parametrize(
@@ -538,5 +816,37 @@ def test_is_valid_type_schema_uri(uri):
 @pytest.mark.parametrize(
     "uri", [None, "ftp://unsupportedurlschema.com/test-schema.json"]
 )
-def test_is_invalid_type_schema_uri(uri):
-    assert not is_valid_type_schema_uri(uri)
+def test_invalid_type_schema_uri(uri):
+    loader = TypeSchemaLoader(Mock(), Mock())
+    with pytest.raises(InvalidTypeSchemaError) as excinfo:
+        loader.load_type_schema_from_uri(uri)
+
+    assert f"URI provided {uri} is not supported or invalid" in str(excinfo.value)
+
+
+def test_load_type_schema_from_uri_invalid_local_uri(local_loader):
+    with pytest.raises(InvalidTypeSchemaError) as excinfo:
+        local_loader.load_type_schema_from_uri(TEST_S3_TARGET_SCHEMA_URI)
+
+    assert f"URI provided is not local: {TEST_S3_TARGET_SCHEMA_URI}" in str(
+        excinfo.value
+    )
+
+
+@pytest.mark.parametrize(
+    "json_input,expected",
+    [
+        ("{}", True),
+        ("[]", True),
+        (b"{}", True),
+        (b"[]", True),
+        (bytearray("{}", "utf-8"), True),
+        (bytearray("[]", "utf-8"), True),
+        ({}, False),
+        ([], False),
+        (21, False),
+        (None, False),
+    ],
+)
+def test_is_valid_json(json_input, expected):
+    assert TypeSchemaLoader._is_json(json_input) == expected

--- a/tests/test_type_schema_loader.py
+++ b/tests/test_type_schema_loader.py
@@ -572,7 +572,7 @@ def test_load_type_schema_from_file_file_not_found(loader):
         with pytest.raises(InvalidTypeSchemaError) as excinfo:
             loader.load_type_schema(TEST_TARGET_SCHEMA_FILE_PATH)
 
-    mock_path_is_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH)
+    mock_path_is_file.assert_has_calls(calls=[call(TEST_TARGET_SCHEMA_FILE_PATH)])
     mock_load_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH)
     mock_file.assert_called_with(TEST_TARGET_SCHEMA_FILE_PATH, "r")
     assert excinfo.value.__cause__ is e


### PR DESCRIPTION
This PR adds support for hooks with wildcard targets. This allows hooks to be registered with wildcard target names which are matched to hook target types during invocation.

For example, the target name `AWS::S3*::Bucket*` would resolve and be invoked by the following resource types:
* `AWS::S3::Bucket`
* `AWS::S3::BucketPolicy`
* `AWS::S3Outpost::Bucket`
* `AWS::S3Outpost::BucketPolicy`


Related PRs:
* https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/pull/406
* https://github.com/aws-cloudformation/cloudformation-cli-python-plugin/pull/224

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
