### PR TITLE
remove python 3.6 from github actions

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -10,7 +10,7 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python: [ 3.7, 3.8, 3.9, "3.10" ]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Github actions have removed support for Python 3.6.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
