### PR TITLE
Add in no-docker and use-docker override to submit command

### DIFF
--- a/src/rpdk/core/submit.py
+++ b/src/rpdk/core/submit.py
@@ -12,7 +12,7 @@ LOG = logging.getLogger(__name__)
 def submit(args):
     project = Project()
     project.load()
-    # Update config file if use-docker or no-docker used in submit call
+    # Use CLI override opposed to config file if use-docker or no-docker switch used
     if args.use_docker or args.no_docker:
         project.settings["use_docker"] = args.use_docker
         project.settings["no_docker"] = args.no_docker

--- a/src/rpdk/core/submit.py
+++ b/src/rpdk/core/submit.py
@@ -12,6 +12,10 @@ LOG = logging.getLogger(__name__)
 def submit(args):
     project = Project()
     project.load()
+    # Update config file if use-docker or no-docker used in submit call
+    if args.use_docker or args.no_docker:
+        project.settings["use_docker"] = args.use_docker
+        project.settings["no_docker"] = args.no_docker
     project.submit(
         args.dry_run,
         args.endpoint_url,
@@ -50,4 +54,19 @@ def setup_subparser(subparsers, parents):
         dest="use_role",
         help="Register the type without an explicit execution role "
         "(Will not be able to invoke AWS APIs).",
+    )
+
+    nodocker_group = parser.add_mutually_exclusive_group()
+    nodocker_group.add_argument(
+        "--use-docker",
+        action="store_true",
+        help="""Use docker for TypeScript platform-independent packaging.
+            This is highly recommended unless you are experienced
+            with cross-platform TypeScript packaging.""",
+    )
+    nodocker_group.add_argument(
+        "--no-docker",
+        action="store_true",
+        help="""Generally not recommended unless you are experienced
+            with cross-platform Typescript packaging.""",
     )

--- a/src/rpdk/core/submit.py
+++ b/src/rpdk/core/submit.py
@@ -60,13 +60,13 @@ def setup_subparser(subparsers, parents):
     nodocker_group.add_argument(
         "--use-docker",
         action="store_true",
-        help="""Use docker for TypeScript platform-independent packaging.
+        help="""Use docker for platform-independent packaging.
             This is highly recommended unless you are experienced
-            with cross-platform TypeScript packaging.""",
+            with cross-platform packaging.""",
     )
     nodocker_group.add_argument(
         "--no-docker",
         action="store_true",
         help="""Generally not recommended unless you are experienced
-            with cross-platform Typescript packaging.""",
+            with cross-platform packaging.""",
     )


### PR DESCRIPTION
Closes #969 

Add in CLI packaging overrides to submit command for `cfn submit --no-docker` and `cfn submit --use-docker`

This will override the use_docker settings in .rpdk-config file when building the package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
