### PR TITLE
Block public access to Artifact/AccessLogs Buckets

### DIFF
--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -26,6 +26,11 @@ Resources:
       LoggingConfiguration:
         DestinationBucketName: !Ref AccessLogsBucket
         LogFilePrefix: ArtifactBucket
+      PublicAccessBlockConfiguration: 
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
 
   AccessLogsBucket:
     Type: AWS::S3::Bucket
@@ -44,6 +49,11 @@ Resources:
             ExpirationInDays: 3653
       VersioningConfiguration:
         Status: Enabled
+      PublicAccessBlockConfiguration: 
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
 
   ArtifactCopyPolicy:
     Type: AWS::S3::BucketPolicy

--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
-  This CloudFormation template provisions all the infrastructure that  is
+  This CloudFormation template provisions all the infrastructure that is
   required to upload artifacts to CloudFormation's managed experience.
 
 Resources:

--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -26,7 +26,7 @@ Resources:
       LoggingConfiguration:
         DestinationBucketName: !Ref AccessLogsBucket
         LogFilePrefix: ArtifactBucket
-      PublicAccessBlockConfiguration: 
+      PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
         IgnorePublicAcls: true
@@ -49,7 +49,7 @@ Resources:
             ExpirationInDays: 3653
       VersioningConfiguration:
         Status: Enabled
-      PublicAccessBlockConfiguration: 
+      PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
         IgnorePublicAcls: true

--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
-  This CloudFormation template provisions all the infrastructure that is
+  This CloudFormation template provisions all the infrastructure that  is
   required to upload artifacts to CloudFormation's managed experience.
 
 Resources:


### PR DESCRIPTION
The two buckets (ArtifactBucket and AccessLogsBucket) created by the stack CloudFormationManagedUploadInfrastructure do not have the Block Public Access setting enabled.. 

**This Pull Request to enable block public access settings to those buckets.**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
