### PR TITLE
Update configuration for the logging bucket.

### DIFF
--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -32,12 +32,10 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      AccessControl: LogDeliveryWrite
       BucketEncryption:
         ServerSideEncryptionConfiguration:
         - ServerSideEncryptionByDefault:
-            SSEAlgorithm: aws:kms
-            KMSMasterKeyID: !Ref EncryptionKey
+            SSEAlgorithm: AES256
       LifecycleConfiguration:
         Rules:
           - Status: Enabled
@@ -80,6 +78,17 @@ Resources:
               Bool:
                 "aws:SecureTransport": "false"
             Principal: "*"
+          - Sid: S3 Server Access Logs Policy
+            Effect: Allow
+            Principal:
+              Service: logging.s3.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub "arn:${AWS::Partition}:s3:::${AccessLogsBucket}/ArtifactBucket*"
+            Condition:
+              ArnLike:
+                aws:SourceArn: !Sub "arn:${AWS::Partition}:s3:::${ArtifactBucket}"
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
 
   EncryptionKey:
     Type: AWS::KMS::Key


### PR DESCRIPTION
*Issue #, if available:*
Fixes #985

*Description of changes:*
Update configuration for the logging bucket:
- use a bucket policy instead of an ACL; see **Grant permissions to the logging service principal using a bucket policy** in [Permissions for log delivery](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html#grant-log-delivery-permissions-general);
- use `AES256` instead of the current `SSE-KMS` setting for the log bucket; see considerations on the default bucket encryption on the target bucket with `AES256` (`SSE-S3`) in [Enabling Amazon S3 server access logging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html) (where I note: _You can use [default bucket encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-bucket-encryption.html) on the target bucket only if you use AES256 (SSE-S3). Default encryption with AWS KMS keys (SSE-KMS) is not supported_).  I started to see logs in my logs bucket after I changed to `AES256` the default bucket encryption for the log bucket itself.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
