### PR TITLE
Update hook project init to use only plugins that support hooks and fixing issue with init when no creds are specified

### DIFF
--- a/src/rpdk/core/data/examples/hook/targets/aws-s3-bucket.json
+++ b/src/rpdk/core/data/examples/hook/targets/aws-s3-bucket.json
@@ -1,0 +1,1611 @@
+{
+    "typeName": "AWS::S3::Bucket",
+    "description": "Resource Type definition for AWS::S3::Bucket",
+    "additionalProperties": false,
+    "properties": {
+        "AccelerateConfiguration": {
+            "$ref": "#/definitions/AccelerateConfiguration",
+            "description": "Configuration for the transfer acceleration state."
+        },
+        "AccessControl": {
+            "description": "A canned access control list (ACL) that grants predefined permissions to the bucket.",
+            "enum": [
+                "AuthenticatedRead",
+                "AwsExecRead",
+                "BucketOwnerFullControl",
+                "BucketOwnerRead",
+                "LogDeliveryWrite",
+                "Private",
+                "PublicRead",
+                "PublicReadWrite"
+            ],
+            "type": "string"
+        },
+        "AnalyticsConfigurations": {
+            "description": "The configuration and any analyses for the analytics filter of an Amazon S3 bucket.",
+            "items": {
+                "$ref": "#/definitions/AnalyticsConfiguration"
+            },
+            "type": "array",
+            "uniqueItems": true,
+            "insertionOrder": true
+        },
+        "BucketEncryption": {
+            "$ref": "#/definitions/BucketEncryption"
+        },
+        "BucketName": {
+            "description": "A name for the bucket. If you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the bucket name.",
+            "maxLength": 63,
+            "minLength": 3,
+            "pattern": "^[a-z0-9][a-z0-9//.//-]*[a-z0-9]$",
+            "type": "string"
+        },
+        "CorsConfiguration": {
+            "$ref": "#/definitions/CorsConfiguration",
+            "description": "Rules that define cross-origin resource sharing of objects in this bucket."
+        },
+        "IntelligentTieringConfigurations": {
+            "description": "Specifies the S3 Intelligent-Tiering configuration for an Amazon S3 bucket.",
+            "items": {
+                "$ref": "#/definitions/IntelligentTieringConfiguration"
+            },
+            "type": "array",
+            "uniqueItems": true,
+            "insertionOrder": true
+        },
+        "InventoryConfigurations": {
+            "description": "The inventory configuration for an Amazon S3 bucket.",
+            "items": {
+                "$ref": "#/definitions/InventoryConfiguration"
+            },
+            "type": "array",
+            "uniqueItems": true,
+            "insertionOrder": true
+        },
+        "LifecycleConfiguration": {
+            "$ref": "#/definitions/LifecycleConfiguration",
+            "description": "Rules that define how Amazon S3 manages objects during their lifetime."
+        },
+        "LoggingConfiguration": {
+            "$ref": "#/definitions/LoggingConfiguration",
+            "description": "Settings that define where logs are stored."
+        },
+        "MetricsConfigurations": {
+            "description": "Settings that define a metrics configuration for the CloudWatch request metrics from the bucket.",
+            "items": {
+                "$ref": "#/definitions/MetricsConfiguration"
+            },
+            "type": "array",
+            "uniqueItems": true,
+            "insertionOrder": true
+        },
+        "NotificationConfiguration": {
+            "$ref": "#/definitions/NotificationConfiguration",
+            "description": "Configuration that defines how Amazon S3 handles bucket notifications."
+        },
+        "ObjectLockConfiguration": {
+            "$ref": "#/definitions/ObjectLockConfiguration",
+            "description": "Places an Object Lock configuration on the specified bucket."
+        },
+        "ObjectLockEnabled": {
+            "description": "Indicates whether this bucket has an Object Lock configuration enabled.",
+            "type": "boolean"
+        },
+        "OwnershipControls": {
+            "description": "Specifies the container element for object ownership rules.",
+            "$ref": "#/definitions/OwnershipControls"
+        },
+        "PublicAccessBlockConfiguration": {
+            "$ref": "#/definitions/PublicAccessBlockConfiguration"
+        },
+        "ReplicationConfiguration": {
+            "$ref": "#/definitions/ReplicationConfiguration",
+            "description": "Configuration for replicating objects in an S3 bucket."
+        },
+        "Tags": {
+            "description": "An arbitrary set of tags (key-value pairs) for this S3 bucket.",
+            "insertionOrder": false,
+            "items": {
+                "$ref": "#/definitions/Tag"
+            },
+            "type": "array"
+        },
+        "VersioningConfiguration": {
+            "$ref": "#/definitions/VersioningConfiguration"
+        },
+        "WebsiteConfiguration": {
+            "$ref": "#/definitions/WebsiteConfiguration"
+        },
+        "Arn": {
+            "$ref": "#/definitions/Arn",
+            "description": "The Amazon Resource Name (ARN) of the specified bucket.",
+            "examples": [
+                "arn:aws:s3:::mybucket"
+            ]
+        },
+        "DomainName": {
+            "description": "The IPv4 DNS name of the specified bucket.",
+            "examples": [
+                "mystack-mybucket-kdwwxmddtr2g.s3.amazonaws.com"
+            ],
+            "type": "string"
+        },
+        "DualStackDomainName": {
+            "description": "The IPv6 DNS name of the specified bucket. For more information about dual-stack endpoints, see [Using Amazon S3 Dual-Stack Endpoints](https://docs.aws.amazon.com/AmazonS3/latest/dev/dual-stack-endpoints.html).",
+            "examples": [
+                "mystack-mybucket-kdwwxmddtr2g.s3.dualstack.us-east-2.amazonaws.com"
+            ],
+            "type": "string"
+        },
+        "RegionalDomainName": {
+            "description": "Returns the regional domain name of the specified bucket.",
+            "examples": [
+                "mystack-mybucket-kdwwxmddtr2g.s3.us-east-2.amazonaws.com"
+            ],
+            "type": "string"
+        },
+        "WebsiteURL": {
+            "description": "The Amazon S3 website endpoint for the specified bucket.",
+            "examples": [
+                "Example (IPv4): http://mystack-mybucket-kdwwxmddtr2g.s3-website-us-east-2.amazonaws.com/",
+                "Example (IPv6): http://mystack-mybucket-kdwwxmddtr2g.s3.dualstack.us-east-2.amazonaws.com/"
+            ],
+            "format": "uri",
+            "type": "string"
+        }
+    },
+    "definitions": {
+        "TagFilter": {
+            "description": "Tags to use to identify a subset of objects for an Amazon S3 bucket.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Value": {
+                    "type": "string"
+                },
+                "Key": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Value",
+                "Key"
+            ]
+        },
+        "Destination": {
+            "description": "Specifies information about where to publish analysis or configuration results for an Amazon S3 bucket and S3 Replication Time Control (S3 RTC).",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "BucketArn": {
+                    "description": "The Amazon Resource Name (ARN) of the bucket to which data is exported.",
+                    "type": "string"
+                },
+                "BucketAccountId": {
+                    "description": "The account ID that owns the destination S3 bucket. ",
+                    "type": "string"
+                },
+                "Format": {
+                    "description": "Specifies the file format used when exporting data to Amazon S3.",
+                    "type": "string",
+                    "enum": [
+                        "CSV",
+                        "ORC",
+                        "Parquet"
+                    ]
+                },
+                "Prefix": {
+                    "description": "The prefix to use when exporting data. The prefix is prepended to all results.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "BucketArn",
+                "Format"
+            ]
+        },
+        "AccelerateConfiguration": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "AccelerationStatus": {
+                    "description": "Configures the transfer acceleration state for an Amazon S3 bucket.",
+                    "type": "string",
+                    "enum": [
+                        "Enabled",
+                        "Suspended"
+                    ]
+                }
+            },
+            "required": [
+                "AccelerationStatus"
+            ]
+        },
+        "AnalyticsConfiguration": {
+            "description": "Specifies the configuration and any analyses for the analytics filter of an Amazon S3 bucket.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "TagFilters": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/TagFilter"
+                    }
+                },
+                "StorageClassAnalysis": {
+                    "$ref": "#/definitions/StorageClassAnalysis"
+                },
+                "Id": {
+                    "description": "The ID that identifies the analytics configuration.",
+                    "type": "string"
+                },
+                "Prefix": {
+                    "description": "The prefix that an object must have to be included in the analytics results.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "StorageClassAnalysis",
+                "Id"
+            ]
+        },
+        "StorageClassAnalysis": {
+            "description": "Specifies data related to access patterns to be collected and made available to analyze the tradeoffs between different storage classes for an Amazon S3 bucket.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "DataExport": {
+                    "$ref": "#/definitions/DataExport"
+                }
+            }
+        },
+        "DataExport": {
+            "description": "Specifies how data related to the storage class analysis for an Amazon S3 bucket should be exported.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Destination": {
+                    "$ref": "#/definitions/Destination"
+                },
+                "OutputSchemaVersion": {
+                    "description": "The version of the output schema to use when exporting data.",
+                    "type": "string",
+                    "const": "V_1"
+                }
+            },
+            "required": [
+                "Destination",
+                "OutputSchemaVersion"
+            ]
+        },
+        "BucketEncryption": {
+            "description": "Specifies default encryption for a bucket using server-side encryption with either Amazon S3-managed keys (SSE-S3) or AWS KMS-managed keys (SSE-KMS).",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ServerSideEncryptionConfiguration": {
+                    "description": "Specifies the default server-side-encryption configuration.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/ServerSideEncryptionRule"
+                    }
+                }
+            },
+            "required": [
+                "ServerSideEncryptionConfiguration"
+            ]
+        },
+        "ServerSideEncryptionRule": {
+            "description": "Specifies the default server-side encryption configuration.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "BucketKeyEnabled": {
+                    "description": "Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS) for new objects in the bucket. Existing objects are not affected. Setting the BucketKeyEnabled element to true causes Amazon S3 to use an S3 Bucket Key. By default, S3 Bucket Key is not enabled.",
+                    "type": "boolean"
+                },
+                "ServerSideEncryptionByDefault": {
+                    "$ref": "#/definitions/ServerSideEncryptionByDefault"
+                }
+            }
+        },
+        "ServerSideEncryptionByDefault": {
+            "description": "Specifies the default server-side encryption to apply to new objects in the bucket. If a PUT Object request doesn't specify any server-side encryption, this default encryption will be applied.",
+            "type": "object",
+            "properties": {
+                "KMSMasterKeyID": {
+                    "description": "\"KMSMasterKeyID\" can only be used when you set the value of SSEAlgorithm as aws:kms.",
+                    "type": "string"
+                },
+                "SSEAlgorithm": {
+                    "type": "string",
+                    "enum": [
+                        "aws:kms",
+                        "AES256"
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "SSEAlgorithm"
+            ]
+        },
+        "CorsConfiguration": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "CorsRules": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/CorsRule",
+                        "maxLength": 100
+                    }
+                }
+            },
+            "required": [
+                "CorsRules"
+            ]
+        },
+        "CorsRule": {
+            "type": "object",
+            "description": "A set of origins and methods (cross-origin access that you want to allow). You can add up to 100 rules to the configuration.",
+            "additionalProperties": false,
+            "properties": {
+                "AllowedHeaders": {
+                    "description": "Headers that are specified in the Access-Control-Request-Headers header.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "AllowedMethods": {
+                    "description": "An HTTP method that you allow the origin to execute.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "GET",
+                            "PUT",
+                            "HEAD",
+                            "POST",
+                            "DELETE"
+                        ]
+                    }
+                },
+                "AllowedOrigins": {
+                    "description": "One or more origins you want customers to be able to access the bucket from.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ExposedHeaders": {
+                    "description": "One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript XMLHttpRequest object).",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "Id": {
+                    "description": "A unique identifier for this rule.",
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "MaxAge": {
+                    "description": "The time in seconds that your browser is to cache the preflight response for the specified resource.",
+                    "type": "integer",
+                    "minimum": 0
+                }
+            },
+            "required": [
+                "AllowedMethods",
+                "AllowedOrigins"
+            ]
+        },
+        "IntelligentTieringConfiguration": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Id": {
+                    "description": "The ID used to identify the S3 Intelligent-Tiering configuration.",
+                    "type": "string"
+                },
+                "Prefix": {
+                    "description": "An object key name prefix that identifies the subset of objects to which the rule applies.",
+                    "type": "string"
+                },
+                "Status": {
+                    "description": "Specifies the status of the configuration.",
+                    "type": "string",
+                    "enum": [
+                        "Disabled",
+                        "Enabled"
+                    ]
+                },
+                "TagFilters": {
+                    "description": "A container for a key-value pair.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/TagFilter"
+                    }
+                },
+                "Tierings": {
+                    "description": "Specifies a list of S3 Intelligent-Tiering storage class tiers in the configuration. At least one tier must be defined in the list. At most, you can specify two tiers in the list, one for each available AccessTier: ARCHIVE_ACCESS and DEEP_ARCHIVE_ACCESS.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/Tiering"
+                    }
+                }
+            },
+            "required": [
+                "Id",
+                "Status",
+                "Tierings"
+            ]
+        },
+        "Tiering": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "AccessTier": {
+                    "description": "S3 Intelligent-Tiering access tier. See Storage class for automatically optimizing frequently and infrequently accessed objects for a list of access tiers in the S3 Intelligent-Tiering storage class.",
+                    "type": "string",
+                    "enum": [
+                        "ARCHIVE_ACCESS",
+                        "DEEP_ARCHIVE_ACCESS"
+                    ]
+                },
+                "Days": {
+                    "description": "The number of consecutive days of no access after which an object will be eligible to be transitioned to the corresponding tier. The minimum number of days specified for Archive Access tier must be at least 90 days and Deep Archive Access tier must be at least 180 days. The maximum can be up to 2 years (730 days).",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "AccessTier",
+                "Days"
+            ]
+        },
+        "InventoryConfiguration": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Destination": {
+                    "$ref": "#/definitions/Destination"
+                },
+                "Enabled": {
+                    "description": "Specifies whether the inventory is enabled or disabled.",
+                    "type": "boolean"
+                },
+                "Id": {
+                    "description": "The ID used to identify the inventory configuration.",
+                    "type": "string"
+                },
+                "IncludedObjectVersions": {
+                    "description": "Object versions to include in the inventory list.",
+                    "type": "string",
+                    "enum": [
+                        "All",
+                        "Current"
+                    ]
+                },
+                "OptionalFields": {
+                    "description": "Contains the optional fields that are included in the inventory results.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "Size",
+                            "LastModifiedDate",
+                            "StorageClass",
+                            "ETag",
+                            "IsMultipartUploaded",
+                            "ReplicationStatus",
+                            "EncryptionStatus",
+                            "ObjectLockRetainUntilDate",
+                            "ObjectLockMode",
+                            "ObjectLockLegalHoldStatus",
+                            "IntelligentTieringAccessTier",
+                            "BucketKeyStatus"
+                        ]
+                    }
+                },
+                "Prefix": {
+                    "description": "The prefix that is prepended to all inventory results.",
+                    "type": "string"
+                },
+                "ScheduleFrequency": {
+                    "description": "Specifies the schedule for generating inventory results.",
+                    "type": "string",
+                    "enum": [
+                        "Daily",
+                        "Weekly"
+                    ]
+                }
+            },
+            "required": [
+                "Destination",
+                "Enabled",
+                "Id",
+                "IncludedObjectVersions",
+                "ScheduleFrequency"
+            ]
+        },
+        "LifecycleConfiguration": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Rules": {
+                    "description": "A lifecycle rule for individual objects in an Amazon S3 bucket.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/Rule"
+                    }
+                }
+            },
+            "required": [
+                "Rules"
+            ]
+        },
+        "Rule": {
+            "type": "object",
+            "description": "You must specify at least one of the following properties: AbortIncompleteMultipartUpload, ExpirationDate, ExpirationInDays, NoncurrentVersionExpirationInDays, NoncurrentVersionTransition, NoncurrentVersionTransitions, Transition, or Transitions.",
+            "additionalProperties": false,
+            "properties": {
+                "AbortIncompleteMultipartUpload": {
+                    "$ref": "#/definitions/AbortIncompleteMultipartUpload"
+                },
+                "ExpirationDate": {
+                    "$ref": "#/definitions/iso8601UTC"
+                },
+                "ExpirationInDays": {
+                    "type": "integer"
+                },
+                "ExpiredObjectDeleteMarker": {
+                    "type": "boolean"
+                },
+                "Id": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "NoncurrentVersionExpirationInDays": {
+                    "type": "integer"
+                },
+                "NoncurrentVersionExpiration": {
+                    "$ref": "#/definitions/NoncurrentVersionExpiration"
+                },
+                "NoncurrentVersionTransition": {
+                    "$ref": "#/definitions/NoncurrentVersionTransition"
+                },
+                "NoncurrentVersionTransitions": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/NoncurrentVersionTransition"
+                    }
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "Status": {
+                    "type": "string",
+                    "enum": [
+                        "Enabled",
+                        "Disabled"
+                    ]
+                },
+                "TagFilters": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/TagFilter"
+                    }
+                },
+                "ObjectSizeGreaterThan": {
+                    "type": "string",
+                    "maxLength": 20,
+                    "pattern": "[0-9]+"
+                },
+                "ObjectSizeLessThan": {
+                    "type": "string",
+                    "maxLength": 20,
+                    "pattern": "[0-9]+"
+                },
+                "Transition": {
+                    "$ref": "#/definitions/Transition"
+                },
+                "Transitions": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/Transition"
+                    }
+                }
+            },
+            "required": [
+                "Status"
+            ]
+        },
+        "AbortIncompleteMultipartUpload": {
+            "description": "Specifies the days since the initiation of an incomplete multipart upload that Amazon S3 will wait before permanently removing all parts of the upload.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "DaysAfterInitiation": {
+                    "description": "Specifies the number of days after which Amazon S3 aborts an incomplete multipart upload.",
+                    "type": "integer",
+                    "minimum": 0
+                }
+            },
+            "required": [
+                "DaysAfterInitiation"
+            ]
+        },
+        "iso8601UTC": {
+            "description": "The date value in ISO 8601 format. The timezone is always UTC. (YYYY-MM-DDThh:mm:ssZ)",
+            "type": "string",
+            "pattern": "^([0-2]\\d{3})-(0[0-9]|1[0-2])-([0-2]\\d|3[01])T([01]\\d|2[0-4]):([0-5]\\d):([0-6]\\d)((\\.\\d{3})?)Z$"
+        },
+        "NoncurrentVersionExpiration": {
+            "type": "object",
+            "description": "Container for the expiration rule that describes when noncurrent objects are expired. If your bucket is versioning-enabled (or versioning is suspended), you can set this action to request that Amazon S3 expire noncurrent object versions at a specific period in the object's lifetime",
+            "additionalProperties": false,
+            "properties": {
+                "NoncurrentDays": {
+                    "description": "Specified the number of days an object is noncurrent before Amazon S3 can perform the associated action",
+                    "type": "integer"
+                },
+                "NewerNoncurrentVersions": {
+                    "description": "Specified the number of newer noncurrent and current versions that must exists before performing the associated action",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "NoncurrentDays"
+            ]
+        },
+        "NoncurrentVersionTransition": {
+            "type": "object",
+            "description": "Container for the transition rule that describes when noncurrent objects transition to the STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER_IR, GLACIER, or DEEP_ARCHIVE storage class. If your bucket is versioning-enabled (or versioning is suspended), you can set this action to request that Amazon S3 transition noncurrent object versions to the STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER_IR, GLACIER, or DEEP_ARCHIVE storage class at a specific period in the object's lifetime.",
+            "additionalProperties": false,
+            "properties": {
+                "StorageClass": {
+                    "description": "The class of storage used to store the object.",
+                    "type": "string",
+                    "enum": [
+                        "DEEP_ARCHIVE",
+                        "GLACIER",
+                        "Glacier",
+                        "GLACIER_IR",
+                        "INTELLIGENT_TIERING",
+                        "ONEZONE_IA",
+                        "STANDARD_IA"
+                    ]
+                },
+                "TransitionInDays": {
+                    "description": "Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action.",
+                    "type": "integer"
+                },
+                "NewerNoncurrentVersions": {
+                    "description": "Specified the number of newer noncurrent and current versions that must exists before performing the associated action",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "StorageClass",
+                "TransitionInDays"
+            ]
+        },
+        "Transition": {
+            "type": "object",
+            "properties": {
+                "StorageClass": {
+                    "type": "string",
+                    "enum": [
+                        "DEEP_ARCHIVE",
+                        "GLACIER",
+                        "Glacier",
+                        "GLACIER_IR",
+                        "INTELLIGENT_TIERING",
+                        "ONEZONE_IA",
+                        "STANDARD_IA"
+                    ]
+                },
+                "TransitionDate": {
+                    "$ref": "#/definitions/iso8601UTC"
+                },
+                "TransitionInDays": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false,
+            "description": "You must specify at least one of \"TransitionDate\" and \"TransitionInDays\"",
+            "required": [
+                "StorageClass"
+            ]
+        },
+        "LoggingConfiguration": {
+            "type": "object",
+            "properties": {
+                "DestinationBucketName": {
+                    "type": "string",
+                    "description": "The name of an Amazon S3 bucket where Amazon S3 store server access log files. You can store log files in any bucket that you own. By default, logs are stored in the bucket where the LoggingConfiguration property is defined."
+                },
+                "LogFilePrefix": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "MetricsConfiguration": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "AccessPointArn": {
+                    "type": "string"
+                },
+                "Id": {
+                    "type": "string"
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "TagFilters": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/TagFilter"
+                    }
+                }
+            },
+            "required": [
+                "Id"
+            ]
+        },
+        "NotificationConfiguration": {
+            "description": "Describes the notification configuration for an Amazon S3 bucket.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "EventBridgeConfiguration": {
+                    "$ref": "#/definitions/EventBridgeConfiguration"
+                },
+                "LambdaConfigurations": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/LambdaConfiguration"
+                    }
+                },
+                "QueueConfigurations": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/QueueConfiguration"
+                    }
+                },
+                "TopicConfigurations": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/TopicConfiguration"
+                    }
+                }
+            }
+        },
+        "EventBridgeConfiguration": {
+            "type": "object",
+            "description": "Describes the Amazon EventBridge notification configuration for an Amazon S3 bucket.",
+            "additionalProperties": false,
+            "properties": {
+                "EventBridgeEnabled": {
+                    "description": "Specifies whether to send notifications to Amazon EventBridge when events occur in an Amazon S3 bucket.",
+                    "type": "boolean",
+                    "default": "true"
+                }
+            },
+            "required": [
+                "EventBridgeEnabled"
+            ]
+        },
+        "LambdaConfiguration": {
+            "type": "object",
+            "description": "Describes the AWS Lambda functions to invoke and the events for which to invoke them.",
+            "additionalProperties": false,
+            "properties": {
+                "Event": {
+                    "description": "The Amazon S3 bucket event for which to invoke the AWS Lambda function.",
+                    "type": "string"
+                },
+                "Filter": {
+                    "description": "The filtering rules that determine which objects invoke the AWS Lambda function.",
+                    "$ref": "#/definitions/NotificationFilter"
+                },
+                "Function": {
+                    "description": "The Amazon Resource Name (ARN) of the AWS Lambda function that Amazon S3 invokes when the specified event type occurs.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Function",
+                "Event"
+            ]
+        },
+        "QueueConfiguration": {
+            "type": "object",
+            "description": "The Amazon Simple Queue Service queues to publish messages to and the events for which to publish messages.",
+            "additionalProperties": false,
+            "properties": {
+                "Event": {
+                    "description": "The Amazon S3 bucket event about which you want to publish messages to Amazon SQS.",
+                    "type": "string"
+                },
+                "Filter": {
+                    "description": "The filtering rules that determine which objects trigger notifications.",
+                    "$ref": "#/definitions/NotificationFilter"
+                },
+                "Queue": {
+                    "description": "The Amazon Resource Name (ARN) of the Amazon SQS queue to which Amazon S3 publishes a message when it detects events of the specified type.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Event",
+                "Queue"
+            ]
+        },
+        "TopicConfiguration": {
+            "type": "object",
+            "description": "The topic to which notifications are sent and the events for which notifications are generated.",
+            "additionalProperties": false,
+            "properties": {
+                "Event": {
+                    "description": "The Amazon S3 bucket event about which to send notifications.",
+                    "type": "string"
+                },
+                "Filter": {
+                    "description": "The filtering rules that determine for which objects to send notifications.",
+                    "$ref": "#/definitions/NotificationFilter"
+                },
+                "Topic": {
+                    "description": "The Amazon Resource Name (ARN) of the Amazon SNS topic to which Amazon S3 publishes a message when it detects events of the specified type.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Event",
+                "Topic"
+            ]
+        },
+        "NotificationFilter": {
+            "type": "object",
+            "description": "Specifies object key name filtering rules.",
+            "additionalProperties": false,
+            "properties": {
+                "S3Key": {
+                    "$ref": "#/definitions/S3KeyFilter"
+                }
+            },
+            "required": [
+                "S3Key"
+            ]
+        },
+        "S3KeyFilter": {
+            "type": "object",
+            "description": "A container for object key name prefix and suffix filtering rules.",
+            "additionalProperties": false,
+            "properties": {
+                "Rules": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/FilterRule"
+                    }
+                }
+            },
+            "required": [
+                "Rules"
+            ]
+        },
+        "FilterRule": {
+            "type": "object",
+            "description": "Specifies the Amazon S3 object key name to filter on and whether to filter on the suffix or prefix of the key name.",
+            "additionalProperties": false,
+            "properties": {
+                "Name": {
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Value",
+                "Name"
+            ]
+        },
+        "ObjectLockConfiguration": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ObjectLockEnabled": {
+                    "type": "string",
+                    "const": "Enabled"
+                },
+                "Rule": {
+                    "$ref": "#/definitions/ObjectLockRule"
+                }
+            }
+        },
+        "ObjectLockRule": {
+            "type": "object",
+            "description": "The Object Lock rule in place for the specified object.",
+            "additionalProperties": false,
+            "properties": {
+                "DefaultRetention": {
+                    "$ref": "#/definitions/DefaultRetention"
+                }
+            }
+        },
+        "DefaultRetention": {
+            "type": "object",
+            "description": "The default retention period that you want to apply to new objects placed in the specified bucket.",
+            "additionalProperties": false,
+            "properties": {
+                "Years": {
+                    "type": "integer"
+                },
+                "Days": {
+                    "type": "integer"
+                },
+                "Mode": {
+                    "type": "string",
+                    "enum": [
+                        "COMPLIANCE",
+                        "GOVERNANCE"
+                    ]
+                }
+            }
+        },
+        "OwnershipControls": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Rules": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/OwnershipControlsRule"
+                    }
+                }
+            },
+            "required": [
+                "Rules"
+            ]
+        },
+        "OwnershipControlsRule": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ObjectOwnership": {
+                    "description": "Specifies an object ownership rule.",
+                    "type": "string",
+                    "enum": [
+                        "ObjectWriter",
+                        "BucketOwnerPreferred",
+                        "BucketOwnerEnforced"
+                    ]
+                }
+            }
+        },
+        "PublicAccessBlockConfiguration": {
+            "description": "Configuration that defines how Amazon S3 handles public access.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "BlockPublicAcls": {
+                    "type": "boolean",
+                    "description": "Specifies whether Amazon S3 should block public access control lists (ACLs) for this bucket and objects in this bucket. Setting this element to TRUE causes the following behavior:\n- PUT Bucket acl and PUT Object acl calls fail if the specified ACL is public.\n - PUT Object calls fail if the request includes a public ACL.\nEnabling this setting doesn't affect existing policies or ACLs."
+                },
+                "BlockPublicPolicy": {
+                    "type": "boolean",
+                    "description": "Specifies whether Amazon S3 should block public bucket policies for this bucket. Setting this element to TRUE causes Amazon S3 to reject calls to PUT Bucket policy if the specified bucket policy allows public access.\nEnabling this setting doesn't affect existing bucket policies."
+                },
+                "IgnorePublicAcls": {
+                    "type": "boolean",
+                    "description": "Specifies whether Amazon S3 should ignore public ACLs for this bucket and objects in this bucket. Setting this element to TRUE causes Amazon S3 to ignore all public ACLs on this bucket and objects in this bucket.\nEnabling this setting doesn't affect the persistence of any existing ACLs and doesn't prevent new public ACLs from being set."
+                },
+                "RestrictPublicBuckets": {
+                    "type": "boolean",
+                    "description": "Specifies whether Amazon S3 should restrict public bucket policies for this bucket. Setting this element to TRUE restricts access to this bucket to only AWS services and authorized users within this account if the bucket has a public policy.\nEnabling this setting doesn't affect previously stored bucket policies, except that public and cross-account access within any public bucket policy, including non-public delegation to specific accounts, is blocked."
+                }
+            }
+        },
+        "ReplicationConfiguration": {
+            "type": "object",
+            "description": "A container for replication rules. You can add up to 1,000 rules. The maximum size of a replication configuration is 2 MB.",
+            "additionalProperties": false,
+            "properties": {
+                "Role": {
+                    "description": "The Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role that Amazon S3 assumes when replicating objects.",
+                    "type": "string"
+                },
+                "Rules": {
+                    "description": "A container for one or more replication rules.",
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/ReplicationRule",
+                        "maxLength": 1000,
+                        "minLength": 1
+                    }
+                }
+            },
+            "required": [
+                "Role",
+                "Rules"
+            ]
+        },
+        "ReplicationRule": {
+            "type": "object",
+            "description": "Specifies which Amazon S3 objects to replicate and where to store the replicas.",
+            "additionalProperties": false,
+            "properties": {
+                "DeleteMarkerReplication": {
+                    "$ref": "#/definitions/DeleteMarkerReplication"
+                },
+                "Destination": {
+                    "$ref": "#/definitions/ReplicationDestination"
+                },
+                "Filter": {
+                    "$ref": "#/definitions/ReplicationRuleFilter"
+                },
+                "Id": {
+                    "description": "A unique identifier for the rule.",
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "Prefix": {
+                    "description": "An object key name prefix that identifies the object or objects to which the rule applies.",
+                    "type": "string",
+                    "maxLength": 1024
+                },
+                "Priority": {
+                    "type": "integer"
+                },
+                "SourceSelectionCriteria": {
+                    "$ref": "#/definitions/SourceSelectionCriteria"
+                },
+                "Status": {
+                    "description": "Specifies whether the rule is enabled.",
+                    "type": "string",
+                    "enum": [
+                        "Disabled",
+                        "Enabled"
+                    ]
+                }
+            },
+            "required": [
+                "Destination",
+                "Status"
+            ]
+        },
+        "DeleteMarkerReplication": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Status": {
+                    "type": "string",
+                    "enum": [
+                        "Disabled",
+                        "Enabled"
+                    ]
+                }
+            }
+        },
+        "ReplicationDestination": {
+            "type": "object",
+            "description": "Specifies which Amazon S3 bucket to store replicated objects in and their storage class.",
+            "additionalProperties": false,
+            "properties": {
+                "AccessControlTranslation": {
+                    "$ref": "#/definitions/AccessControlTranslation"
+                },
+                "Account": {
+                    "type": "string"
+                },
+                "Bucket": {
+                    "type": "string"
+                },
+                "EncryptionConfiguration": {
+                    "$ref": "#/definitions/EncryptionConfiguration"
+                },
+                "Metrics": {
+                    "$ref": "#/definitions/Metrics"
+                },
+                "ReplicationTime": {
+                    "$ref": "#/definitions/ReplicationTime"
+                },
+                "StorageClass": {
+                    "description": "The storage class to use when replicating objects, such as S3 Standard or reduced redundancy.",
+                    "type": "string",
+                    "enum": [
+                        "DEEP_ARCHIVE",
+                        "GLACIER",
+                        "GLACIER_IR",
+                        "INTELLIGENT_TIERING",
+                        "ONEZONE_IA",
+                        "REDUCED_REDUNDANCY",
+                        "STANDARD",
+                        "STANDARD_IA"
+                    ]
+                }
+            },
+            "required": [
+                "Bucket"
+            ]
+        },
+        "AccessControlTranslation": {
+            "type": "object",
+            "description": "Specify this only in a cross-account scenario (where source and destination bucket owners are not the same), and you want to change replica ownership to the AWS account that owns the destination bucket. If this is not specified in the replication configuration, the replicas are owned by same AWS account that owns the source object.",
+            "additionalProperties": false,
+            "properties": {
+                "Owner": {
+                    "type": "string",
+                    "const": "Destination"
+                }
+            },
+            "required": [
+                "Owner"
+            ]
+        },
+        "EncryptionConfiguration": {
+            "type": "object",
+            "description": "Specifies encryption-related information for an Amazon S3 bucket that is a destination for replicated objects.",
+            "additionalProperties": false,
+            "properties": {
+                "ReplicaKmsKeyID": {
+                    "description": "Specifies the ID (Key ARN or Alias ARN) of the customer managed customer master key (CMK) stored in AWS Key Management Service (KMS) for the destination bucket.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ReplicaKmsKeyID"
+            ]
+        },
+        "Metrics": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "EventThreshold": {
+                    "$ref": "#/definitions/ReplicationTimeValue"
+                },
+                "Status": {
+                    "type": "string",
+                    "enum": [
+                        "Disabled",
+                        "Enabled"
+                    ]
+                }
+            },
+            "required": [
+                "Status"
+            ]
+        },
+        "ReplicationTimeValue": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Minutes": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "Minutes"
+            ]
+        },
+        "ReplicationTime": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Status": {
+                    "type": "string",
+                    "enum": [
+                        "Disabled",
+                        "Enabled"
+                    ]
+                },
+                "Time": {
+                    "$ref": "#/definitions/ReplicationTimeValue"
+                }
+            },
+            "required": [
+                "Status",
+                "Time"
+            ]
+        },
+        "ReplicationRuleFilter": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "And": {
+                    "$ref": "#/definitions/ReplicationRuleAndOperator"
+                },
+                "Prefix": {
+                    "type": "string"
+                },
+                "TagFilter": {
+                    "$ref": "#/definitions/TagFilter"
+                }
+            }
+        },
+        "ReplicationRuleAndOperator": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Prefix": {
+                    "type": "string"
+                },
+                "TagFilters": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/TagFilter"
+                    }
+                }
+            }
+        },
+        "SourceSelectionCriteria": {
+            "description": "A container that describes additional filters for identifying the source objects that you want to replicate.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ReplicaModifications": {
+                    "description": "A filter that you can specify for selection for modifications on replicas.",
+                    "$ref": "#/definitions/ReplicaModifications"
+                },
+                "SseKmsEncryptedObjects": {
+                    "description": "A container for filter information for the selection of Amazon S3 objects encrypted with AWS KMS.",
+                    "$ref": "#/definitions/SseKmsEncryptedObjects"
+                }
+            }
+        },
+        "ReplicaModifications": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Status": {
+                    "description": "Specifies whether Amazon S3 replicates modifications on replicas.",
+                    "type": "string",
+                    "enum": [
+                        "Enabled",
+                        "Disabled"
+                    ]
+                }
+            },
+            "required": [
+                "Status"
+            ]
+        },
+        "SseKmsEncryptedObjects": {
+            "type": "object",
+            "description": "A container for filter information for the selection of S3 objects encrypted with AWS KMS.",
+            "additionalProperties": false,
+            "properties": {
+                "Status": {
+                    "description": "Specifies whether Amazon S3 replicates objects created with server-side encryption using a customer master key (CMK) stored in AWS Key Management Service.",
+                    "type": "string",
+                    "enum": [
+                        "Disabled",
+                        "Enabled"
+                    ]
+                }
+            },
+            "required": [
+                "Status"
+            ]
+        },
+        "Tag": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                },
+                "Value": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                }
+            },
+            "required": [
+                "Value",
+                "Key"
+            ]
+        },
+        "VersioningConfiguration": {
+            "description": "Describes the versioning state of an Amazon S3 bucket.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Status": {
+                    "description": "The versioning state of the bucket.",
+                    "type": "string",
+                    "default": "Suspended",
+                    "enum": [
+                        "Enabled",
+                        "Suspended"
+                    ]
+                }
+            },
+            "required": [
+                "Status"
+            ]
+        },
+        "WebsiteConfiguration": {
+            "type": "object",
+            "description": "Specifies website configuration parameters for an Amazon S3 bucket.",
+            "additionalProperties": false,
+            "properties": {
+                "ErrorDocument": {
+                    "description": "The name of the error document for the website.",
+                    "type": "string"
+                },
+                "IndexDocument": {
+                    "description": "The name of the index document for the website.",
+                    "type": "string"
+                },
+                "RoutingRules": {
+                    "type": "array",
+                    "insertionOrder": true,
+                    "items": {
+                        "$ref": "#/definitions/RoutingRule"
+                    }
+                },
+                "RedirectAllRequestsTo": {
+                    "$ref": "#/definitions/RedirectAllRequestsTo"
+                }
+            }
+        },
+        "RoutingRule": {
+            "description": "Specifies the redirect behavior and when a redirect is applied.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "RedirectRule": {
+                    "description": "Container for redirect information. You can redirect requests to another host, to another page, or with another protocol. In the event of an error, you can specify a different error code to return.",
+                    "$ref": "#/definitions/RedirectRule"
+                },
+                "RoutingRuleCondition": {
+                    "$ref": "#/definitions/RoutingRuleCondition"
+                }
+            },
+            "required": [
+                "RedirectRule"
+            ]
+        },
+        "RedirectRule": {
+            "type": "object",
+            "description": "Specifies how requests are redirected. In the event of an error, you can specify a different error code to return.",
+            "additionalProperties": false,
+            "properties": {
+                "HostName": {
+                    "description": "The host name to use in the redirect request.",
+                    "type": "string"
+                },
+                "HttpRedirectCode": {
+                    "description": "The HTTP redirect code to use on the response. Not required if one of the siblings is present.",
+                    "type": "string"
+                },
+                "Protocol": {
+                    "description": "Protocol to use when redirecting requests. The default is the protocol that is used in the original request.",
+                    "enum": [
+                        "http",
+                        "https"
+                    ],
+                    "type": "string"
+                },
+                "ReplaceKeyPrefixWith": {
+                    "description": "The object key prefix to use in the redirect request.",
+                    "type": "string"
+                },
+                "ReplaceKeyWith": {
+                    "description": "The specific object key to use in the redirect request.d",
+                    "type": "string"
+                }
+            }
+        },
+        "RoutingRuleCondition": {
+            "description": "A container for describing a condition that must be met for the specified redirect to apply.You must specify at least one of HttpErrorCodeReturnedEquals and KeyPrefixEquals",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "KeyPrefixEquals": {
+                    "description": "The object key name prefix when the redirect is applied.",
+                    "type": "string"
+                },
+                "HttpErrorCodeReturnedEquals": {
+                    "description": "The HTTP error code when the redirect is applied. ",
+                    "type": "string"
+                }
+            }
+        },
+        "RedirectAllRequestsTo": {
+            "description": "Specifies the redirect behavior of all requests to a website endpoint of an Amazon S3 bucket.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "HostName": {
+                    "description": "Name of the host where requests are redirected.",
+                    "type": "string"
+                },
+                "Protocol": {
+                    "description": "Protocol to use when redirecting requests. The default is the protocol that is used in the original request.",
+                    "type": "string",
+                    "enum": [
+                        "http",
+                        "https"
+                    ]
+                }
+            },
+            "required": [
+                "HostName"
+            ]
+        },
+        "Arn": {
+            "description": "the Amazon Resource Name (ARN) of the specified bucket.",
+            "type": "string"
+        }
+    },
+    "tagging": {
+        "taggable": true,
+        "tagOnCreate": true,
+        "tagUpdatable": true,
+        "cloudFormationSystemTags": true,
+        "tagProperty": "/properties/Tags"
+    },
+    "createOnlyProperties": [
+        "/properties/BucketName",
+        "/properties/ObjectLockEnabled"
+    ],
+    "primaryIdentifier": [
+        "/properties/BucketName"
+    ],
+    "readOnlyProperties": [
+        "/properties/Arn",
+        "/properties/DomainName",
+        "/properties/DualStackDomainName",
+        "/properties/RegionalDomainName",
+        "/properties/WebsiteURL"
+    ],
+    "handlers": {
+        "create": {
+            "permissions": [
+                "s3:CreateBucket",
+                "s3:PutBucketTagging",
+                "s3:PutAnalyticsConfiguration",
+                "s3:PutEncryptionConfiguration",
+                "s3:PutBucketCORS",
+                "s3:PutInventoryConfiguration",
+                "s3:PutLifecycleConfiguration",
+                "s3:PutMetricsConfiguration",
+                "s3:PutBucketNotification",
+                "s3:PutBucketReplication",
+                "s3:PutBucketWebsite",
+                "s3:PutAccelerateConfiguration",
+                "s3:PutBucketPublicAccessBlock",
+                "s3:PutReplicationConfiguration",
+                "s3:PutObjectAcl",
+                "s3:PutBucketObjectLockConfiguration",
+                "s3:GetBucketAcl",
+                "s3:ListBucket",
+                "iam:PassRole",
+                "s3:DeleteObject",
+                "s3:PutBucketLogging",
+                "s3:PutBucketVersioning",
+                "s3:PutObjectLockConfiguration",
+                "s3:PutBucketOwnershipControls",
+                "s3:PutBucketIntelligentTieringConfiguration"
+            ]
+        },
+        "read": {
+            "permissions": [
+                "s3:GetAccelerateConfiguration",
+                "s3:GetLifecycleConfiguration",
+                "s3:GetBucketPublicAccessBlock",
+                "s3:GetAnalyticsConfiguration",
+                "s3:GetBucketCORS",
+                "s3:GetEncryptionConfiguration",
+                "s3:GetInventoryConfiguration",
+                "s3:GetBucketLogging",
+                "s3:GetMetricsConfiguration",
+                "s3:GetBucketNotification",
+                "s3:GetBucketVersioning",
+                "s3:GetReplicationConfiguration",
+                "S3:GetBucketWebsite",
+                "s3:GetBucketPublicAccessBlock",
+                "s3:GetBucketObjectLockConfiguration",
+                "s3:GetBucketTagging",
+                "s3:GetBucketOwnershipControls",
+                "s3:GetIntelligentTieringConfiguration",
+                "s3:ListBucket"
+            ]
+        },
+        "update": {
+            "permissions": [
+                "s3:PutBucketAcl",
+                "s3:PutBucketTagging",
+                "s3:PutAnalyticsConfiguration",
+                "s3:PutEncryptionConfiguration",
+                "s3:PutBucketCORS",
+                "s3:PutInventoryConfiguration",
+                "s3:PutLifecycleConfiguration",
+                "s3:PutMetricsConfiguration",
+                "s3:PutBucketNotification",
+                "s3:PutBucketReplication",
+                "s3:PutBucketWebsite",
+                "s3:PutAccelerateConfiguration",
+                "s3:PutBucketPublicAccessBlock",
+                "s3:PutReplicationConfiguration",
+                "s3:PutBucketOwnershipControls",
+                "s3:PutBucketIntelligentTieringConfiguration",
+                "s3:DeleteBucketWebsite",
+                "s3:PutBucketLogging",
+                "s3:PutBucketVersioning",
+                "s3:PutObjectLockConfiguration",
+                "s3:DeleteBucketAnalyticsConfiguration",
+                "s3:DeleteBucketCors",
+                "s3:DeleteBucketMetricsConfiguration",
+                "s3:DeleteBucketEncryption",
+                "s3:DeleteBucketLifecycle",
+                "s3:DeleteBucketReplication",
+                "iam:PassRole"
+            ]
+        },
+        "delete": {
+            "permissions": [
+                "s3:DeleteBucket"
+            ]
+        },
+        "list": {
+            "permissions": [
+                "s3:ListAllMyBuckets"
+            ]
+        }
+    }
+}

--- a/src/rpdk/core/hook/init_hook.py
+++ b/src/rpdk/core/hook/init_hook.py
@@ -1,12 +1,18 @@
 import logging
 import re
 
-from rpdk.core.exceptions import WizardAbortError, WizardValidationError
+from rpdk.core.data_loaders import resource_json
+from rpdk.core.exceptions import (
+    CLIMisconfiguredError,
+    WizardAbortError,
+    WizardValidationError,
+)
 from rpdk.core.plugin_registry import get_plugin_choices
 from rpdk.core.utils.init_utils import input_with_validation, print_error
 
 LOG = logging.getLogger(__name__)
 HOOK_TYPE_NAME_REGEX = r"^[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}::[a-zA-Z0-9]{2,64}$"
+HOOK_PLUGINS = ("java", "python37", "python38", "python39")
 
 
 def init_hook(args, project):
@@ -31,7 +37,21 @@ def init_hook(args, project):
     }
 
     project.init_hook(type_name, language, settings)
-    project.generate(args.endpoint_url, args.region, args.target_schemas, args.profile)
+    try:
+        project.generate(
+            args.endpoint_url, args.region, False, args.target_schemas, args.profile
+        )
+    except CLIMisconfiguredError as e:
+        LOG.debug(
+            "Error when initializing hook project, attempting local project generation",
+            exc_info=e,
+        )
+        example_target = resource_json(
+            __name__, "../data/examples/hook/targets/aws-s3-bucket.json"
+        )
+        project.generate(
+            args.endpoint_url, args.region, True, [example_target], args.profile
+        )
     # Reload the generated example schema
     project.load_configuration_schema()
     # generate the docs based on the example schema loaded
@@ -77,7 +97,7 @@ def validate_type_name(value):
 
 class ValidatePluginChoice:
     def __init__(self, choices):
-        self.choices = tuple(choices)
+        self.choices = tuple(filter(lambda l: l in HOOK_PLUGINS, choices))
         self.max = len(self.choices)
 
         pretty = "\n".join(

--- a/tests/hook/test_init_hook.py
+++ b/tests/hook/test_init_hook.py
@@ -71,7 +71,7 @@ def test_validate_plugin_choice_greater_than_choice():
 
 
 def test_validate_plugin_choice_valid():
-    choices = ["python38", PROMPT, "pyton39"]
+    choices = ["python38", PROMPT, "python39"]
     validator = ValidatePluginChoice(choices)
     assert validator("2") == PROMPT
 

--- a/tests/hook/test_init_hook.py
+++ b/tests/hook/test_init_hook.py
@@ -9,7 +9,8 @@ from rpdk.core.hook.init_hook import (
     input_typename,
     validate_type_name,
 )
-from tests.test_init import PROMPT
+
+PROMPT = "java"
 
 
 def test_input_typename():
@@ -36,7 +37,7 @@ def test_input_language_one_plugin():
 
 
 def test_input_language_several_plugins():
-    validator = ValidatePluginChoice(["1", PROMPT, "2"])
+    validator = ValidatePluginChoice(["python38", PROMPT, "python39"])
     patch_validator = patch(
         "rpdk.core.hook.init_hook.validate_plugin_choice", validator
     )
@@ -70,7 +71,7 @@ def test_validate_plugin_choice_greater_than_choice():
 
 
 def test_validate_plugin_choice_valid():
-    choices = ["1", PROMPT, "2"]
+    choices = ["python38", PROMPT, "pyton39"]
     validator = ValidatePluginChoice(choices)
     assert validator("2") == PROMPT
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -128,7 +128,9 @@ def test_init_hook_method_interactive():
             "profile": DEFAULT_PROFILE,
         },
     )
-    mock_project.generate.assert_called_once_with(None, None, [], DEFAULT_PROFILE)
+    mock_project.generate.assert_called_once_with(
+        None, None, False, [], DEFAULT_PROFILE
+    )
 
 
 def test_init_resource_method_noninteractive():
@@ -222,7 +224,9 @@ def test_init_hook_method_noninteractive():
             "profile": DEFAULT_PROFILE,
         },
     )
-    mock_project.generate.assert_called_once_with(None, None, [], DEFAULT_PROFILE)
+    mock_project.generate.assert_called_once_with(
+        None, None, False, [], DEFAULT_PROFILE
+    )
 
 
 def test_init_resource_method_noninteractive_invalid_type_name():
@@ -328,7 +332,9 @@ def test_init_hook_method_noninteractive_invalid_type_name():
             "profile": DEFAULT_PROFILE,
         },
     )
-    mock_project.generate.assert_called_once_with(None, None, [], DEFAULT_PROFILE)
+    mock_project.generate.assert_called_once_with(
+        None, None, False, [], DEFAULT_PROFILE
+    )
 
 
 def test_init_hook_method_noninteractive_target_schemas():
@@ -383,6 +389,7 @@ def test_init_hook_method_noninteractive_target_schemas():
     mock_project.generate.assert_called_once_with(
         None,
         None,
+        False,
         ["/files/target-schema.json", "/files/other-target-schema.json"],
         DEFAULT_PROFILE,
     )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2451,7 +2451,7 @@ def test__load_target_info_for_hooks(project):
     }
 
     mock_loader.assert_called_once_with(
-        set(test_type_info.keys()),
+        sorted(test_type_info.keys()),
         local_schemas=[
             "/files/target-schema.json",
             "/files/target-schema-not-for-this-project.json",


### PR DESCRIPTION
*Issue #, if available:*
* https://github.com/aws-cloudformation/cloudformation-cli/issues/959
* https://github.com/aws-cloudformation/cloudformation-cli/issues/960


*Description of changes:*
Updated the `cfn init` command for `HOOK` type projects to only allow projects to be initialized with language plugins that support `HOOK` types.

This PR also fixes an issue with error being thrown when project was initialized with no AWS credentials set

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
