### PR TITLE
Update lifecycle config for the logs bucket.

### DIFF
--- a/src/rpdk/core/data/managed-upload-infrastructure.yaml
+++ b/src/rpdk/core/data/managed-upload-infrastructure.yaml
@@ -43,8 +43,14 @@ Resources:
             SSEAlgorithm: AES256
       LifecycleConfiguration:
         Rules:
-          - Status: Enabled
+          - Id: ExpireObjectsLifecycleRule
+            Status: Enabled
             ExpirationInDays: 3653
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+          - Id: ExpiredObjectDeleteMarkerLifecycleRule
+            Status: Enabled
+            ExpiredObjectDeleteMarker: true
       VersioningConfiguration:
         Status: Enabled
       PublicAccessBlockConfiguration:


### PR DESCRIPTION
*Issue #, if available:*
Fix #1001

*Description of changes:*
For the logs bucket described in the template, update its lifecycle configuration as follows:
- replace the existing rule with `Status: Enabled` and `ExpirationInDays: 3653` with the same content, and:
    - add a name for the rule, for consistency;
    - add configuration to expunge noncurrent objects (as the logs bucket is versioned) after one day they became noncurrent (in the case of this versioned bucket with `ExpirationInDays: 3653`, objects will be made noncurrent after 10 years or 3653 days);
- add another, separate rule to expunge expired object delete markers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
