### PR TITLE
Fix pin to cfn-lint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "colorama>=0.4.1",
         "docker>=4.3.1",
         "ordered-set>=4.0.2",
-        "cfn-lint<=0.72.10",
+        "cfn-lint>=0.78.1",
         "cfn_flip>=1.2.3",
         "nested-lookup",
     ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
PR #990 pins the version of cfn-lint without much documentation or linking to bugs.  This will revert that pin as there isn't much reason to have the public version of this pinned down.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
