### PR TITLE
Support for extending cfn cli with custom commands

### DIFF
--- a/src/rpdk/core/cli.py
+++ b/src/rpdk/core/cli.py
@@ -12,13 +12,13 @@ from .__init__ import __version__
 from .build_image import setup_subparser as build_image_setup_subparser
 from .data_loaders import resource_yaml
 from .exceptions import DownstreamError, SysExitRecommendedError
+from .extensions import setup_subparsers as extensions_setup_subparser
 from .generate import setup_subparser as generate_setup_subparser
 from .init import setup_subparser as init_setup_subparser
 from .invoke import setup_subparser as invoke_setup_subparser
 from .submit import setup_subparser as submit_setup_subparser
 from .test import setup_subparser as test_setup_subparser
 from .validate import setup_subparser as validate_setup_subparser
-from .extensions import setup_subparsers as extensions_setup_subparser
 
 EXIT_UNHANDLED_EXCEPTION = 127
 
@@ -43,6 +43,7 @@ def setup_logging(verbosity):
 
 def unittest_patch_setup_subparser(_subparsers, _parents):
     pass
+
 
 def main(args_in=None):  # pylint: disable=too-many-statements
     """The entry point for the CLI."""

--- a/src/rpdk/core/cli.py
+++ b/src/rpdk/core/cli.py
@@ -18,6 +18,7 @@ from .invoke import setup_subparser as invoke_setup_subparser
 from .submit import setup_subparser as submit_setup_subparser
 from .test import setup_subparser as test_setup_subparser
 from .validate import setup_subparser as validate_setup_subparser
+from .plugin_registry import get_parsers, get_plugin_choices, get_extensions
 
 EXIT_UNHANDLED_EXCEPTION = 127
 
@@ -43,6 +44,17 @@ def setup_logging(verbosity):
 def unittest_patch_setup_subparser(_subparsers, _parents):
     pass
 
+def extension_setup_subparser(subparsers, parents):
+    ext = get_extensions()
+
+    for name, extension_cls in ext.items():
+        # parser = subparsers.add_parser(name, parents=parents)
+        # The entry point should be some common class
+        # so that we can do things like ext[name].setup_subparser() in addition to just setting the command
+        extension = extension_cls()()
+        extension.setup_subparser(subparsers, parents)
+        print("UGA UGA")
+        print(name, extension, extension_cls)
 
 def main(args_in=None):  # pylint: disable=too-many-statements
     """The entry point for the CLI."""
@@ -88,6 +100,7 @@ def main(args_in=None):  # pylint: disable=too-many-statements
         invoke_setup_subparser(subparsers, parents)
         unittest_patch_setup_subparser(subparsers, parents)
         build_image_setup_subparser(subparsers, parents)
+        extension_setup_subparser(subparsers, parents)
         args = parser.parse_args(args=args_in)
 
         setup_logging(args.verbose)

--- a/src/rpdk/core/cli.py
+++ b/src/rpdk/core/cli.py
@@ -18,7 +18,7 @@ from .invoke import setup_subparser as invoke_setup_subparser
 from .submit import setup_subparser as submit_setup_subparser
 from .test import setup_subparser as test_setup_subparser
 from .validate import setup_subparser as validate_setup_subparser
-from .plugin_registry import get_parsers, get_plugin_choices, get_extensions
+from .extensions import setup_subparsers as extensions_setup_subparser
 
 EXIT_UNHANDLED_EXCEPTION = 127
 
@@ -43,18 +43,6 @@ def setup_logging(verbosity):
 
 def unittest_patch_setup_subparser(_subparsers, _parents):
     pass
-
-def extension_setup_subparser(subparsers, parents):
-    ext = get_extensions()
-
-    for name, extension_cls in ext.items():
-        # parser = subparsers.add_parser(name, parents=parents)
-        # The entry point should be some common class
-        # so that we can do things like ext[name].setup_subparser() in addition to just setting the command
-        extension = extension_cls()()
-        extension.setup_subparser(subparsers, parents)
-        print("UGA UGA")
-        print(name, extension, extension_cls)
 
 def main(args_in=None):  # pylint: disable=too-many-statements
     """The entry point for the CLI."""
@@ -100,7 +88,7 @@ def main(args_in=None):  # pylint: disable=too-many-statements
         invoke_setup_subparser(subparsers, parents)
         unittest_patch_setup_subparser(subparsers, parents)
         build_image_setup_subparser(subparsers, parents)
-        extension_setup_subparser(subparsers, parents)
+        extensions_setup_subparser(subparsers, parents)
         args = parser.parse_args(args=args_in)
 
         setup_logging(args.verbose)

--- a/src/rpdk/core/extensions.py
+++ b/src/rpdk/core/extensions.py
@@ -1,0 +1,8 @@
+from .plugin_registry import get_extensions
+
+def setup_subparsers(subparsers, parents):
+    extensions = get_extensions()
+
+    for extension_cls in extensions.values():
+        extension = extension_cls()()
+        extension.setup_subparser(subparsers, parents)

--- a/src/rpdk/core/extensions.py
+++ b/src/rpdk/core/extensions.py
@@ -1,10 +1,18 @@
 from .plugin_registry import get_extensions
 
 
+def _check_command_name_collision(subparsers, command_name):
+    if command_name in subparsers.choices:
+        raise RuntimeError(
+            f'"{command_name}" is already registered as an extension. Please use a different name.'
+        )
+
+
 def setup_subparsers(subparsers, parents):
     extensions = get_extensions()
 
     for extension_cls in extensions.values():
         extension = extension_cls()()
+        _check_command_name_collision(subparsers, extension.command_name)
         parser = subparsers.add_parser(extension.command_name, parents=parents)
         extension.setup_parser(parser)

--- a/src/rpdk/core/extensions.py
+++ b/src/rpdk/core/extensions.py
@@ -1,5 +1,6 @@
 from .plugin_registry import get_extensions
 
+
 def setup_subparsers(subparsers, parents):
     extensions = get_extensions()
 

--- a/src/rpdk/core/extensions.py
+++ b/src/rpdk/core/extensions.py
@@ -6,4 +6,5 @@ def setup_subparsers(subparsers, parents):
 
     for extension_cls in extensions.values():
         extension = extension_cls()()
-        extension.setup_subparser(subparsers, parents)
+        parser = subparsers.add_parser(extension.command_name, parents=parents)
+        extension.setup_parser(parser)

--- a/src/rpdk/core/plugin_base.py
+++ b/src/rpdk/core/plugin_base.py
@@ -68,7 +68,3 @@ class ExtensionPlugin(ABC):
     @abstractmethod
     def setup_subparser(self, subparsers, parents):
         pass
-
-    @abstractmethod
-    def execute(self, args):
-        pass

--- a/src/rpdk/core/plugin_base.py
+++ b/src/rpdk/core/plugin_base.py
@@ -55,3 +55,12 @@ class LanguagePlugin(ABC):
     @abstractmethod
     def package(self, project, zip_file):
         pass
+
+class ExtensionPlugin(ABC):
+    @abstractmethod
+    def setup_subparser(self, subparsers, parents):
+        pass
+
+    @abstractmethod
+    def execute(self, args):
+        pass

--- a/src/rpdk/core/plugin_base.py
+++ b/src/rpdk/core/plugin_base.py
@@ -61,7 +61,7 @@ class ExtensionPlugin(ABC):
     COMMAND_NAME = None
 
     @property
-    def _command_name(self):
+    def command_name(self):
         if not self.COMMAND_NAME:
             raise RuntimeError(
                 "Set COMMAND_NAME to the command you want to extend cfn with: `cfn COMMAND_NAME`."
@@ -69,5 +69,5 @@ class ExtensionPlugin(ABC):
         return self.COMMAND_NAME
 
     @abstractmethod
-    def setup_subparser(self, parent_subparsers, parents):
+    def setup_parser(self, parser):
         pass

--- a/src/rpdk/core/plugin_base.py
+++ b/src/rpdk/core/plugin_base.py
@@ -56,15 +56,18 @@ class LanguagePlugin(ABC):
     def package(self, project, zip_file):
         pass
 
+
 class ExtensionPlugin(ABC):
     COMMAND_NAME = None
 
     @property
     def _command_name(self):
         if not self.COMMAND_NAME:
-            raise RuntimeError("Set COMMAND_NAME to the command you want to extend cfn with: `cfn COMMAND_NAME`.")
+            raise RuntimeError(
+                "Set COMMAND_NAME to the command you want to extend cfn with: `cfn COMMAND_NAME`."
+            )
         return self.COMMAND_NAME
 
     @abstractmethod
-    def setup_subparser(self, subparsers, parents):
+    def setup_subparser(self, parent_subparsers, parents):
         pass

--- a/src/rpdk/core/plugin_base.py
+++ b/src/rpdk/core/plugin_base.py
@@ -57,6 +57,14 @@ class LanguagePlugin(ABC):
         pass
 
 class ExtensionPlugin(ABC):
+    COMMAND_NAME = None
+
+    @property
+    def _command_name(self):
+        if not self.COMMAND_NAME:
+            raise RuntimeError("Set COMMAND_NAME to the command you want to extend cfn with: `cfn COMMAND_NAME`.")
+        return self.COMMAND_NAME
+
     @abstractmethod
     def setup_subparser(self, subparsers, parents):
         pass

--- a/src/rpdk/core/plugin_registry.py
+++ b/src/rpdk/core/plugin_registry.py
@@ -22,6 +22,7 @@ def get_parsers():
 
     return parsers
 
+
 def get_extensions():
     extensions = {
         entry_point.name: entry_point.load
@@ -29,6 +30,7 @@ def get_extensions():
     }
 
     return extensions
+
 
 def load_plugin(language):
     return PLUGIN_REGISTRY[language]()()

--- a/src/rpdk/core/plugin_registry.py
+++ b/src/rpdk/core/plugin_registry.py
@@ -22,6 +22,13 @@ def get_parsers():
 
     return parsers
 
+def get_extensions():
+    extensions = {
+        entry_point.name: entry_point.load
+        for entry_point in pkg_resources.iter_entry_points("rpdk.v1.extensions")
+    }
+
+    return extensions
 
 def load_plugin(language):
     return PLUGIN_REGISTRY[language]()()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,6 +77,15 @@ def test_main_no_args_prints_help(capsys):
     assert "--help" in out
 
 
+def test_main_setup_extensions():
+    with patch(
+        "rpdk.core.cli.extensions_setup_subparser"
+    ) as extensions_setup_subparser:
+        main(args_in=[])
+
+    extensions_setup_subparser.assert_called_once()
+
+
 def test_main_version_arg_prints_version(capsys):
     main(args_in=["--version"])
     out, err = capsys.readouterr()

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,0 +1,18 @@
+from unittest.mock import MagicMock, patch
+
+from rpdk.core.extensions import setup_subparsers
+
+
+def test_setup_subparsers():
+    patch_get_extensions = patch("rpdk.core.extensions.get_extensions")
+
+    subparsers, parents = MagicMock(), MagicMock()
+
+    with patch_get_extensions as mock_get_extensions:
+        mock_extension_entry_point = MagicMock()
+        extensions = {"key": mock_extension_entry_point}
+        mock_get_extensions.return_value = extensions
+        setup_subparsers(subparsers, parents)
+
+    mock_extension = mock_extension_entry_point.return_value.return_value
+    mock_extension.setup_subparser.assert_called_once_with(subparsers, parents)

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,25 +1,60 @@
+import argparse
+from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from rpdk.core.extensions import setup_subparsers
 
 
-def test_setup_subparsers():
-    expeted_command_name = "expected-command-name"
+class ExtensionTest(TestCase):
+    def test_setup_subparsers(self):  # pylint: disable=no-self-use
+        expeted_command_name = "expected-command-name"
 
-    mock_extension = MagicMock()
-    mock_extension.command_name = expeted_command_name
+        mock_extension = MagicMock()
+        mock_extension.command_name = expeted_command_name
 
-    mock_extension_entry_point = MagicMock()
-    mock_extension_entry_point.return_value.return_value = mock_extension
+        mock_extension_entry_point = MagicMock()
+        mock_extension_entry_point.return_value.return_value = mock_extension
 
-    mock_extension_entry_points = {"key": mock_extension_entry_point}
+        mock_extension_entry_points = {"key": mock_extension_entry_point}
 
-    subparsers, parents, parser = MagicMock(), MagicMock(), MagicMock()
-    subparsers.add_parser.return_value = parser
+        subparsers, parents, parser = MagicMock(), MagicMock(), MagicMock()
+        subparsers.add_parser.return_value = parser
 
-    with patch("rpdk.core.extensions.get_extensions") as mock_get_extensions:
-        mock_get_extensions.return_value = mock_extension_entry_points
-        setup_subparsers(subparsers, parents)
+        with patch("rpdk.core.extensions.get_extensions") as mock_get_extensions:
+            mock_get_extensions.return_value = mock_extension_entry_points
+            setup_subparsers(subparsers, parents)
 
-    mock_extension.setup_parser.assert_called_once_with(parser)
-    subparsers.add_parser.assert_called_with(expeted_command_name, parents=parents)
+        mock_extension.setup_parser.assert_called_once_with(parser)
+        subparsers.add_parser.assert_called_with(expeted_command_name, parents=parents)
+
+    def test_setup_subparsers_should_raise_error_when_collision_occur(self):
+        command_name = "command-name"
+
+        mock_extension_1, mock_extension_2 = MagicMock(), MagicMock()
+        mock_extension_1.command_name = command_name
+        mock_extension_2.command_name = command_name
+
+        mock_extension_1_entry_point = MagicMock()
+        mock_extension_1_entry_point.return_value.return_value = mock_extension_1
+
+        mock_extension_2_entry_point = MagicMock()
+        mock_extension_2_entry_point.return_value.return_value = mock_extension_2
+
+        mock_extension_entry_points = {
+            "key_1": mock_extension_1_entry_point,
+            "key_2": mock_extension_2_entry_point,
+        }
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+
+        with patch(
+            "rpdk.core.extensions.get_extensions"
+        ) as mock_get_extensions, self.assertRaises(RuntimeError) as context:
+            mock_get_extensions.return_value = mock_extension_entry_points
+            setup_subparsers(subparsers, [])
+
+        assert (
+            str(context.exception)
+            == '"command-name" is already registered as an extension. Please use a different name.'
+        )

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -4,15 +4,22 @@ from rpdk.core.extensions import setup_subparsers
 
 
 def test_setup_subparsers():
-    patch_get_extensions = patch("rpdk.core.extensions.get_extensions")
+    expeted_command_name = "expected-command-name"
 
-    subparsers, parents = MagicMock(), MagicMock()
+    mock_extension = MagicMock()
+    mock_extension.command_name = expeted_command_name
 
-    with patch_get_extensions as mock_get_extensions:
-        mock_extension_entry_point = MagicMock()
-        extensions = {"key": mock_extension_entry_point}
-        mock_get_extensions.return_value = extensions
+    mock_extension_entry_point = MagicMock()
+    mock_extension_entry_point.return_value.return_value = mock_extension
+
+    mock_extension_entry_points = {"key": mock_extension_entry_point}
+
+    subparsers, parents, parser = MagicMock(), MagicMock(), MagicMock()
+    subparsers.add_parser.return_value = parser
+
+    with patch("rpdk.core.extensions.get_extensions") as mock_get_extensions:
+        mock_get_extensions.return_value = mock_extension_entry_points
         setup_subparsers(subparsers, parents)
 
-    mock_extension = mock_extension_entry_point.return_value.return_value
-    mock_extension.setup_subparser.assert_called_once_with(subparsers, parents)
+    mock_extension.setup_parser.assert_called_once_with(parser)
+    subparsers.add_parser.assert_called_with(expeted_command_name, parents=parents)

--- a/tests/test_plugin_base.py
+++ b/tests/test_plugin_base.py
@@ -93,8 +93,8 @@ def test_language_plugin_setup_jinja_env_no_spec(language_plugin):
 class TestExtensionPlugin(ExtensionPlugin):
     COMMAND_NAME = "test-extension"
 
-    def setup_subparser(self, parent_subparsers, parents):
-        super().setup_subparser(parent_subparsers, parents)
+    def setup_parser(self, parser):
+        super().setup_parser(parser)
 
 
 @pytest.fixture
@@ -102,5 +102,15 @@ def extension_plugin():
     return TestExtensionPlugin()
 
 
-def test_extension_plugin_package_no_op(extension_plugin):
-    extension_plugin.setup_subparser(None, None)
+def test_extension_plugin_command_name(extension_plugin):
+    assert extension_plugin.command_name == "test-extension"
+
+
+def test_extension_plugin_command_name_error(extension_plugin):
+    extension_plugin.COMMAND_NAME = None
+    with pytest.raises(RuntimeError):
+        extension_plugin.command_name  # pylint: disable=pointless-statement
+
+
+def test_extension_plugin_setup_parser_no_op(extension_plugin):
+    extension_plugin.setup_parser(None)

--- a/tests/test_plugin_base.py
+++ b/tests/test_plugin_base.py
@@ -5,7 +5,11 @@ from unittest.mock import call, patch
 import pytest
 
 from rpdk.core.filters import FILTER_REGISTRY
-from rpdk.core.plugin_base import LanguagePlugin, __name__ as plugin_base_name
+from rpdk.core.plugin_base import (
+    ExtensionPlugin,
+    LanguagePlugin,
+    __name__ as plugin_base_name,
+)
 
 
 class TestLanguagePlugin(LanguagePlugin):
@@ -84,3 +88,19 @@ def test_language_plugin_setup_jinja_env_no_spec(language_plugin):
 
     for name in FILTER_REGISTRY:
         assert name in env.filters
+
+
+class TestExtensionPlugin(ExtensionPlugin):
+    COMMAND_NAME = "test-extension"
+
+    def setup_subparser(self, parent_subparsers, parents):
+        super().setup_subparser(parent_subparsers, parents)
+
+
+@pytest.fixture
+def extension_plugin():
+    return TestExtensionPlugin()
+
+
+def test_extension_plugin_package_no_op(extension_plugin):
+    extension_plugin.setup_subparser(None, None)

--- a/tests/test_plugin_base.py
+++ b/tests/test_plugin_base.py
@@ -22,7 +22,7 @@ class TestLanguagePlugin(LanguagePlugin):
 
 
 @pytest.fixture
-def plugin():
+def language_plugin():
     return TestLanguagePlugin()
 
 
@@ -34,20 +34,20 @@ def test_language_plugin_module_not_set():
         plugin._module_name  # pylint: disable=pointless-statement
 
 
-def test_language_plugin_init_no_op(plugin):
-    plugin.init(None)
+def test_language_plugin_init_no_op(language_plugin):
+    language_plugin.init(None)
 
 
-def test_language_plugin_generate_no_op(plugin):
-    plugin.generate(None)
+def test_language_plugin_generate_no_op(language_plugin):
+    language_plugin.generate(None)
 
 
-def test_language_plugin_package_no_op(plugin):
-    plugin.package(None, None)
+def test_language_plugin_package_no_op(language_plugin):
+    language_plugin.package(None, None)
 
 
-def test_language_plugin_setup_jinja_env_defaults(plugin):
-    env = plugin._setup_jinja_env()
+def test_language_plugin_setup_jinja_env_defaults(language_plugin):
+    env = language_plugin._setup_jinja_env()
     assert env.loader
     assert env.autoescape
 
@@ -57,10 +57,10 @@ def test_language_plugin_setup_jinja_env_defaults(plugin):
     assert env.get_template("test.txt")
 
 
-def test_language_plugin_setup_jinja_env_overrides(plugin):
+def test_language_plugin_setup_jinja_env_overrides(language_plugin):
     loader = object()
     autoescape = object()
-    env = plugin._setup_jinja_env(autoescape=autoescape, loader=loader)
+    env = language_plugin._setup_jinja_env(autoescape=autoescape, loader=loader)
     assert env.loader is loader
     assert env.autoescape is autoescape
 
@@ -68,14 +68,16 @@ def test_language_plugin_setup_jinja_env_overrides(plugin):
         assert name in env.filters
 
 
-def test_language_plugin_setup_jinja_env_no_spec(plugin):
+def test_language_plugin_setup_jinja_env_no_spec(language_plugin):
     with patch(
         "rpdk.core.plugin_base.importlib.util.find_spec", return_value=None
     ) as mock_spec, patch("rpdk.core.plugin_base.PackageLoader") as mock_loader:
-        env = plugin._setup_jinja_env()
+        env = language_plugin._setup_jinja_env()
 
-    mock_spec.assert_called_once_with(plugin._module_name)
-    mock_loader.assert_has_calls([call(plugin._module_name), call(plugin_base_name)])
+    mock_spec.assert_called_once_with(language_plugin._module_name)
+    mock_loader.assert_has_calls(
+        [call(language_plugin._module_name), call(plugin_base_name)]
+    )
 
     assert env.loader
     assert env.autoescape

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock, patch
 
-from rpdk.core.plugin_registry import load_plugin
+from rpdk.core.plugin_registry import get_extensions, load_plugin
 
 
 def test_load_plugin():
@@ -11,3 +11,21 @@ def test_load_plugin():
         load_plugin("test")
     plugin.assert_called_once_with()
     plugin.return_value.assert_called_once_with()
+
+
+def test_get_extensions():
+    mock_entrypoint_1 = Mock()
+    mock_entrypoint_2 = Mock()
+
+    patch_iter_entry_points = patch(
+        "rpdk.core.plugin_registry.pkg_resources.iter_entry_points"
+    )
+    with patch_iter_entry_points as mock_iter_entry_points:
+        mock_iter_entry_points.return_value = [mock_entrypoint_1, mock_entrypoint_2]
+
+        extensions = get_extensions()
+
+    assert extensions == {
+        mock_entrypoint_1.name: mock_entrypoint_1.load,
+        mock_entrypoint_2.name: mock_entrypoint_2.load,
+    }


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* 

This change enables custom plugins to be developed under the `rpdk.v1.extensions` entrypoint to extend `cfn` functionality. E.g. developing a new `hello` command:
```
cfn hello --name Adrian

Hello, Adrian!
```

In this change, I introduce the `ExtensionPlugin` abstract base class, which has 2 methods. `command_name` determines what the command will be (e.g. `hello` in the above example). This registers a subparser under `cfn`. The second method is `setup_parser` which should be implemented in the child class to setup any arguments and behaviors required (e.g. `--name` parameter and printing `Hello, Adrian!` in examble above)

The way a new extension can be setup is the same way as other plugins already developed, where you simply `pip install` the package in your environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
