### PR TITLE
Validate typename prefix is valid when creating ListType request whil…

### DIFF
--- a/src/rpdk/core/type_name_resolver.py
+++ b/src/rpdk/core/type_name_resolver.py
@@ -1,6 +1,7 @@
 import fnmatch
 import logging
 import os
+import re
 
 from botocore.exceptions import ClientError
 
@@ -13,6 +14,9 @@ REGISTRY_DEPRECATED_STATUS_LIVE = "LIVE"
 REGISTRY_VISIBILITY_PRIVATE = "PRIVATE"
 REGISTRY_VISIBILITY_PUBLIC = "PUBLIC"
 REGISTRY_RESULTS_PAGE_SIZE = 100
+TYPE_NAME_PREFIX_REGEX = (
+    r"([A-Za-z0-9]{2,64}::){0,2}([A-Za-z0-9]{2,64}:?){0,1}(:[A-Za-z0-9:]{2,64}){0,1}"
+)
 
 
 def contains_wildcard(pattern):
@@ -132,7 +136,7 @@ class TypeNameResolver:
             prefix = prefix[:index]
 
         req = {}
-        if prefix:
+        if prefix and re.fullmatch(TYPE_NAME_PREFIX_REGEX, prefix):
             req["Filters"] = {"TypeNamePrefix": prefix}
 
         return req

--- a/tests/test_type_name_resolver.py
+++ b/tests/test_type_name_resolver.py
@@ -237,15 +237,18 @@ def test_resolve_type_names_locally_no_local_info(resolver):
         (["AWS::S?::Bucket"], "AWS::S"),
         (["AWS::S?::*Bucket"], "AWS::S"),
         (["AWS::*::Log*"], "AWS::"),
-        (["A*::S?::Bucket*"], "A"),
+        (["A*::S?::Bucket*"], None),
         (["*::S?::Bucket*"], ""),
         (["AWS::S?::BucketPolicy", "AWS::S3::Bucket"], "AWS::S"),
         (["AWS::S*::Queue", "AWS::DynamoDB::*"], "AWS::"),
+        (["AwsCommunity::S3::BucketVersioningEnabled", "AWS::*"], None),
+        (["AWSSamples::*", f'AW{"S" * 64}*', "AWS::S3::Bucket"], "AWS"),
+        ([f'AW{"S" * 64}*'], None),
     ],
 )
 def test_create_list_types_request(type_names, expected):
     req = TypeNameResolver._create_list_types_request(type_names)
     if not expected:
-        assert not req
+        assert req == {}
     else:
         assert req == {"Filters": {"TypeNamePrefix": expected}}


### PR DESCRIPTION
…e resolving hook target names

*Issue #, if available:*

*Description of changes:*
Updated the TypeNameResolver to validate that the type name prefix used with the TypeFilters field is correct and matches expected regex for parameter

Error message:
```
botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the ListTypes operation: 1 validation error detected: Value 'A' at 'filters.typeNamePrefix' failed to satisfy constraint: Member must satisfy regular expression pattern: ([A-Za-z0-9]{2,64}::){0,2}([A-Za-z0-9]{2,64}:?){0,1}(:[A-Za-z0-9:]{2,64}){0,1}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
