### PR TITLE
Fix prepare_payload_for_reinvocation in invoke

### DIFF
--- a/src/rpdk/core/invoke.py
+++ b/src/rpdk/core/invoke.py
@@ -76,7 +76,7 @@ def get_contract_client(args, project):
 def prepare_payload_for_reinvocation(payload, response, artifact_type):
     if artifact_type == ARTIFACT_TYPE_RESOURCE:
         payload["callbackContext"] = response.get("callbackContext")
-        if response.get("resourceModel") and payload.get("requestData"):
+        if ("resourceModel" in response) and ("requestData" in payload):
             payload["requestData"]["resourceProperties"] = response.get("resourceModel")
 
     return payload

--- a/src/rpdk/core/invoke.py
+++ b/src/rpdk/core/invoke.py
@@ -76,6 +76,8 @@ def get_contract_client(args, project):
 def prepare_payload_for_reinvocation(payload, response, artifact_type):
     if artifact_type == ARTIFACT_TYPE_RESOURCE:
         payload["callbackContext"] = response.get("callbackContext")
+        if response.get("resourceModel") and payload.get("requestData"):
+            payload["requestData"]["resourceProperties"] = response.get("resourceModel")
 
     return payload
 


### PR DESCRIPTION
*Description of changes:*

This is for the use case where we are leveraging cfn invoke.
Before the fix only the callbackContext was passedin leading to a situation where if the model is updated and the handler emits a progress event we would end up losing recoding the updates that were made (and making the handler fail for those instances).  
One such example is when we are creating a resources and there are multiple API calls needed to materialize this resource with a progress event being emitted between this API calls and one of the later API calls needed info returned by the earlier calls and persisted in the model.

    Validation:
    seed isort known_third_party.............................................Passed
    isort....................................................................Passed
    black....................................................................Passed
    check for case conflicts.................................................Passed
    fix end of files.........................................................Passed
    mixed line ending........................................................Passed
    trim trailing whitespace.................................................Passed
    pretty format json...................................(no files to check)Skipped
    check for merge conflicts................................................Passed
    flake8...................................................................Passed
    check blanket noqa.......................................................Passed
    check for not-real mock methods..........................................Passed
    use logger.warning(......................................................Passed
    bandit...................................................................Passed
    pylint-local.............................................................Passed
    pytest-local.............................................................Passed

    In addition ran the cfn invoke and verified that the model is correctly passed back in

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
