### PR TITLE
require botocore version 1.31.17, as it has tlv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "cfn-lint>=0.78.1",
         "cfn_flip>=1.2.3",
         "nested-lookup",
+        "botocore>=1.31.17",
     ],
     entry_points={
         "console_scripts": ["cfn-cli = rpdk.core.cli:main", "cfn = rpdk.core.cli:main"]


### PR DESCRIPTION
botocore version 1.31.17 has tlv, needed to run contract test in tlv.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
