### PR TITLE
fix(submit): only adding .json files from the inputs

### DIFF
--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -673,11 +673,13 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             LOG.debug("%s found. Writing to package.", OVERRIDES_FILENAME)
         except FileNotFoundError:
             LOG.debug("%s not found. Not writing to package.", OVERRIDES_FILENAME)
+        
 
     def _add_resources_content_to_zip(self, zip_file):
         zip_file.write(self.schema_path, SCHEMA_UPLOAD_FILENAME)
         if os.path.isdir(self.inputs_path):
-            for filename in os.listdir(self.inputs_path):
+            input_files = os.listdir(self.inputs_path)
+            for filename in list(filter(lambda f: f.endsWith('.json'), input_files)):
                 absolute_path = self.inputs_path / filename
                 zip_file.write(absolute_path, INPUTS_FOLDER + "/" + filename)
                 LOG.debug("%s found. Writing to package.", filename)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -91,6 +91,7 @@ INVALID_INPUTS_FILE = "inputs/inputs_1_invalid.json"
 PRE_CREATE_INPUTS_FILE = "inputs/inputs_1_pre_create.json"
 PRE_UPDATE_INPUTS_FILE = "inputs/inputs_1_pre_update.json"
 INVALID_PRE_DELETE_INPUTS_FILE = "inputs/inputs_1_invalid_pre_delete.json"
+README_INPUTS_FILE = "inputs/README.md"
 
 PLUGIN_INFORMATION = {
     "plugin-version": "2.1.3",
@@ -1125,7 +1126,7 @@ def test_settings_not_found(project):
     assert "init" in str(excinfo.value)
 
 
-def create_input_file(base):
+def create_input_files(base):
     path = base / "inputs"
     os.mkdir(path, mode=0o777)
 
@@ -1140,6 +1141,11 @@ def create_input_file(base):
     path_invalid = base / INVALID_INPUTS_FILE
     with path_invalid.open("w", encoding="utf-8") as f:
         f.write("{}")
+
+    # Add a file 
+    path_readme = base / README_INPUTS_FILE
+    with path_readme.open("w", encoding="utf-8") as f:
+        f.write("# My README for devs")
 
 
 def create_hook_input_file(base):
@@ -1207,7 +1213,7 @@ def test_submit_dry_run(project, is_type_configuration_available):
     with project.overrides_path.open("w", encoding="utf-8") as f:
         f.write(json.dumps(empty_override()))
 
-    create_input_file(project.root)
+    create_input_files(project.root)
 
     project.write_settings()
 
@@ -1279,6 +1285,8 @@ def test_submit_dry_run(project, is_type_configuration_available):
         assert input_invalid == {}
         input_update = json.loads(zip_file.read(UPDATE_INPUTS_FILE).decode("utf-8"))
         assert input_update == {}
+        # ensure we don't add non-json files
+        assert README_INPUTS_FILE not in zipfile.namelist()
         assert zip_file.testzip() is None
         metadata_info = json.loads(zip_file.read(CFN_METADATA_FILENAME).decode("utf-8"))
         assert "cli-version" in metadata_info
@@ -1374,7 +1382,7 @@ def test_submit_dry_run_hooks(project):
     with project.overrides_path.open("w", encoding="utf-8") as f:
         f.write(json.dumps(empty_hook_override()))
 
-    create_input_file(project.root)
+    create_input_files(project.root)
 
     project.write_settings()
 


### PR DESCRIPTION
*Issue #, if available:*
[Relates to issue 1046](https://github.com/aws-cloudformation/cloudformation-cli/issues/1046)

*Description of changes:*

While running cloudformation validation, if you add a README.md or anything into your `inputs/` folder, you will only find out  during submission that you failed to upload your resource type because the non-open source cloudformation code tries to parse every file into .json in that folder.

As a result, this PR proposes the simplest fix for cloudformation-cli users, which is only uploading .json files from the input folder.  That way, developers can create supplemental information for their extensions and how they are expected to be tested.

PS: if this proposal is approved, I would like to also submit a follow-up PR to use a comment tolerating JSON library to process these json files into raw JSON so that maintainers can leave comments about why they have chosen certain payload configurations in the .json file itself.

Please feel free to push back on anything and let me know if there is a greater scope I'm missing!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
