### PR TITLE
Adding regex based exports replacement

### DIFF
--- a/src/rpdk/core/test.py
+++ b/src/rpdk/core/test.py
@@ -127,6 +127,7 @@ def _stub_exports(template, exports, pattern):
                 f"Export does not contain provided undeclared variable '{export}'. {e}"
             ) from e
         return value_to_stub
+
     return re.sub(pattern, __retrieve_args, template)
 
 

--- a/src/rpdk/core/test.py
+++ b/src/rpdk/core/test.py
@@ -125,10 +125,8 @@ def _stub_exports(template, exports, pattern):
             LOG.error(str(e))
             raise ValueError(
                 f"Export does not contain provided undeclared variable '{export}'. {e}"
-            )
-        else:
-            return value_to_stub
-
+            ) from e
+        return value_to_stub
     return re.sub(pattern, __retrieve_args, template)
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding a regex based exports replacement, as it is a less expensive manipulation. The change finds `{{ variable }}` pattern that jinja supports but verifies that variable is compliant with [stack export naming convention](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html). 

Example:

overrides.json
```
{
    "CREATE": {
        "/SubnetId": "{{ subnetID }}"
    }
}
```

rendered overrides.json
```
{
    "CREATE": {
        "/SubnetId": "subnet-0bc6136e"
    }
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
