### PR TITLE
Fix for docs generation when no items key for a schema property of array type is present.

### DIFF
--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -959,6 +959,22 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     lambda markdown_value: f"List of {markdown_value}"
                 )  # noqa: E731
 
+                if "items" not in prop.keys():
+                    LOG.warning(
+                        'Warning: found schema property of array type with no "items" key; \n'
+                        'defaulting data types for array items to "Map" in generated docs.\n'
+                        'If "Map" is not what you need instead, specify the expected data type \n'
+                        "for array items such as (example with items of string type):\n"
+                        '    "ExampleProperty" : {\n'
+                        '        "description" : "Example description.",\n'
+                        '        "type": "array",\n'
+                        '        "items": {\n'
+                        '            "type": "string"\n'
+                        "        }\n"
+                        "    }\n"
+                    )
+                    prop["items"] = {}
+
                 # potential circular ref
                 # setting up markdown before going deep in the heap to reuse markdown
                 if "$ref" in prop["items"]:

--- a/tests/data/schema/hook/valid/valid_hook_configuration_with_array_items.json
+++ b/tests/data/schema/hook/valid/valid_hook_configuration_with_array_items.json
@@ -1,0 +1,40 @@
+{
+    "typeName": "TestOnly::Sample::Hook",
+    "description": "Example hook schema for unit tests.",
+    "sourceUrl": "https://github.com/aws-cloudformation/SAMPLE-URL-SUFFIX",
+    "documentationUrl": "https://github.com/aws-cloudformation/SAMPLE-URL-SUFFIX/blob/main/README.md",
+    "typeConfiguration": {
+        "properties": {
+            "exampleArrayProperty": {
+                "type": "array",
+                "description": "Example property of array type with items of string type.",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "additionalProperties": false
+    },
+    "required": [],
+    "handlers": {
+        "preCreate": {
+            "targetNames": [
+                "AWS::S3::Bucket"
+            ],
+            "permissions": []
+        },
+        "preUpdate": {
+            "targetNames": [
+                "AWS::S3::Bucket"
+            ],
+            "permissions": []
+        },
+        "preDelete": {
+            "targetNames": [
+                "AWS::S3::Bucket"
+            ],
+            "permissions": []
+        }
+    },
+    "additionalProperties": false
+}

--- a/tests/data/schema/hook/valid/valid_hook_configuration_without_array_items.json
+++ b/tests/data/schema/hook/valid/valid_hook_configuration_without_array_items.json
@@ -1,0 +1,37 @@
+{
+    "typeName": "TestOnly::Sample::Hook",
+    "description": "Example hook schema for unit tests.",
+    "sourceUrl": "https://github.com/aws-cloudformation/SAMPLE-URL-SUFFIX",
+    "documentationUrl": "https://github.com/aws-cloudformation/SAMPLE-URL-SUFFIX/blob/main/README.md",
+    "typeConfiguration": {
+        "properties": {
+            "exampleArrayProperty": {
+                "type": "array",
+                "description": "Example property of array type without items (that is, an 'items` key at this same level)."
+            }
+        },
+        "additionalProperties": false
+    },
+    "required": [],
+    "handlers": {
+        "preCreate": {
+            "targetNames": [
+                "AWS::S3::Bucket"
+            ],
+            "permissions": []
+        },
+        "preUpdate": {
+            "targetNames": [
+                "AWS::S3::Bucket"
+            ],
+            "permissions": []
+        },
+        "preDelete": {
+            "targetNames": [
+                "AWS::S3::Bucket"
+            ],
+            "permissions": []
+        }
+    },
+    "additionalProperties": false
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix for documentation generation when no `items` key for a schema property of `array` type is present. When running `cfn generate`, for example against a schema of a CloudFormation hook that is missing the `items` node for a given property of `array` type, while the schema validation succeeds, the document generation logic fails with a `KeyError` because it assumes the `items` node is present in the input data:

```
[...]
    if "$ref" in prop["items"]:
                 ~~~~^^^^^^^^^
KeyError: 'items'
```

This change fixes this behavior by leaving the schema validation unchanged, and by defaulting to an empty map for `items` if `items` itself is not present in the input data. Proposed changes also include a warning message for the user to take action if needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
