### PR TITLE
Issues with pytest 8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ ipdb>=0.13
 # testing tools
 pylint==3.0.1
 coverage>=7.3.2
-pytest>=7.4.2
+pytest>=7.4.2,<8.0.0
 pytest-cov>=4.1.0
 pytest-random-order>=1.1.0
 hypothesis>=6.87.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Version 8 of pytest is causing issues with the patches builtin.open calls resulting in the tests to fail

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
