### PR TITLE
Implement canary file generation functionality from contract test PatchInputs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ include_trailing_comma = true
 combine_as_imports = True
 force_grid_wrap = 0
 known_first_party = rpdk
-known_third_party = boto3,botocore,cfn_tools,cfnlint,colorama,docker,hypothesis,jinja2,jsonschema,nested_lookup,ordered_set,pkg_resources,pytest,pytest_localserver,requests,setuptools,yaml
+known_third_party = boto3,botocore,cfn_tools,cfnlint,colorama,docker,hypothesis,jinja2,jsonpatch,jsonschema,nested_lookup,ordered_set,pkg_resources,pytest,pytest_localserver,requests,setuptools,yaml
 
 [tool:pytest]
 # can't do anything about 3rd part modules, so don't spam us

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "boto3>=1.10.20",
         "Jinja2>=3.1.2",
         "markupsafe>=2.1.0",
+        "jsonpatch",
         "jsonschema>=3.0.0,<=4.17.3",
         "pytest>=4.5.0",
         "pytest-random-order>=1.0.4",

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -57,6 +57,8 @@ from .utils import CONTENTS_UTF8, UnclosingBytesIO
 ARTIFACT_TYPE_RESOURCE = "RESOURCE"
 ARTIFACT_TYPE_MODULE = "MODULE"
 ARTIFACT_TYPE_HOOK = "HOOK"
+CANARY_CREATE_FILE_SUFFIX = "001"
+CANARY_PATCH_FILE_SUFFIX = "002"
 LANGUAGE = "BQHDBC"
 TYPE_NAME = "AWS::Color::Red"
 MODULE_TYPE_NAME = "AWS::Color::Red::MODULE"
@@ -3017,3 +3019,494 @@ def test_generate_canary_files_empty_canary_settings(project):
     canary_folder_path = tmp_path / TARGET_CANARY_FOLDER
     assert not canary_root_path.exists()
     assert not canary_folder_path.exists()
+
+
+def _get_mock_yaml_dump_call_arg(
+    call_args_list, canary_operation_suffix, arg_index=0, contract_test_count="2"
+):
+    pattern = (
+        rf"{CANARY_FILE_PREFIX}{contract_test_count}_{canary_operation_suffix}\.yaml$"
+    )
+    return [
+        call_item
+        for call_item in call_args_list
+        if re.search(pattern, call_item.args[1].name)
+    ][arg_index]
+
+
+@patch("rpdk.core.project.yaml.dump")
+def test_generate_canary_files_with_patch_inputs(mock_yaml_dump, project):
+    tmp_path = project.root
+    update_value_1 = "Value1b"
+    contract_test_data = {
+        "CreateInputs": {
+            "Property1": "Value1",
+        },
+        "PatchInputs": [
+            {
+                "op": "replace",
+                "path": "Property1",
+                "value": update_value_1,
+            }
+        ],
+    }
+    setup_contract_test_data(project.root, contract_test_data)
+    plugin = object()
+    data = json.dumps(
+        {
+            "artifact_type": "RESOURCE",
+            "language": LANGUAGE,
+            "runtime": RUNTIME,
+            "entrypoint": None,
+            "testEntrypoint": None,
+            "futureProperty": "value",
+            "typeName": "AWS::Example::Resource",
+            "canarySettings": {
+                FILE_GENERATION_ENABLED: True,
+                CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
+            },
+        }
+    )
+    patch_load = patch(
+        "rpdk.core.project.load_plugin", autospec=True, return_value=plugin
+    )
+
+    with patch_settings(project, data) as mock_open, patch_load as mock_load:
+        project.load_settings()
+    project.generate_canary_files()
+    mock_open.assert_called_once_with("r", encoding="utf-8")
+    mock_load.assert_called_once_with(LANGUAGE)
+    canary_root_path = tmp_path / TARGET_CANARY_ROOT_FOLDER
+    canary_folder_path = tmp_path / TARGET_CANARY_FOLDER
+    assert canary_root_path.exists()
+    assert canary_folder_path.exists()
+
+    canary_files = list(canary_folder_path.glob(f"{CANARY_FILE_PREFIX}*"))
+    assert len(canary_files) == 4
+    canary_files.sort()
+    assert canary_files[0].name == f"{CANARY_FILE_PREFIX}1_001.yaml"
+    assert canary_files[1].name == f"{CANARY_FILE_PREFIX}1_002.yaml"
+    assert canary_files[2].name == f"{CANARY_FILE_PREFIX}2_001.yaml"
+    assert canary_files[3].name == f"{CANARY_FILE_PREFIX}2_002.yaml"
+
+    bootstrap_file = canary_root_path / CANARY_DEPENDENCY_FILE_NAME
+    assert bootstrap_file.exists()
+
+
+@patch("rpdk.core.project.yaml.dump")
+def test_create_template_file_with_patch_inputs(mock_yaml_dump, project):
+    update_value_1 = "Value1b"
+    update_value_2 = "Value2b"
+
+    contract_test_data = {
+        "CreateInputs": {
+            "Property1": "Value1",
+            "Property2": "{{test123}}",
+            "Property3": {"Nested": "{{partition}}"},
+            "Property4": ["{{region}}", "Value2"],
+            "Property5": "{{uuid}}",
+            "Property6": "{{account}}",
+            "Property7": "prefix-{{uuid}}-sufix",
+        },
+        "PatchInputs": [
+            {
+                "op": "replace",
+                "path": "Property1",
+                "value": update_value_1,
+            },
+            {
+                "op": "replace",
+                "path": "Property2",
+                "value": "{{test1234}}",
+            },
+            {
+                "op": "replace",
+                "path": "Property3",
+                "value": {"Nested": "{{partition}}"},
+            },
+            {
+                "op": "replace",
+                "path": "Property4",
+                "value": ["{{region}}", update_value_2],
+            },
+        ],
+    }
+    setup_contract_test_data(project.root, contract_test_data)
+    plugin = object()
+    data = json.dumps(
+        {
+            "artifact_type": "RESOURCE",
+            "language": LANGUAGE,
+            "runtime": RUNTIME,
+            "entrypoint": None,
+            "testEntrypoint": None,
+            "futureProperty": "value",
+            "typeName": "AWS::Example::Resource",
+            "canarySettings": {
+                FILE_GENERATION_ENABLED: True,
+                CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
+            },
+        }
+    )
+    patch_load = patch(
+        "rpdk.core.project.load_plugin", autospec=True, return_value=plugin
+    )
+
+    with patch_settings(project, data) as mock_open, patch_load as mock_load:
+        project.load_settings()
+    project.generate_canary_files()
+    mock_open.assert_called_once_with("r", encoding="utf-8")
+    mock_load.assert_called_once_with(LANGUAGE)
+    # verify that PatchInputs canary template has the PatchInputs "replace" operation applied
+    expected_template_data = {
+        "Description": "Template for AWS::Example::Resource",
+        "Resources": {
+            "Resource": {
+                "Type": "AWS::Example::Resource",
+                "Properties": {
+                    "Property1": update_value_1,
+                    "Property2": {"Fn::ImportValue": "test1234"},
+                    "Property3": {"Nested": {"Fn::Sub": "${AWS::Partition}"}},
+                    "Property4": [{"Fn::Sub": "${AWS::Region}"}, update_value_2],
+                    "Property5": ANY,
+                    "Property6": {"Fn::Sub": "${AWS::AccountId}"},
+                    "Property7": ANY,
+                },
+            }
+        },
+    }
+    args, kwargs = _get_mock_yaml_dump_call_arg(
+        mock_yaml_dump.call_args_list, CANARY_PATCH_FILE_SUFFIX
+    )
+    assert args[0] == expected_template_data
+    assert kwargs
+
+    # verify that CreateInputs canary is correct
+    expected_template_data_create = {
+        "Description": "Template for AWS::Example::Resource",
+        "Resources": {
+            "Resource": {
+                "Type": "AWS::Example::Resource",
+                "Properties": {
+                    "Property1": "Value1",
+                    "Property2": {"Fn::ImportValue": "test123"},
+                    "Property3": {"Nested": {"Fn::Sub": "${AWS::Partition}"}},
+                    "Property4": [{"Fn::Sub": "${AWS::Region}"}, "Value2"],
+                    "Property5": ANY,
+                    "Property6": {"Fn::Sub": "${AWS::AccountId}"},
+                    "Property7": ANY,
+                },
+            }
+        },
+    }
+    args, kwargs = _get_mock_yaml_dump_call_arg(
+        mock_yaml_dump.call_args_list, CANARY_CREATE_FILE_SUFFIX
+    )
+    assert args[0] == expected_template_data_create
+    assert kwargs
+
+
+@patch("rpdk.core.project.yaml.dump")
+def test_create_template_file_with_skipped_patch_operation(mock_yaml_dump, project):
+    update_value_1 = "Value1b"
+    update_value_2 = "Value2b"
+    contract_test_data = {
+        "CreateInputs": {
+            "Property1": "Value1",
+            "Property2": "{{test123}}",
+            "Property3": {"Nested": "{{partition}}"},
+            "Property4": ["{{region}}", "Value2"],
+            "Property5": "{{uuid}}",
+            "Property6": "{{account}}",
+            "Property7": "prefix-{{uuid}}-sufix",
+        },
+        "PatchInputs": [
+            {
+                "op": "replace",
+                "path": "Property1",
+                "value": update_value_1,
+            },
+            {
+                "op": "add",
+                "path": "Property4",
+                "value": ["{{region}}", update_value_2],
+            },
+        ],
+    }
+    setup_contract_test_data(project.root, contract_test_data)
+    plugin = object()
+    data = json.dumps(
+        {
+            "artifact_type": "RESOURCE",
+            "language": LANGUAGE,
+            "runtime": RUNTIME,
+            "entrypoint": None,
+            "testEntrypoint": None,
+            "futureProperty": "value",
+            "typeName": "AWS::Example::Resource",
+            "canarySettings": {
+                FILE_GENERATION_ENABLED: True,
+                CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
+            },
+        }
+    )
+    patch_load = patch(
+        "rpdk.core.project.load_plugin", autospec=True, return_value=plugin
+    )
+
+    with patch_settings(project, data) as mock_open, patch_load as mock_load:
+        project.load_settings()
+    project.generate_canary_files()
+    mock_open.assert_called_once_with("r", encoding="utf-8")
+    mock_load.assert_called_once_with(LANGUAGE)
+    # verify that PatchInputs canary template has the PatchInputs "replace" operation applied
+    expected_template_data = {
+        "Description": "Template for AWS::Example::Resource",
+        "Resources": {
+            "Resource": {
+                "Type": "AWS::Example::Resource",
+                "Properties": {
+                    "Property1": update_value_1,
+                    "Property2": {"Fn::ImportValue": ANY},
+                    "Property3": {"Nested": {"Fn::Sub": "${AWS::Partition}"}},
+                    "Property4": [{"Fn::Sub": "${AWS::Region}"}, "Value2"],
+                    "Property5": ANY,
+                    "Property6": {"Fn::Sub": "${AWS::AccountId}"},
+                    "Property7": ANY,
+                },
+            }
+        },
+    }
+    args, kwargs = _get_mock_yaml_dump_call_arg(
+        mock_yaml_dump.call_args_list, CANARY_PATCH_FILE_SUFFIX
+    )
+    assert args[0] == expected_template_data
+    assert kwargs
+
+    # verify that CreateInputs canary is correct
+    expected_template_data_create = {
+        "Description": "Template for AWS::Example::Resource",
+        "Resources": {
+            "Resource": {
+                "Type": "AWS::Example::Resource",
+                "Properties": {
+                    "Property1": "Value1",
+                    "Property2": {"Fn::ImportValue": ANY},
+                    "Property3": {"Nested": {"Fn::Sub": "${AWS::Partition}"}},
+                    "Property4": [{"Fn::Sub": "${AWS::Region}"}, "Value2"],
+                    "Property5": ANY,
+                    "Property6": {"Fn::Sub": "${AWS::AccountId}"},
+                    "Property7": ANY,
+                },
+            }
+        },
+    }
+    args, kwargs = args, kwargs = _get_mock_yaml_dump_call_arg(
+        mock_yaml_dump.call_args_list, CANARY_CREATE_FILE_SUFFIX
+    )
+    assert args[0] == expected_template_data_create
+    assert kwargs
+
+
+@patch("rpdk.core.project.yaml.dump")
+def test_create_template_file_with_patch_inputs_missing_from_create(
+    mock_yaml_dump, project
+):
+    update_value_2 = "Value2b"
+    contract_test_data = {
+        "CreateInputs": {
+            "Property1": "Value1",
+            "Property2": "{{test123}}",
+            "Property3": {"Nested": "{{partition}}"},
+            "Property5": "{{uuid}}",
+            "Property6": "{{account}}",
+            "Property7": "prefix-{{uuid}}-sufix",
+        },
+        "PatchInputs": [
+            {
+                "op": "replace",
+                "path": "Property4",
+                "value": ["{{region}}", update_value_2],
+            },
+        ],
+    }
+    setup_contract_test_data(project.root, contract_test_data)
+    plugin = object()
+    data = json.dumps(
+        {
+            "artifact_type": "RESOURCE",
+            "language": LANGUAGE,
+            "runtime": RUNTIME,
+            "entrypoint": None,
+            "testEntrypoint": None,
+            "futureProperty": "value",
+            "typeName": "AWS::Example::Resource",
+            "canarySettings": {
+                FILE_GENERATION_ENABLED: True,
+                CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
+            },
+        }
+    )
+    patch_load = patch(
+        "rpdk.core.project.load_plugin", autospec=True, return_value=plugin
+    )
+
+    with patch_settings(project, data) as mock_open, patch_load as mock_load:
+        project.load_settings()
+    project.generate_canary_files()
+    mock_open.assert_called_once_with("r", encoding="utf-8")
+    mock_load.assert_called_once_with(LANGUAGE)
+    # verify that PatchInputs canary template has the PatchInputs "replace" operation applied
+    expected_template_data = {
+        "Description": "Template for AWS::Example::Resource",
+        "Resources": {
+            "Resource": {
+                "Type": "AWS::Example::Resource",
+                "Properties": {
+                    "Property1": "Value1",
+                    "Property2": {"Fn::ImportValue": ANY},
+                    "Property3": {"Nested": {"Fn::Sub": "${AWS::Partition}"}},
+                    "Property4": [{"Fn::Sub": "${AWS::Region}"}, update_value_2],
+                    "Property5": ANY,
+                    "Property6": {"Fn::Sub": "${AWS::AccountId}"},
+                    "Property7": ANY,
+                },
+            }
+        },
+    }
+    args, kwargs = _get_mock_yaml_dump_call_arg(
+        mock_yaml_dump.call_args_list, CANARY_PATCH_FILE_SUFFIX
+    )
+    assert args[0] == expected_template_data
+    assert kwargs
+
+    # verify that CreateInputs canary is correct
+    expected_template_data_create = {
+        "Description": "Template for AWS::Example::Resource",
+        "Resources": {
+            "Resource": {
+                "Type": "AWS::Example::Resource",
+                "Properties": {
+                    "Property1": "Value1",
+                    "Property2": {"Fn::ImportValue": ANY},
+                    "Property3": {"Nested": {"Fn::Sub": "${AWS::Partition}"}},
+                    "Property5": ANY,
+                    "Property6": {"Fn::Sub": "${AWS::AccountId}"},
+                    "Property7": ANY,
+                },
+            }
+        },
+    }
+    args, kwargs = _get_mock_yaml_dump_call_arg(
+        mock_yaml_dump.call_args_list, CANARY_CREATE_FILE_SUFFIX
+    )
+    assert args[0] == expected_template_data_create
+    assert kwargs
+
+
+@patch("rpdk.core.project.yaml.dump")
+def test_create_template_file_with_nested_patch_inputs(mock_yaml_dump, project):
+    update_value_1 = "Value_Nested1b"
+    update_value_2 = "Value_Nested2b"
+    contract_test_data = {
+        "CreateInputs": {
+            "Property1": "Value1",
+            "Property8": {
+                "Nested": {
+                    "PropertyA": "Value_Nested1",
+                    "PropertyB": ["{{region}}", "Value_Nested2"],
+                }
+            },
+        },
+        "PatchInputs": [
+            {
+                "op": "replace",
+                "path": "Property8/Nested/PropertyA",
+                "value": update_value_1,
+            },
+            {
+                "op": "replace",
+                "path": "Property8/Nested/PropertyB",
+                "value": ["{{region}}", update_value_2],
+            },
+        ],
+    }
+    setup_contract_test_data(project.root, contract_test_data)
+    plugin = object()
+    data = json.dumps(
+        {
+            "artifact_type": "RESOURCE",
+            "language": LANGUAGE,
+            "runtime": RUNTIME,
+            "entrypoint": None,
+            "testEntrypoint": None,
+            "futureProperty": "value",
+            "typeName": "AWS::Example::Resource",
+            "canarySettings": {
+                FILE_GENERATION_ENABLED: True,
+                CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
+            },
+        }
+    )
+    patch_load = patch(
+        "rpdk.core.project.load_plugin", autospec=True, return_value=plugin
+    )
+
+    with patch_settings(project, data) as mock_open, patch_load as mock_load:
+        project.load_settings()
+    project.generate_canary_files()
+    mock_open.assert_called_once_with("r", encoding="utf-8")
+    mock_load.assert_called_once_with(LANGUAGE)
+    # verify that PatchInputs canary template has the PatchInputs "replace" operation applied
+    expected_template_data = {
+        "Description": "Template for AWS::Example::Resource",
+        "Resources": {
+            "Resource": {
+                "Type": "AWS::Example::Resource",
+                "Properties": {
+                    "Property1": "Value1",
+                    "Property8": {
+                        "Nested": {
+                            "PropertyA": update_value_1,
+                            "PropertyB": [
+                                {"Fn::Sub": "${AWS::Region}"},
+                                update_value_2,
+                            ],
+                        }
+                    },
+                },
+            }
+        },
+    }
+    args, kwargs = _get_mock_yaml_dump_call_arg(
+        mock_yaml_dump.call_args_list, CANARY_PATCH_FILE_SUFFIX
+    )
+    assert args[0] == expected_template_data
+    assert kwargs
+
+    # verify that CreateInputs canary is correct
+    expected_template_data_create = {
+        "Description": "Template for AWS::Example::Resource",
+        "Resources": {
+            "Resource": {
+                "Type": "AWS::Example::Resource",
+                "Properties": {
+                    "Property1": "Value1",
+                    "Property8": {
+                        "Nested": {
+                            "PropertyA": "Value_Nested1",
+                            "PropertyB": [
+                                {"Fn::Sub": "${AWS::Region}"},
+                                "Value_Nested2",
+                            ],
+                        }
+                    },
+                },
+            }
+        },
+    }
+    args, kwargs = _get_mock_yaml_dump_call_arg(
+        mock_yaml_dump.call_args_list, CANARY_CREATE_FILE_SUFFIX
+    )
+    assert args[0] == expected_template_data_create
+    assert kwargs

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -3116,7 +3116,7 @@ def test_create_template_file_with_patch_inputs(mock_yaml_dump, project):
             },
             {
                 "op": "replace",
-                "path": "Property2",
+                "path": "/Property2",
                 "value": "{{test1234}}",
             },
             {
@@ -3157,7 +3157,7 @@ def test_create_template_file_with_patch_inputs(mock_yaml_dump, project):
     project.generate_canary_files()
     mock_open.assert_called_once_with("r", encoding="utf-8")
     mock_load.assert_called_once_with(LANGUAGE)
-    # verify that PatchInputs canary template has the PatchInputs "replace" operation applied
+
     expected_template_data = {
         "Description": "Template for AWS::Example::Resource",
         "Resources": {
@@ -3180,6 +3180,8 @@ def test_create_template_file_with_patch_inputs(mock_yaml_dump, project):
     )
     assert args[0] == expected_template_data
     assert kwargs
+    # verify that dynamically generated variables will be equal between patch and create canaries
+    patch_property5 = args[0]["Resources"]["Resource"]["Properties"]["Property5"]
 
     # verify that CreateInputs canary is correct
     expected_template_data_create = {
@@ -3204,6 +3206,81 @@ def test_create_template_file_with_patch_inputs(mock_yaml_dump, project):
     )
     assert args[0] == expected_template_data_create
     assert kwargs
+    assert (
+        patch_property5 == args[0]["Resources"]["Resource"]["Properties"]["Property5"]
+    )
+
+
+@patch("rpdk.core.project.yaml.dump")
+def test_create_template_file_by_list_index(mock_yaml_dump, project):
+    update_value_1 = "Value1b"
+    update_value_2 = "Value2b"
+    contract_test_data = {
+        "CreateInputs": {
+            "Property1": ["{{region}}", "Value1"],
+            "Property2": ["{{region}}", "Value2"],
+        },
+        "PatchInputs": [
+            {
+                "op": "replace",
+                "path": "Property1/1",
+                "value": update_value_1,
+            },
+            {
+                "op": "add",
+                "path": "Property2/1",
+                "value": update_value_2,
+            },
+        ],
+    }
+    setup_contract_test_data(project.root, contract_test_data)
+    plugin = object()
+    data = json.dumps(
+        {
+            "artifact_type": "RESOURCE",
+            "language": LANGUAGE,
+            "runtime": RUNTIME,
+            "entrypoint": None,
+            "testEntrypoint": None,
+            "futureProperty": "value",
+            "typeName": "AWS::Example::Resource",
+            "canarySettings": {
+                FILE_GENERATION_ENABLED: True,
+                CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
+            },
+        }
+    )
+    patch_load = patch(
+        "rpdk.core.project.load_plugin", autospec=True, return_value=plugin
+    )
+
+    with patch_settings(project, data) as mock_open, patch_load as mock_load:
+        project.load_settings()
+    project.generate_canary_files()
+    mock_open.assert_called_once_with("r", encoding="utf-8")
+    mock_load.assert_called_once_with(LANGUAGE)
+
+    expected_template_data = {
+        "Description": "Template for AWS::Example::Resource",
+        "Resources": {
+            "Resource": {
+                "Type": "AWS::Example::Resource",
+                "Properties": {
+                    "Property1": [{"Fn::Sub": "${AWS::Region}"}, update_value_1],
+                    "Property2": [
+                        {"Fn::Sub": "${AWS::Region}"},
+                        update_value_2,
+                        "Value2",
+                    ],
+                },
+            }
+        },
+    }
+    args, kwargs = _get_mock_yaml_dump_call_arg(
+        mock_yaml_dump.call_args_list, CANARY_PATCH_FILE_SUFFIX
+    )
+    assert args[0] == expected_template_data
+    assert kwargs
 
 
 @patch("rpdk.core.project.yaml.dump")
@@ -3222,15 +3299,16 @@ def test_create_template_file_with_skipped_patch_operation(mock_yaml_dump, proje
         },
         "PatchInputs": [
             {
-                "op": "replace",
+                "op": "test",
                 "path": "Property1",
                 "value": update_value_1,
             },
             {
-                "op": "add",
+                "op": "move",
                 "path": "Property4",
-                "value": ["{{region}}", update_value_2],
+                "value": update_value_2,
             },
+            {"op": "copy", "from": "Property4", "path": "Property2"},
         ],
     }
     setup_contract_test_data(project.root, contract_test_data)
@@ -3259,32 +3337,8 @@ def test_create_template_file_with_skipped_patch_operation(mock_yaml_dump, proje
     project.generate_canary_files()
     mock_open.assert_called_once_with("r", encoding="utf-8")
     mock_load.assert_called_once_with(LANGUAGE)
-    # verify that PatchInputs canary template has the PatchInputs "replace" operation applied
-    expected_template_data = {
-        "Description": "Template for AWS::Example::Resource",
-        "Resources": {
-            "Resource": {
-                "Type": "AWS::Example::Resource",
-                "Properties": {
-                    "Property1": update_value_1,
-                    "Property2": {"Fn::ImportValue": ANY},
-                    "Property3": {"Nested": {"Fn::Sub": "${AWS::Partition}"}},
-                    "Property4": [{"Fn::Sub": "${AWS::Region}"}, "Value2"],
-                    "Property5": ANY,
-                    "Property6": {"Fn::Sub": "${AWS::AccountId}"},
-                    "Property7": ANY,
-                },
-            }
-        },
-    }
-    args, kwargs = _get_mock_yaml_dump_call_arg(
-        mock_yaml_dump.call_args_list, CANARY_PATCH_FILE_SUFFIX
-    )
-    assert args[0] == expected_template_data
-    assert kwargs
 
-    # verify that CreateInputs canary is correct
-    expected_template_data_create = {
+    expected_template_data = {
         "Description": "Template for AWS::Example::Resource",
         "Resources": {
             "Resource": {
@@ -3301,10 +3355,10 @@ def test_create_template_file_with_skipped_patch_operation(mock_yaml_dump, proje
             }
         },
     }
-    args, kwargs = args, kwargs = _get_mock_yaml_dump_call_arg(
-        mock_yaml_dump.call_args_list, CANARY_CREATE_FILE_SUFFIX
+    args, kwargs = _get_mock_yaml_dump_call_arg(
+        mock_yaml_dump.call_args_list, CANARY_PATCH_FILE_SUFFIX
     )
-    assert args[0] == expected_template_data_create
+    assert args[0] == expected_template_data
     assert kwargs
 
 
@@ -3313,6 +3367,7 @@ def test_create_template_file_with_patch_inputs_missing_from_create(
     mock_yaml_dump, project
 ):
     update_value_2 = "Value2b"
+    update_value_8 = "Value8"
     contract_test_data = {
         "CreateInputs": {
             "Property1": "Value1",
@@ -3328,6 +3383,11 @@ def test_create_template_file_with_patch_inputs_missing_from_create(
                 "path": "Property4",
                 "value": ["{{region}}", update_value_2],
             },
+            {
+                "op": "add",
+                "path": "Property8",
+                "value": update_value_8,
+            },
         ],
     }
     setup_contract_test_data(project.root, contract_test_data)
@@ -3356,7 +3416,7 @@ def test_create_template_file_with_patch_inputs_missing_from_create(
     project.generate_canary_files()
     mock_open.assert_called_once_with("r", encoding="utf-8")
     mock_load.assert_called_once_with(LANGUAGE)
-    # verify that PatchInputs canary template has the PatchInputs "replace" operation applied
+
     expected_template_data = {
         "Description": "Template for AWS::Example::Resource",
         "Resources": {
@@ -3370,6 +3430,7 @@ def test_create_template_file_with_patch_inputs_missing_from_create(
                     "Property5": ANY,
                     "Property6": {"Fn::Sub": "${AWS::AccountId}"},
                     "Property7": ANY,
+                    "Property8": update_value_8,
                 },
             }
         },
@@ -3405,7 +3466,75 @@ def test_create_template_file_with_patch_inputs_missing_from_create(
 
 
 @patch("rpdk.core.project.yaml.dump")
-def test_create_template_file_with_nested_patch_inputs(mock_yaml_dump, project):
+def test_create_template_file_with_skipping_patch_inputs_with_invalid_path(
+    mock_yaml_dump, project
+):
+    update_value1 = "Value1b"
+    update_value_2 = "Value2b"
+    contract_test_data = {
+        "CreateInputs": {
+            "Property1": "Value1",
+        },
+        "PatchInputs": [
+            {
+                "op": "replace",
+                "path": "Property1",
+                "value": update_value1,
+            },
+            {
+                "op": "replace",
+                "path": "Property4/SubProperty4",
+                "value": update_value_2,
+            },
+        ],
+    }
+    setup_contract_test_data(project.root, contract_test_data)
+    plugin = object()
+    data = json.dumps(
+        {
+            "artifact_type": "RESOURCE",
+            "language": LANGUAGE,
+            "runtime": RUNTIME,
+            "entrypoint": None,
+            "testEntrypoint": None,
+            "futureProperty": "value",
+            "typeName": "AWS::Example::Resource",
+            "canarySettings": {
+                FILE_GENERATION_ENABLED: True,
+                CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
+            },
+        }
+    )
+    patch_load = patch(
+        "rpdk.core.project.load_plugin", autospec=True, return_value=plugin
+    )
+
+    with patch_settings(project, data) as mock_open, patch_load as mock_load:
+        project.load_settings()
+    project.generate_canary_files()
+    mock_open.assert_called_once_with("r", encoding="utf-8")
+    mock_load.assert_called_once_with(LANGUAGE)
+
+    expected_template_data = {
+        "Description": "Template for AWS::Example::Resource",
+        "Resources": {
+            "Resource": {
+                "Type": "AWS::Example::Resource",
+                "Properties": {
+                    "Property1": update_value1,
+                },
+            }
+        },
+    }
+    args, kwargs = _get_mock_yaml_dump_call_arg(
+        mock_yaml_dump.call_args_list, CANARY_PATCH_FILE_SUFFIX
+    )
+    assert args[0] == expected_template_data
+    assert kwargs
+
+
+@patch("rpdk.core.project.yaml.dump")
+def test_create_template_file_with_nested_replace_patch_inputs(mock_yaml_dump, project):
     update_value_1 = "Value_Nested1b"
     update_value_2 = "Value_Nested2b"
     contract_test_data = {
@@ -3457,7 +3586,7 @@ def test_create_template_file_with_nested_patch_inputs(mock_yaml_dump, project):
     project.generate_canary_files()
     mock_open.assert_called_once_with("r", encoding="utf-8")
     mock_load.assert_called_once_with(LANGUAGE)
-    # verify that PatchInputs canary template has the PatchInputs "replace" operation applied
+
     expected_template_data = {
         "Description": "Template for AWS::Example::Resource",
         "Resources": {
@@ -3492,6 +3621,210 @@ def test_create_template_file_with_nested_patch_inputs(mock_yaml_dump, project):
                 "Type": "AWS::Example::Resource",
                 "Properties": {
                     "Property1": "Value1",
+                    "Property8": {
+                        "Nested": {
+                            "PropertyA": "Value_Nested1",
+                            "PropertyB": [
+                                {"Fn::Sub": "${AWS::Region}"},
+                                "Value_Nested2",
+                            ],
+                        }
+                    },
+                },
+            }
+        },
+    }
+    args, kwargs = _get_mock_yaml_dump_call_arg(
+        mock_yaml_dump.call_args_list, CANARY_CREATE_FILE_SUFFIX
+    )
+    assert args[0] == expected_template_data_create
+    assert kwargs
+
+
+@patch("rpdk.core.project.yaml.dump")
+def test_create_template_file_with_nested_remove_patch_inputs(mock_yaml_dump, project):
+    update_value_1 = "Value_Nested1b"
+    contract_test_data = {
+        "CreateInputs": {
+            "Property1": "Value1",
+            "Property8": {
+                "Nested": {
+                    "PropertyA": "Value_Nested1",
+                    "PropertyB": ["{{region}}", "Value_Nested2"],
+                }
+            },
+        },
+        "PatchInputs": [
+            {
+                "op": "replace",
+                "path": "Property8/Nested/PropertyA",
+                "value": update_value_1,
+            },
+            {
+                "op": "remove",
+                "path": "Property8/Nested/PropertyB/1",
+            },
+        ],
+    }
+    setup_contract_test_data(project.root, contract_test_data)
+    plugin = object()
+    data = json.dumps(
+        {
+            "artifact_type": "RESOURCE",
+            "language": LANGUAGE,
+            "runtime": RUNTIME,
+            "entrypoint": None,
+            "testEntrypoint": None,
+            "futureProperty": "value",
+            "typeName": "AWS::Example::Resource",
+            "canarySettings": {
+                FILE_GENERATION_ENABLED: True,
+                CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
+            },
+        }
+    )
+    patch_load = patch(
+        "rpdk.core.project.load_plugin", autospec=True, return_value=plugin
+    )
+
+    with patch_settings(project, data) as mock_open, patch_load as mock_load:
+        project.load_settings()
+    project.generate_canary_files()
+    mock_open.assert_called_once_with("r", encoding="utf-8")
+    mock_load.assert_called_once_with(LANGUAGE)
+    expected_template_data = {
+        "Description": "Template for AWS::Example::Resource",
+        "Resources": {
+            "Resource": {
+                "Type": "AWS::Example::Resource",
+                "Properties": {
+                    "Property1": "Value1",
+                    "Property8": {
+                        "Nested": {
+                            "PropertyA": update_value_1,
+                            "PropertyB": [
+                                {"Fn::Sub": "${AWS::Region}"},
+                            ],
+                        }
+                    },
+                },
+            }
+        },
+    }
+    args, kwargs = _get_mock_yaml_dump_call_arg(
+        mock_yaml_dump.call_args_list, CANARY_PATCH_FILE_SUFFIX
+    )
+    assert args[0] == expected_template_data
+    assert kwargs
+
+    # verify that CreateInputs canary is correct
+    expected_template_data_create = {
+        "Description": "Template for AWS::Example::Resource",
+        "Resources": {
+            "Resource": {
+                "Type": "AWS::Example::Resource",
+                "Properties": {
+                    "Property1": "Value1",
+                    "Property8": {
+                        "Nested": {
+                            "PropertyA": "Value_Nested1",
+                            "PropertyB": [
+                                {"Fn::Sub": "${AWS::Region}"},
+                                "Value_Nested2",
+                            ],
+                        }
+                    },
+                },
+            }
+        },
+    }
+    args, kwargs = _get_mock_yaml_dump_call_arg(
+        mock_yaml_dump.call_args_list, CANARY_CREATE_FILE_SUFFIX
+    )
+    assert args[0] == expected_template_data_create
+    assert kwargs
+
+
+@patch("rpdk.core.project.yaml.dump")
+def test_create_template_file_with_nested_add_patch_inputs(mock_yaml_dump, project):
+    update_value_2 = "Value_Nested2b"
+    contract_test_data = {
+        "CreateInputs": {
+            "Property8": {
+                "Nested": {
+                    "PropertyA": "Value_Nested1",
+                    "PropertyB": ["{{region}}", "Value_Nested2"],
+                }
+            },
+        },
+        "PatchInputs": [
+            {
+                "op": "add",
+                "path": "Property8/Nested/PropertyB/2",
+                "value": update_value_2,
+            },
+        ],
+    }
+    setup_contract_test_data(project.root, contract_test_data)
+    plugin = object()
+    data = json.dumps(
+        {
+            "artifact_type": "RESOURCE",
+            "language": LANGUAGE,
+            "runtime": RUNTIME,
+            "entrypoint": None,
+            "testEntrypoint": None,
+            "futureProperty": "value",
+            "typeName": "AWS::Example::Resource",
+            "canarySettings": {
+                FILE_GENERATION_ENABLED: True,
+                CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
+            },
+        }
+    )
+    patch_load = patch(
+        "rpdk.core.project.load_plugin", autospec=True, return_value=plugin
+    )
+
+    with patch_settings(project, data) as mock_open, patch_load as mock_load:
+        project.load_settings()
+    project.generate_canary_files()
+    mock_open.assert_called_once_with("r", encoding="utf-8")
+    mock_load.assert_called_once_with(LANGUAGE)
+
+    expected_template_data = {
+        "Description": "Template for AWS::Example::Resource",
+        "Resources": {
+            "Resource": {
+                "Type": "AWS::Example::Resource",
+                "Properties": {
+                    "Property8": {
+                        "Nested": {
+                            "PropertyA": "Value_Nested1",
+                            "PropertyB": [
+                                {"Fn::Sub": "${AWS::Region}"},
+                                "Value_Nested2",
+                                update_value_2,
+                            ],
+                        }
+                    },
+                },
+            }
+        },
+    }
+    args, kwargs = _get_mock_yaml_dump_call_arg(
+        mock_yaml_dump.call_args_list, CANARY_PATCH_FILE_SUFFIX
+    )
+    assert args[0] == expected_template_data
+    assert kwargs
+
+    # verify that CreateInputs canary is correct
+    expected_template_data_create = {
+        "Description": "Template for AWS::Example::Resource",
+        "Resources": {
+            "Resource": {
+                "Type": "AWS::Example::Resource",
+                "Properties": {
                     "Property8": {
                         "Nested": {
                             "PropertyA": "Value_Nested1",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add canary file generation functionality for Patch Operation canaries from contract test inputs.
canarySettings will be shared with generating Create Operation canaries. 

Testing Scenarios:
1. Validate that the correct number of output files are generated. Validated that file naming and structure are correct.
2. Validate that an existing field in the `CreateInputs` will be updated by a `replace`, `add` or `remove` operation in `PatchInputs`. 
3. Validate that only `replace`, `add` and `remove` operations result in an update. Other operations such as `move`, `copy` and `test` are ignored.
4. Validate that a field can be updated if it was not included in `CreateInputs` but included in `PatchInputs` for `add` and `replace` operations. 
5. Validate that nested inputs are correctly updated. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
