### PR TITLE
Add logging for canary auto generation and refactor canarySettings

### DIFF
--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -1323,9 +1323,12 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             not self.file_generation_enabled
             or not Path(self.target_contract_test_folder_path).exists()
         ):
+            LOG.info("Skipping Canary Auto-Generation")
             return
+        LOG.info("Starting Canary Auto-Generation...")
         self._setup_stack_template_environment()
         self._generate_stack_template_files()
+        LOG.info("Finished Canary Auto-Generation")
 
     def _setup_stack_template_environment(self) -> None:
         stack_template_root = Path(self.target_canary_root_path)
@@ -1337,7 +1340,12 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         )
         bootstrap_file = stack_template_root / CANARY_DEPENDENCY_FILE_NAME
         if dependencies_file.exists():
+            LOG.debug("Writing: %s", bootstrap_file)
             shutil.copy(str(dependencies_file), str(bootstrap_file))
+        else:
+            LOG.debug(
+                "Not found: %s. Not writing to: %s", dependencies_file, bootstrap_file
+            )
 
     def _generate_stack_template_files(self) -> None:
         stack_template_folder = Path(self.target_canary_folder_path)
@@ -1349,6 +1357,7 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         ]
         contract_test_files = sorted(contract_test_files)
         for count, ct_file in enumerate(contract_test_files, start=1):
+            LOG.debug("Loading contract test input file: %s", ct_file)
             with ct_file.open("r") as f:
                 json_data = json.load(f)
             resource_name = self.type_info[2]
@@ -1398,6 +1407,7 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             f"{CANARY_FILE_PREFIX}{contract_test_input_count}_{suffix}.yaml"
         )
         stack_template_file_path = stack_template_folder / stack_template_file_name
+        LOG.debug("Writing Canary Stack Template File: %s", stack_template_file_path)
         with stack_template_file_path.open("w") as stack_template_file:
             yaml.dump(stack_template_data, stack_template_file, indent=2)
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -39,7 +39,6 @@ from rpdk.core.project import (
     CONTRACT_TEST_DEPENDENCY_FILE_NAME,
     CONTRACT_TEST_FILE_NAMES,
     CONTRACT_TEST_FOLDER,
-    FILE_GENERATION_ENABLED,
     OVERRIDES_FILENAME,
     SCHEMA_UPLOAD_FILENAME,
     SETTINGS_FILENAME,
@@ -2796,7 +2795,6 @@ def test_generate_canary_files(project):
             "futureProperty": "value",
             "typeName": "AWS::Example::Resource",
             "canarySettings": {
-                FILE_GENERATION_ENABLED: True,
                 CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
             },
         }
@@ -2850,7 +2848,6 @@ def test_create_template_file(mock_yaml_dump, project):
             "futureProperty": "value",
             "typeName": "AWS::Example::Resource",
             "canarySettings": {
-                FILE_GENERATION_ENABLED: True,
                 CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
             },
         }
@@ -2932,30 +2929,6 @@ def setup_rpdk_config(project, rpdk_config):
     (contract_test_folder / CONTRACT_TEST_DEPENDENCY_FILE_NAME).touch()
 
 
-def test_generate_canary_files_when_not_enabled(project):
-    rpdk_config = {
-        ARTIFACT_TYPE_RESOURCE: "RESOURCE",
-        "language": LANGUAGE,
-        "runtime": RUNTIME,
-        "entrypoint": None,
-        "testEntrypoint": None,
-        "futureProperty": "value",
-        "typeName": "AWS::Example::Resource",
-        "canarySettings": {
-            FILE_GENERATION_ENABLED: False,
-            "contract_test_file_names": ["inputs_1.json", "inputs_2.json"],
-        },
-    }
-    tmp_path = project.root
-    setup_rpdk_config(project, rpdk_config)
-    project.generate_canary_files()
-
-    canary_root_path = tmp_path / TARGET_CANARY_ROOT_FOLDER
-    canary_folder_path = tmp_path / TARGET_CANARY_FOLDER
-    assert not canary_root_path.exists()
-    assert not canary_folder_path.exists()
-
-
 def test_generate_canary_files_no_canary_settings(project):
     rpdk_config = {
         ARTIFACT_TYPE_RESOURCE: "RESOURCE",
@@ -2986,7 +2959,6 @@ def test_generate_canary_files_empty_input_files(project):
         "futureProperty": "value",
         "typeName": "AWS::Example::Resource",
         "canarySettings": {
-            FILE_GENERATION_ENABLED: True,
             "contract_test_file_names": [],
         },
     }
@@ -3018,8 +2990,8 @@ def test_generate_canary_files_empty_canary_settings(project):
     project.generate_canary_files()
     canary_root_path = tmp_path / TARGET_CANARY_ROOT_FOLDER
     canary_folder_path = tmp_path / TARGET_CANARY_FOLDER
-    assert not canary_root_path.exists()
-    assert not canary_folder_path.exists()
+    assert canary_root_path.exists()
+    assert canary_folder_path.exists()
 
 
 def _get_mock_yaml_dump_call_arg(
@@ -3063,7 +3035,6 @@ def test_generate_canary_files_with_patch_inputs(mock_yaml_dump, project):
             "futureProperty": "value",
             "typeName": "AWS::Example::Resource",
             "canarySettings": {
-                FILE_GENERATION_ENABLED: True,
                 CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
             },
         }
@@ -3144,7 +3115,6 @@ def test_create_template_file_with_patch_inputs(mock_yaml_dump, project):
             "futureProperty": "value",
             "typeName": "AWS::Example::Resource",
             "canarySettings": {
-                FILE_GENERATION_ENABLED: True,
                 CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
             },
         }
@@ -3246,7 +3216,6 @@ def test_create_template_file_by_list_index(mock_yaml_dump, project):
             "futureProperty": "value",
             "typeName": "AWS::Example::Resource",
             "canarySettings": {
-                FILE_GENERATION_ENABLED: True,
                 CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
             },
         }
@@ -3324,7 +3293,6 @@ def test_create_template_file_with_skipped_patch_operation(mock_yaml_dump, proje
             "futureProperty": "value",
             "typeName": "AWS::Example::Resource",
             "canarySettings": {
-                FILE_GENERATION_ENABLED: True,
                 CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
             },
         }
@@ -3403,7 +3371,6 @@ def test_create_template_file_with_patch_inputs_missing_from_create(
             "futureProperty": "value",
             "typeName": "AWS::Example::Resource",
             "canarySettings": {
-                FILE_GENERATION_ENABLED: True,
                 CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
             },
         }
@@ -3499,7 +3466,6 @@ def test_create_template_file_throws_error_with_invalid_path(mock_yaml_dump, pro
             "futureProperty": "value",
             "typeName": "AWS::Example::Resource",
             "canarySettings": {
-                FILE_GENERATION_ENABLED: True,
                 CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
             },
         }
@@ -3555,7 +3521,6 @@ def test_create_template_file_with_nested_replace_patch_inputs(mock_yaml_dump, p
             "futureProperty": "value",
             "typeName": "AWS::Example::Resource",
             "canarySettings": {
-                FILE_GENERATION_ENABLED: True,
                 CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
             },
         }
@@ -3661,7 +3626,6 @@ def test_create_template_file_with_nested_remove_patch_inputs(mock_yaml_dump, pr
             "futureProperty": "value",
             "typeName": "AWS::Example::Resource",
             "canarySettings": {
-                FILE_GENERATION_ENABLED: True,
                 CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
             },
         }
@@ -3760,7 +3724,6 @@ def test_create_template_file_with_nested_add_patch_inputs(mock_yaml_dump, proje
             "futureProperty": "value",
             "typeName": "AWS::Example::Resource",
             "canarySettings": {
-                FILE_GENERATION_ENABLED: True,
                 CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
             },
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Remove `file_generation_enabled` from `canarySettings`. If the canarySettings field is provided with an empty object, canaries will be generated with `contract_test_file_names: [input1.json]` default. If canarySettings are removed from .rpdk-config, no canary generation will occur. 
- Improved logging will simplify debugging canary autogeneration. 
- Add a warning log when `canarySettings` are provided but empty
- Add Logging at `info` level for skipping, starting, and finishing canary autogeneration
- Add Logging at the `debug` level for loading contract test inputs and writing canary file outputs. 
```
"canarySettings": {
        "contract_test_file_names": ["inputs1.json"]
    }
```

```
#positive case at Debug Log Level

% cfn generate -v -v -v
Logging set up successfully
...
Starting Canary Auto-Generation...
Writing: /[ROOT]/testcfncli/canary-bundle/bootstrap.yaml
Loading contract test input file: /[ROOT]/testcfncli/contract-tests-artifacts/inputs_1.json
Writing Canary Stack Template File: /[ROOT]/testcfncli/canary-bundle/canary/canary1_001.yaml
Writing Canary Stack Template File: /[ROOT]/testcfncli/canary-bundle/canary/canary1_002.yaml
Loading contract test input file: /[ROOT]/testcfncli/contract-tests-artifacts/inputs_2.json
Writing Canary Stack Template File: /[ROOT]/testcfncli/canary-bundle/canary/canary2_001.yaml
Writing Canary Stack Template File: /[ROOT]/testcfncli/canary-bundle/canary/canary2_002.yaml
Loading contract test input file: /[ROOT]/testcfncli/contract-tests-artifacts/inputs_3.json
Writing Canary Stack Template File: /[ROOT]/testcfncli/canary-bundle/canary/canary3_001.yaml
Writing Canary Stack Template File: /[ROOT]/testcfncli/canary-bundle/canary/canary3_002.yaml
Finished Canary Auto-Generation
Generated files for TestOrg::TestService::TestResource
Finished generate

# canarySettings not in .rpdk-config

% cfn generate -vv
Logging set up successfully
...
Skipping Canary Auto-Generation
Generated files for TestOrg::TestService::TestResource
Finished generate

#canarySettings:{} with DEBUG Log Level

Logging set up successfully
Writing docs README: [ROOT]/testcfncli/docs/README.md
Starting Canary Auto-Generation...
canarySettings are provided but empty. Generation is enabled with default settings.
Writing: [ROOT]/testcfncli/canary-bundle/bootstrap.yaml
Loading contract test input file: [ROOT]/testcfncli/contract-tests-artifacts/inputs_1.json
Writing Canary Stack Template File: [ROOT]/testcfncli/canary-bundle/canary/canary1_001.yaml
Writing Canary Stack Template File: [ROOT]/testcfncli/canary-bundle/canary/canary1_002.yaml
Finished Canary Auto-Generation
Generated files for TestOrg::TestService::TestResource
Finished generate


```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
