### PR TITLE
Refactor canary auto-generation cli semantics

### DIFF
--- a/src/rpdk/core/generate.py
+++ b/src/rpdk/core/generate.py
@@ -20,7 +20,9 @@ def generate(args):
         args.profile,
     )
     project.generate_docs()
-    project.generate_canary_files()
+    project.generate_canary_files(
+        args.local_code_generation,
+    )
     LOG.warning("Generated files for %s", project.type_name)
 
 
@@ -38,3 +40,8 @@ def setup_subparser(subparsers, parents):
         "--target-schemas", help="Path to target schemas.", nargs="*", default=[]
     )
     parser.add_argument("--profile", help="AWS profile to use.")
+    parser.add_argument(
+        "--local-code-generation",
+        action="store_true",
+        help="Enable local code generation.",
+    )

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -179,7 +179,6 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.executable_entrypoint = None
         self.fragment_dir = None
         self.canary_settings = {}
-        self.has_canary_settings = None
         self.target_info = {}
 
         self.env = Environment(
@@ -256,7 +255,7 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @property
     def file_generation_enabled(self):
-        if self.has_canary_settings is False:
+        if self.canary_settings == {}:
             return False
         return True
 
@@ -339,10 +338,6 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._plugin = load_plugin(raw_settings["language"])
         self.settings = raw_settings.get("settings", {})
         self.canary_settings = raw_settings.get("canarySettings", {})
-        if raw_settings.get("canarySettings", False) is False:
-            self.has_canary_settings = False
-        else:
-            self.has_canary_settings = True
 
     def _write_example_schema(self):
         self.schema = resource_json(
@@ -1322,18 +1317,15 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         return type_info
 
-    def generate_canary_files(self) -> None:
+    def generate_canary_files(self, local_code_generation=False) -> None:
         if (
             not self.file_generation_enabled
             or not Path(self.target_contract_test_folder_path).exists()
+            or not local_code_generation
         ):
             LOG.info("Skipping Canary Auto-Generation")
             return
         LOG.info("Starting Canary Auto-Generation...")
-        if self.file_generation_enabled and self.canary_settings == {}:
-            LOG.warning(
-                "canarySettings are provided but empty. Generation is enabled with default settings."
-            )
         self._setup_stack_template_environment()
         self._generate_stack_template_files()
         LOG.info("Finished Canary Auto-Generation")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2805,7 +2805,7 @@ def test_generate_canary_files(project):
 
     with patch_settings(project, data) as mock_open, patch_load as mock_load:
         project.load_settings()
-    project.generate_canary_files()
+    project.generate_canary_files(local_code_generation=True)
     mock_open.assert_called_once_with("r", encoding="utf-8")
     mock_load.assert_called_once_with(LANGUAGE)
     canary_root_path = tmp_path / TARGET_CANARY_ROOT_FOLDER
@@ -2858,7 +2858,7 @@ def test_create_template_file(mock_yaml_dump, project):
 
     with patch_settings(project, data) as mock_open, patch_load as mock_load:
         project.load_settings()
-    project.generate_canary_files()
+    project.generate_canary_files(local_code_generation=True)
     mock_open.assert_called_once_with("r", encoding="utf-8")
     mock_load.assert_called_once_with(LANGUAGE)
     expected_template_data = {
@@ -2941,7 +2941,53 @@ def test_generate_canary_files_no_canary_settings(project):
     }
     tmp_path = project.root
     setup_rpdk_config(project, rpdk_config)
+    project.generate_canary_files(local_code_generation=True)
+
+    canary_root_path = tmp_path / TARGET_CANARY_ROOT_FOLDER
+    canary_folder_path = tmp_path / TARGET_CANARY_FOLDER
+    assert not canary_root_path.exists()
+    assert not canary_folder_path.exists()
+
+
+def test_generate_canary_files_no_local_code_generation(project):
+    rpdk_config = {
+        ARTIFACT_TYPE_RESOURCE: "RESOURCE",
+        "language": LANGUAGE,
+        "runtime": RUNTIME,
+        "entrypoint": None,
+        "testEntrypoint": None,
+        "futureProperty": "value",
+        "typeName": "AWS::Example::Resource",
+        "canarySettings": {
+            CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
+        },
+    }
+    tmp_path = project.root
+    setup_rpdk_config(project, rpdk_config)
     project.generate_canary_files()
+
+    canary_root_path = tmp_path / TARGET_CANARY_ROOT_FOLDER
+    canary_folder_path = tmp_path / TARGET_CANARY_FOLDER
+    assert not canary_root_path.exists()
+    assert not canary_folder_path.exists()
+
+
+def test_generate_canary_files_false_local_code_generation(project):
+    rpdk_config = {
+        ARTIFACT_TYPE_RESOURCE: "RESOURCE",
+        "language": LANGUAGE,
+        "runtime": RUNTIME,
+        "entrypoint": None,
+        "testEntrypoint": None,
+        "futureProperty": "value",
+        "typeName": "AWS::Example::Resource",
+        "canarySettings": {
+            CONTRACT_TEST_FILE_NAMES: ["inputs_1.json", "inputs_2.json"],
+        },
+    }
+    tmp_path = project.root
+    setup_rpdk_config(project, rpdk_config)
+    project.generate_canary_files(local_code_generation=False)
 
     canary_root_path = tmp_path / TARGET_CANARY_ROOT_FOLDER
     canary_folder_path = tmp_path / TARGET_CANARY_FOLDER
@@ -2964,7 +3010,7 @@ def test_generate_canary_files_empty_input_files(project):
     }
     tmp_path = project.root
     setup_rpdk_config(project, rpdk_config)
-    project.generate_canary_files()
+    project.generate_canary_files(local_code_generation=True)
 
     canary_root_path = tmp_path / TARGET_CANARY_ROOT_FOLDER
     canary_folder_path = tmp_path / TARGET_CANARY_FOLDER
@@ -2987,11 +3033,11 @@ def test_generate_canary_files_empty_canary_settings(project):
     }
     tmp_path = project.root
     setup_rpdk_config(project, rpdk_config)
-    project.generate_canary_files()
+    project.generate_canary_files(local_code_generation=True)
     canary_root_path = tmp_path / TARGET_CANARY_ROOT_FOLDER
     canary_folder_path = tmp_path / TARGET_CANARY_FOLDER
-    assert canary_root_path.exists()
-    assert canary_folder_path.exists()
+    assert not canary_root_path.exists()
+    assert not canary_folder_path.exists()
 
 
 def _get_mock_yaml_dump_call_arg(
@@ -3045,7 +3091,7 @@ def test_generate_canary_files_with_patch_inputs(mock_yaml_dump, project):
 
     with patch_settings(project, data) as mock_open, patch_load as mock_load:
         project.load_settings()
-    project.generate_canary_files()
+    project.generate_canary_files(local_code_generation=True)
     mock_open.assert_called_once_with("r", encoding="utf-8")
     mock_load.assert_called_once_with(LANGUAGE)
     canary_root_path = tmp_path / TARGET_CANARY_ROOT_FOLDER
@@ -3125,7 +3171,7 @@ def test_create_template_file_with_patch_inputs(mock_yaml_dump, project):
 
     with patch_settings(project, data) as mock_open, patch_load as mock_load:
         project.load_settings()
-    project.generate_canary_files()
+    project.generate_canary_files(local_code_generation=True)
     mock_open.assert_called_once_with("r", encoding="utf-8")
     mock_load.assert_called_once_with(LANGUAGE)
 
@@ -3226,7 +3272,7 @@ def test_create_template_file_by_list_index(mock_yaml_dump, project):
 
     with patch_settings(project, data) as mock_open, patch_load as mock_load:
         project.load_settings()
-    project.generate_canary_files()
+    project.generate_canary_files(local_code_generation=True)
     mock_open.assert_called_once_with("r", encoding="utf-8")
     mock_load.assert_called_once_with(LANGUAGE)
 
@@ -3303,7 +3349,7 @@ def test_create_template_file_with_skipped_patch_operation(mock_yaml_dump, proje
 
     with patch_settings(project, data) as mock_open, patch_load as mock_load:
         project.load_settings()
-    project.generate_canary_files()
+    project.generate_canary_files(local_code_generation=True)
     mock_open.assert_called_once_with("r", encoding="utf-8")
     mock_load.assert_called_once_with(LANGUAGE)
 
@@ -3381,7 +3427,7 @@ def test_create_template_file_with_patch_inputs_missing_from_create(
 
     with patch_settings(project, data) as mock_open, patch_load as mock_load:
         project.load_settings()
-    project.generate_canary_files()
+    project.generate_canary_files(local_code_generation=True)
     mock_open.assert_called_once_with("r", encoding="utf-8")
     mock_load.assert_called_once_with(LANGUAGE)
 
@@ -3477,7 +3523,7 @@ def test_create_template_file_throws_error_with_invalid_path(mock_yaml_dump, pro
     with patch_settings(project, data) as mock_open, patch_load as mock_load:
         project.load_settings()
     with pytest.raises(jsonpatch.JsonPointerException):
-        project.generate_canary_files()
+        project.generate_canary_files(local_code_generation=True)
     mock_open.assert_called_once_with("r", encoding="utf-8")
     mock_load.assert_called_once_with(LANGUAGE)
 
@@ -3531,7 +3577,7 @@ def test_create_template_file_with_nested_replace_patch_inputs(mock_yaml_dump, p
 
     with patch_settings(project, data) as mock_open, patch_load as mock_load:
         project.load_settings()
-    project.generate_canary_files()
+    project.generate_canary_files(local_code_generation=True)
     mock_open.assert_called_once_with("r", encoding="utf-8")
     mock_load.assert_called_once_with(LANGUAGE)
 
@@ -3636,7 +3682,7 @@ def test_create_template_file_with_nested_remove_patch_inputs(mock_yaml_dump, pr
 
     with patch_settings(project, data) as mock_open, patch_load as mock_load:
         project.load_settings()
-    project.generate_canary_files()
+    project.generate_canary_files(local_code_generation=True)
     mock_open.assert_called_once_with("r", encoding="utf-8")
     mock_load.assert_called_once_with(LANGUAGE)
     expected_template_data = {
@@ -3734,7 +3780,7 @@ def test_create_template_file_with_nested_add_patch_inputs(mock_yaml_dump, proje
 
     with patch_settings(project, data) as mock_open, patch_load as mock_load:
         project.load_settings()
-    project.generate_canary_files()
+    project.generate_canary_files(local_code_generation=True)
     mock_open.assert_called_once_with("r", encoding="utf-8")
     mock_load.assert_called_once_with(LANGUAGE)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Canary auto generation will be disabled for empty canary settings. This is intended to prevent auto generation when a key is added to the `.rpdk-config` when providers are upgrading their rpdk version set.
- Add an argument `local-code-generation` to the `cfn generate` command to enable canary auto generation. This intended to restrict canary autogeneration to specific development use cases. Canary auto-generation should not occur for remote builds. 

Unit Test Cases:
- Canary autogeneration will not occur if the `local-code-generation` flag is missing or False. 
- Add `local-code-generation=True` to existing unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
