### PR TITLE
fix(generate): add remote to configuration schema

### DIFF
--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -509,6 +509,7 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if "typeConfiguration" in self.schema:
             configuration_schema = self.schema["typeConfiguration"]
             configuration_schema["definitions"] = self.schema.get("definitions", {})
+            configuration_schema["remote"] = self.schema.get("remote", {})
             configuration_schema["typeName"] = self.type_name
             self.configuration_schema = configuration_schema
 


### PR DESCRIPTION
*Issue #, if available:* #1084

*Description of changes:*

A pragmatic fix for generating type configuration schemas with remote attributes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
