### PR TITLE
Add mpr validations to cfn validate with supporting tests.

### DIFF
--- a/src/rpdk/core/data_loaders.py
+++ b/src/rpdk/core/data_loaders.py
@@ -21,6 +21,7 @@ LOG = logging.getLogger(__name__)
 
 TIMEOUT_IN_SECONDS = 10
 STDIN_NAME = "<stdin>"
+MAX_CONFIGURATION_SCHEMA_LENGTH = 60 * 1024  # 60 KiB
 
 
 def resource_stream(package_name, resource_name, encoding="utf-8"):
@@ -151,6 +152,12 @@ def load_resource_spec(resource_spec_file):  # pylint: disable=R # noqa: C901
     except ValueError as e:
         LOG.debug("Resource spec decode failed", exc_info=True)
         raise SpecValidationError(str(e)) from e
+
+    # check TypeConfiguration schema size
+    if len(json.dumps(resource_spec).encode("utf-8")) > MAX_CONFIGURATION_SCHEMA_LENGTH:
+        raise SpecValidationError(
+            "TypeConfiguration schema exceeds maximum length of 60 KiB"
+        )
 
     validator = make_resource_validator()
     additional_properties_validator = (

--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -95,6 +95,10 @@ DEFAULT_ROLE_TIMEOUT_MINUTES = 120  # 2 hours
 # https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html
 MIN_ROLE_TIMEOUT_SECONDS = 3600  # 1 hour
 MAX_ROLE_TIMEOUT_SECONDS = 43200  # 12 hours
+MAX_RPDK_CONFIG_LENGTH = 10 * 1024  # 10 KiB
+MAX_CONFIGURATION_SCHEMA_LENGTH = 60 * 1024  # 60 KiB
+
+PROTOCOL_VERSION_VALUES = frozenset({"1.0.0", "2.0.0"})
 
 CFN_METADATA_FILENAME = ".cfn_metadata.json"
 
@@ -280,6 +284,25 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         except json.JSONDecodeError as e:
             self._raise_invalid_project(
                 f"Project file '{self.settings_path}' is invalid", e
+            )
+
+        # check size of RPDK config
+        if len(json.dumps(raw_settings).encode("utf-8")) > MAX_RPDK_CONFIG_LENGTH:
+            raise InvalidProjectError(
+                f"Project file '{self.settings_path}' exceeds maximum length of 10 KiB."
+            )
+        # validate protocol version, if specified
+        if "settings" in raw_settings and "protocolVersion" in raw_settings["settings"]:
+            protocol_version = raw_settings["settings"]["protocolVersion"]
+            if protocol_version not in PROTOCOL_VERSION_VALUES:
+                raise InvalidProjectError(
+                    f"Invalid 'protocolVersion' settings in '{self.settings_path}"
+                )
+        else:
+            LOG.warning(
+                "No protovolVersion found: this will default to version 1.0.0 during registration. "
+                "Please consider upgrading to CFN-CLI 2.0 following the guide: "
+                "https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html"
             )
 
         # backward compatible
@@ -844,13 +867,15 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         target_names = (
             self.target_info.keys()
             if self.target_info
-            else {
-                target_name
-                for handler in self.schema.get("handlers", {}).values()
-                for target_name in handler.get("targetNames", [])
-            }
-            if self.artifact_type == ARTIFACT_TYPE_HOOK
-            else []
+            else (
+                {
+                    target_name
+                    for handler in self.schema.get("handlers", {}).values()
+                    for target_name in handler.get("targetNames", [])
+                }
+                if self.artifact_type == ARTIFACT_TYPE_HOOK
+                else []
+            )
         )
 
         LOG.debug("Removing generated docs: %s", docs_path)

--- a/src/rpdk/core/validate.py
+++ b/src/rpdk/core/validate.py
@@ -9,6 +9,7 @@ from .project import Project
 LOG = logging.getLogger(__name__)
 
 
+# validations for cfn validate are done in both project.py and data_loaders.py
 def validate(_args):
     project = Project()
     project.load()


### PR DESCRIPTION
*Issue #, if available:*

These changes are made as part of Registration Improvement efforts.

*Description of changes:*
This pull request is to add validations used in MPR into RPDK for `cfn validate`, and testing to support the changes.

(There is also a formatting change in `generate_docs()` that was modified by Black code formatter and does not contribute to any functionality changes)

This includes:
- checking the size of the RPDK config
- checking the size of the TypeConfiguration schema
- checking for a valid protocol version

Validations that were not included are:
- checks done in Schema Guard Rail
- checks between the configuration and the request (done during registration)
- checks for resource type relations (involves server-side calls to describe type)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.