### PR TITLE
Fix for _replace_dynamic_values in canary file auto-generator

### DIFF
--- a/src/rpdk/core/project.py
+++ b/src/rpdk/core/project.py
@@ -1455,7 +1455,12 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             if isinstance(value, dict):
                 properties[key] = self._replace_dynamic_values(value)
             elif isinstance(value, list):
-                properties[key] = [self._replace_dynamic_value(item) for item in value]
+                properties[key] = [
+                    self._replace_dynamic_values(item)
+                    if isinstance(item, dict)
+                    else self._replace_dynamic_value(item)
+                    for item in value
+                ]
             else:
                 return_value = self._replace_dynamic_value(value)
                 properties[key] = return_value
@@ -1468,7 +1473,12 @@ class Project:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if isinstance(value, dict):
             properties[root_key] = self._replace_dynamic_values(value)
         elif isinstance(value, list):
-            properties[root_key] = [self._replace_dynamic_value(item) for item in value]
+            properties[root_key] = [
+                self._replace_dynamic_values(item)
+                if isinstance(item, dict)
+                else self._replace_dynamic_value(item)
+                for item in value
+            ]
         else:
             return_value = self._replace_dynamic_value(value)
             properties[root_key] = return_value

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2915,6 +2915,7 @@ def test_create_template_file(mock_yaml_dump, project):
             "Property5": "{{uuid}}",
             "Property6": "{{account}}",
             "Property7": "prefix-{{uuid}}-sufix",
+            "Property8": [{"Nested": "{{test123}}"}],
         }
     }
     setup_contract_test_data(project.root, contract_test_data)
@@ -2955,6 +2956,7 @@ def test_create_template_file(mock_yaml_dump, project):
                     "Property5": ANY,
                     "Property6": {"Fn::Sub": "${AWS::AccountId}"},
                     "Property7": ANY,
+                    "Property8": [{"Nested": {"Fn::ImportValue": "test123"}}],
                 },
             }
         },
@@ -3196,6 +3198,7 @@ def test_generate_canary_files_with_patch_inputs(mock_yaml_dump, project):
 def test_create_template_file_with_patch_inputs(mock_yaml_dump, project):
     update_value_1 = "Value1b"
     update_value_2 = "Value2b"
+    updated_value_3 = "{{test456}}"
 
     contract_test_data = {
         "CreateInputs": {
@@ -3206,6 +3209,7 @@ def test_create_template_file_with_patch_inputs(mock_yaml_dump, project):
             "Property5": "{{uuid}}",
             "Property6": "{{account}}",
             "Property7": "prefix-{{uuid}}-sufix",
+            "Property8": [{"Nested": "{{test123}}"}],
         },
         "PatchInputs": [
             {
@@ -3227,6 +3231,11 @@ def test_create_template_file_with_patch_inputs(mock_yaml_dump, project):
                 "op": "replace",
                 "path": "/Property4",
                 "value": ["{{region}}", update_value_2],
+            },
+            {
+                "op": "replace",
+                "path": "/Property8",
+                "value": [{"Nested": updated_value_3}],
             },
         ],
     }
@@ -3269,6 +3278,7 @@ def test_create_template_file_with_patch_inputs(mock_yaml_dump, project):
                     "Property5": ANY,
                     "Property6": {"Fn::Sub": "${AWS::AccountId}"},
                     "Property7": ANY,
+                    "Property8": [{"Nested": {"Fn::ImportValue": "test456"}}],
                 },
             }
         },
@@ -3295,6 +3305,7 @@ def test_create_template_file_with_patch_inputs(mock_yaml_dump, project):
                     "Property5": ANY,
                     "Property6": {"Fn::Sub": "${AWS::AccountId}"},
                     "Property7": ANY,
+                    "Property8": [{"Nested": {"Fn::ImportValue": "test123"}}],
                 },
             }
         },


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

While generating canary test files from contract input files, we are getting following error if input structure has a list of dicts:
```
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
```

Example input:
```
{
        "CreateInputs": {
            "Property": [{"Nested": "{{test123}}"}]
        }
}
```

This commit fixes this issue by updating the parsing logic to be recursive when list items are dicts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
