### PR TITLE
Fix invalid escape sequence warnings

### DIFF
--- a/src/rpdk/core/contract/hook_client.py
+++ b/src/rpdk/core/contract/hook_client.py
@@ -448,7 +448,7 @@ class HookClient:  # pylint: disable=too-many-instance-attributes
             LOG.debug("=== Handler execution logs ===")
             LOG.debug(result)
             # pylint: disable=W1401
-            regex = "__CFN_HOOK_START_RESPONSE__([\s\S]*)__CFN_HOOK_END_RESPONSE__"  # noqa: W605,B950 # pylint: disable=C0301
+            regex = r"__CFN_HOOK_START_RESPONSE__([\s\S]*)__CFN_HOOK_END_RESPONSE__"  # noqa: W605,B950 # pylint: disable=C0301
             payload = json.loads(re.search(regex, result).group(1))
         else:
             result = self._client.invoke(

--- a/src/rpdk/core/contract/resource_client.py
+++ b/src/rpdk/core/contract/resource_client.py
@@ -735,7 +735,7 @@ class ResourceClient:  # pylint: disable=too-many-instance-attributes
             LOG.debug("=== Handler execution logs ===")
             LOG.debug(result)
             # pylint: disable=W1401
-            regex = "__CFN_RESOURCE_START_RESPONSE__([\s\S]*)__CFN_RESOURCE_END_RESPONSE__"  # noqa: W605,B950 # pylint: disable=C0301
+            regex = r"__CFN_RESOURCE_START_RESPONSE__([\s\S]*)__CFN_RESOURCE_END_RESPONSE__"  # noqa: W605,B950 # pylint: disable=C0301
             payload = json.loads(re.search(regex, result).group(1))
         else:
             result = self._client.invoke(


### PR DESCRIPTION
Fixes #1088 <!-- Needed for GitHub to link the issue to the PR -->

## Fix invalid escape sequence warnings
Resolves Python 3.12 syntax warnings by making regex patterns raw strings. The warnings occurred for invalid escape sequences `\s` in regex patterns - converting them to raw strings (`r&#34;...&#34;`) properly escapes the sequences. This change affects both hook and resource client response pattern matching while maintaining identical functionality.

The fix was applied to both:
- `hook_client.py` (__CFN_HOOK_* patterns)
- `resource_client.py` (__CFN_RESOURCE_* patterns)

---

This change was produced by **Harry Patcher** 🧙‍♂️, an autonomous & anonymous AI engineering agent. No human was involved in creating this pull request.

Learn more about Harry Patcher and how he came up with this fix [here](https://harry-patcher.ai/viewer?url=aHR0cHM6Ly9naXN0LmdpdGh1YnVzZXJjb250ZW50LmNvbS9oYXJyeS1wYXRjaGVyLzUxMjczMDE0MzE4YzFjMzQ3NDg1NmQ5YjkxYWE3YjQ4L3Jhdy82NTJhNDQyNWFkYTRjNDVlMTcxODhiMDQ4MzRiYmM2ZWZjNzMyZGIyL3N3ZWJlbmNoX2F3cy1jbG91ZGZvcm1hdGlvbl9fY2xvdWRmb3JtYXRpb24tY2xpLTEwODguanNvbg) 🔍.

Harry cannot yet respond to review feedback. If the patch isn’t relevant, reject the PR and optionally [let us know](https://forms.office.com/Pages/ResponsePage.aspx?id=UjyyTqXzvEm1VQsGEmephKlyfnndRsBKt5Fmxu7iHWpUMEdIRzFTUU9LNkxYMDZWQlZWT0gwSFJUTCQlQCN0PWcu&r1e8e3930f96f400aa91b5105dbd09b7d=&rb85bea8de07843f9835f9d001f689f4c=&r034de175aef248b29aaf36f2a5e92912=&r9e0cc5d7ff8b484e81eb97531d4cefd7=) 📬.