### PR TITLE
Fix comparing resource clients with differing lists not raising an error

### DIFF
--- a/src/rpdk/core/jsonutils/utils.py
+++ b/src/rpdk/core/jsonutils/utils.py
@@ -29,7 +29,7 @@ def item_hash(
     if isinstance(item, dict):
         item = {k: item_hash(v) for k, v in item.items()}
     if isinstance(item, list):
-        item = [item_hash(i) for i in item].sort()
+        item = sorted(item_hash(i) for i in item)
     encoded = json.dumps(item, sort_keys=True).encode()
     dhash.update(encoded)
     return dhash.hexdigest()

--- a/tests/contract/test_resource_client.py
+++ b/tests/contract/test_resource_client.py
@@ -1909,6 +1909,24 @@ def test_compare_collection(resource_client, inputs, outputs, schema_fragment):
     resource_client.compare(inputs, outputs)
 
 
+def test_compare_collection_with_list_items_should_fail(resource_client):
+    inputs = {"CollectionToCompare": [[1]]}
+    outputs = {"CollectionToCompare": [[2]]}
+    schema_fragment = {
+        "properties": {
+            "CollectionToCompare": {
+                "type": "array",
+                "insertionOrder": False,
+                "items": {"type": "array", "items": {"type": "integer"}},
+            }
+        }
+    }
+    resource_client._update_schema(schema_fragment)
+
+    with pytest.raises(AssertionError):
+        resource_client.compare(inputs, outputs)
+
+
 def test_compare_should_throw_key_error(resource_client):
     resource_client._update_schema(SCHEMA_WITH_NESTED_PROPERTIES)
     inputs = {"b": {"d": 1}, "f": [{"d": 1}], "h": [{"d": 1}]}


### PR DESCRIPTION
The previous implementation of `item_hash` (used by `ResourceClient.compare`) used an in-place `.sort` method. This returns `None` for all lists, which means that resource clients which differ in that list will incorrectly appear as if they were equal. To confirm this, I have added a test which fails on master.

fwiw: I found this bug during a research project I'm working on which uses LLMs to write property-based tests in [Hypothesis](https://github.com/HypothesisWorks/hypothesis). This property, that different lists hash to different values, was proposed and written "autonomously" by the agent. I wrote this PR myself and take full responsibility for it.

---

*(By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.)*
