### PR TITLE
docs: document --use-docker and --no-docker options in cfn submit

### DIFF
--- a/doc_source/resource-type-cli-submit.md
+++ b/doc_source/resource-type-cli-submit.md
@@ -27,6 +27,8 @@ The user registering the extension must be able to access the schema handler pac
 [--role-arn <value>]
 [--no-role]
 [--set-default]
+[--use-docker]
+[--no-docker]
 ```
 
 ## Options<a name="resource-type-cli-submit-options"></a>
@@ -66,6 +68,18 @@ You can't specify both `--role-arn` and `--no-role` arguments\.
 `--set-default`
 
 Upon successful registration of the type version, sets the current type version as the default version\.
+
+`--use-docker`
+
+Use docker for platform\-independent packaging\. This is highly recommended unless you are experienced with cross\-platform packaging\. This overrides the `use_docker` setting in your project's `.rpdk-config` file\.
+
+You can't specify both `--use-docker` and `--no-docker` arguments\.
+
+`--no-docker`
+
+Skip docker when packaging the project\. Generally not recommended unless you are experienced with cross\-platform packaging\. This overrides the `use_docker` setting in your project's `.rpdk-config` file\.
+
+You can't specify both `--use-docker` and `--no-docker` arguments\.
 
 ## Output<a name="resource-type-cli-submit-output"></a>
 


### PR DESCRIPTION
*Issue #, if available:* #1119

*Description of changes:*

## Summary

Document the `--use-docker` and `--no-docker` options of `cfn submit` in `doc_source/resource-type-cli-submit.md`.

These options were added to the CLI in #970 but were never reflected in the documentation. As a result, the [public AWS documentation page](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-cli-submit.html) (generated from `doc_source/`) does not mention them either.


## Changes

- Add `[--use-docker]` and `[--no-docker]` to the Synopsis block.
- Add an Options entry for each flag, describing:
  - What the flag does.
  - That `--use-docker` and `--no-docker` are mutually exclusive.
  - That these flags override the corresponding setting in the project's `.rpdk-config`.

No code changes. The wording for the options is adapted from the existing `help=` strings in `src/rpdk/core/submit.py` so that `cfn submit --help` and the documentation stay consistent.

## Verification

- Confirmed that `--use-docker` / `--no-docker` are implemented in `src/rpdk/core/submit.py` (added in #970).
- Compared the updated doc against `cfn submit --help` output to make sure the described semantics match the implementation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
