### PR TITLE
Fix release & add readme for --v2

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -20,10 +20,11 @@ jobs:
         cache: 'pip'
     - name: Install dependencies
       run: |
-        pip install --upgrade wheel twine
+        pip install --upgrade pip
+        pip install --upgrade wheel twine build
     - name: Package project
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
     - name: Publish distribution 📦 to PyPI (If triggered from release)
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/README.md
+++ b/README.md
@@ -96,6 +96,30 @@ Install PYJQ for Ubuntu system
 pip install pyjq
 ```
 
+#### Running contract tests with `--v2`
+
+`cfn test --v2` is an opt-in flag that runs the contract tests through the RQTS (CTv2) executor in a Docker container instead of the default pytest-based suite. Without `--v2`, the existing behavior is unchanged.
+
+```bash
+cfn test --v2
+cfn test --v2 --region us-west-2 --profile my-profile
+cfn test --v2 --typeconfig ./myResourceTypeConfig.json # type configuration is passed through to the executor
+cfn test --v2 --rqts-image my-registry/my-executor:my-tag # override the CLI-pinned executor image
+```
+
+The runner checks all of the following before starting the container, and reports every unmet requirement at once:
+
+* Docker is installed and the daemon is reachable.
+* The project is a **Java** resource type. Hook and module projects are not supported, and other language plugins do not produce an artifact the executor can load.
+* The project has been built, so that `<hyphenated-type-name>.zip` exists in the project root. Run `cfn generate` and your language plugin's build first.
+* AWS credentials and a region resolve and pass `sts:GetCallerIdentity`.
+
+Notes:
+
+* Scenario selection is owned by the executor image, so pytest-style arguments such as `-- -k contract_delete_update` are silently ignored on the `--v2` path. Test inputs are read from the ones packaged inside the artifact zip.
+* Executor output is written to `rqts-output/` in the project root, and per-scenario results are streamed to the console as the container runs.
+* The default image reference follows the `latest` tag on [ECR Public](https://gallery.ecr.aws/), matching what the cloud contract-test path runs. The CLI attempts a pull on each run and falls back to a locally cached image when the registry is unreachable.
+
 ### Command: validate
 
 To validate the schema, use the `validate` command.

--- a/src/rpdk/core/__init__.py
+++ b/src/rpdk/core/__init__.py
@@ -1,5 +1,5 @@
 import logging
 
-__version__ = "0.2.40"
+__version__ = "0.2.41"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())


### PR DESCRIPTION
*Issue #, if available:*
Fix GH release workflow. Update README to include --v2 flag. Minor version bump as failed release updated pypi repo.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
